### PR TITLE
Fix debounced storage saving

### DIFF
--- a/SudokuApp/utils/storage.js
+++ b/SudokuApp/utils/storage.js
@@ -11,11 +11,31 @@ export const STORAGE_VERSION = 2; // Incremented to handle addition of gameCompl
  * @returns {Function} - The debounced function
  */
 const debounce = (func, wait) => {
-  let timeout;
-  return (...args) => {
-    clearTimeout(timeout);
-    timeout = setTimeout(() => func(...args), wait);
+  let timeout = null;
+  let lastArgs;
+  let lastThis;
+
+  const invoke = () => {
+    const result = func.apply(lastThis, lastArgs);
+    timeout = null;
+    return result;
   };
+
+  const debounced = function (...args) {
+    lastArgs = args;
+    lastThis = this;
+    clearTimeout(timeout);
+    timeout = setTimeout(invoke, wait);
+  };
+
+  debounced.flush = () => {
+    if (timeout) {
+      clearTimeout(timeout);
+      return invoke();
+    }
+  };
+
+  return debounced;
 };
 
 /**


### PR DESCRIPTION
## Summary
- implement a flushable debounce helper in storage utils
- preserve context when invoking debounced functions and return the result from `flush`

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_68407a8ca9fc8326be0cc12eebb0697c