### PR TITLE
Fungiku Step 1: rendering seam (Symbol + symbolSets), zero visual change

### DIFF
--- a/SudokuApp/components/Cell.js
+++ b/SudokuApp/components/Cell.js
@@ -1,5 +1,12 @@
 import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, Platform } from 'react-native';
+import Symbol from './Symbol';
+import { SYMBOL_SET_IDS, getSymbolLabel } from '../utils/symbolSets';
+
+// Step 1 of the Fungiku seam: values render through <Symbol>, but the symbol set
+// is hardcoded to "numbers" so the board is visually identical to before. State
+// + a toggle arrive in Step 2 (docs/fungiku-plan.md §4, §6).
+const SYMBOL_SET = SYMBOL_SET_IDS.NUMBERS;
 
 // Performance-optimized Cell component
 const Cell = ({ 
@@ -103,8 +110,8 @@ const Cell = ({
   if (value !== 0) {
     // Cell has a value
     return (
-      <View style={cellStyle} accessibilityLabel={`Cell value: ${value}`}>
-        <Text style={textStyle}>{value}</Text>
+      <View style={cellStyle} accessibilityLabel={`Cell value: ${getSymbolLabel(SYMBOL_SET, value)}`}>
+        <Symbol symbolSet={SYMBOL_SET} value={value} textStyle={textStyle} />
       </View>
     );
   } else {

--- a/SudokuApp/components/Symbol.js
+++ b/SudokuApp/components/Symbol.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { resolveSymbol } from '../utils/symbolSets';
+
+/**
+ * Symbol — owns "value → glyph" for the active symbol set (docs/fungiku-plan.md
+ * §2). It is the single rendering seam Fungiku rides on: swap the symbol set and
+ * every place a value is drawn changes, without touching game logic.
+ *
+ * The "numbers" path returns today's digit <Text> verbatim, using the exact
+ * `textStyle` the caller already computes — so with `symbolSet` hardcoded to
+ * "numbers" (Step 1) the board is pixel-identical to before.
+ *
+ * Props:
+ *   symbolSet — active set id ('numbers' | 'fungiku')
+ *   value     — numeric cell value (1..9); the board stays numeric internally
+ *   textStyle — style passed straight through to the digit <Text> (numbers mode)
+ *   size      — glyph size for swatch/mushroom rendering (fungiku mode)
+ *   color     — optional color override for the mushroom glyph
+ */
+const Symbol = ({ symbolSet, value, textStyle, size = 22, color }) => {
+  const symbol = resolveSymbol(symbolSet, value);
+
+  if (symbol.kind === 'swatch') {
+    const [tl, tr, br, bl] = symbol.corners;
+    return (
+      <View
+        style={[
+          styles.swatch,
+          {
+            width: size,
+            height: size,
+            backgroundColor: symbol.color,
+            borderTopLeftRadius: tl * size,
+            borderTopRightRadius: tr * size,
+            borderBottomRightRadius: br * size,
+            borderBottomLeftRadius: bl * size,
+          },
+        ]}
+      />
+    );
+  }
+
+  if (symbol.kind === 'icon') {
+    return <MaterialCommunityIcons name={symbol.icon} size={size} color={color || symbol.color} />;
+  }
+
+  // 'text' — the digit, drawn exactly as the cell drew it before the seam.
+  return <Text style={textStyle}>{symbol.text}</Text>;
+};
+
+const styles = StyleSheet.create({
+  swatch: {
+    // A subtle rim so a swatch reads against any theme background — a redundant,
+    // non-color edge cue that pairs with the per-swatch corner shape.
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: 'rgba(0, 0, 0, 0.25)',
+  },
+});
+
+export default React.memo(Symbol);

--- a/SudokuApp/utils/symbolSets.js
+++ b/SudokuApp/utils/symbolSets.js
@@ -1,0 +1,79 @@
+/**
+ * symbolSets.js — the source of truth for how a Sudoku cell value (1..9) maps
+ * to a drawable "symbol". Fungiku is a *rendering* skin (docs/fungiku-plan.md
+ * §2–§3): the board stays numeric internally; only the glyph a value is drawn
+ * with changes. Nothing here touches the generator, reducer, notes, undo/redo,
+ * feedback, or win detection.
+ *
+ * Two sets:
+ *   - "numbers": the digit itself — today's behavior, verbatim.
+ *   - "fungiku": 8 color swatches + 1 mushroom character. The mushroom uses the
+ *     MaterialCommunityIcons "mushroom" glyph as a placeholder until static art
+ *     lands behind this same seam (plan §3, Step 5).
+ *
+ * Colorblind-awareness (plan §3/§6): the swatch palette is the Okabe–Ito
+ * colorblind-safe set, so hues stay distinct under the common CVD types, and it
+ * spans a range of lightness. On top of color, each swatch carries a distinct
+ * corner/shape cue (`corners`) so color is never the only channel of identity.
+ */
+
+export const SYMBOL_SET_IDS = { NUMBERS: 'numbers', FUNGIKU: 'fungiku' };
+
+// Which cell value is drawn as the mushroom (the "star"). Fixed per game — it's
+// logically just another symbol. Plan §3: "e.g. always 1".
+const MUSHROOM_VALUE = 1;
+
+// The mushroom placeholder: MaterialCommunityIcons glyph + a spotlight color and
+// a stable screen-reader name. Swapped for a static PNG later (plan Step 5).
+const MUSHROOM = { icon: 'mushroom', color: '#C1272D', name: 'mushroom' };
+
+// Okabe–Ito colorblind-safe palette assigned to the 8 non-mushroom values.
+// Each entry:
+//   color   — distinct hue (colorblind-safe under deutan/protan/tritan)
+//   name    — human name used as the stable accessibilityLabel (plan §5)
+//   corners — a non-color shape cue: [topLeft, topRight, bottomRight, bottomLeft]
+//             border-radius fractions of the swatch size. Every value gets a
+//             distinct silhouette (circle, rounded, square, leaf, teardrop) so
+//             identity survives even if two colors read alike.
+const FUNGIKU_SWATCHES = {
+  2: { color: '#E69F00', name: 'orange',   corners: [0.5, 0.5, 0.5, 0.5] },  // circle
+  3: { color: '#56B4E9', name: 'sky blue', corners: [0.28, 0.28, 0.28, 0.28] }, // rounded square
+  4: { color: '#009E73', name: 'green',    corners: [0.06, 0.06, 0.06, 0.06] }, // square
+  5: { color: '#F0E442', name: 'yellow',   corners: [0.5, 0.06, 0.5, 0.06] }, // leaf ╱
+  6: { color: '#0072B2', name: 'blue',     corners: [0.06, 0.5, 0.06, 0.5] }, // leaf ╲
+  7: { color: '#D55E00', name: 'red',      corners: [0.06, 0.5, 0.5, 0.5] }, // teardrop ◤
+  8: { color: '#CC79A7', name: 'pink',     corners: [0.5, 0.06, 0.5, 0.5] }, // teardrop ◥
+  9: { color: '#6E6E6E', name: 'gray',     corners: [0.5, 0.5, 0.06, 0.5] }, // teardrop ◢
+};
+
+/**
+ * resolveSymbol(setId, value) → a plain descriptor Symbol.js knows how to draw:
+ *   { kind: 'text',   value, text,  label }               // numbers
+ *   { kind: 'swatch', value, color, corners, label }      // fungiku color
+ *   { kind: 'icon',   value, icon,  color,   label }       // fungiku mushroom
+ *
+ * Any unknown set or unexpected value falls back to the numeric digit, so the
+ * default path is always safe and visually unchanged.
+ */
+export function resolveSymbol(setId, value) {
+  if (setId === SYMBOL_SET_IDS.FUNGIKU) {
+    if (value === MUSHROOM_VALUE) {
+      return { kind: 'icon', value, icon: MUSHROOM.icon, color: MUSHROOM.color, label: MUSHROOM.name };
+    }
+    const swatch = FUNGIKU_SWATCHES[value];
+    if (swatch) {
+      return { kind: 'swatch', value, color: swatch.color, corners: swatch.corners, label: swatch.name };
+    }
+    // Unexpected value — fall through to the numeric digit.
+  }
+  return { kind: 'text', value, text: String(value), label: String(value) };
+}
+
+/**
+ * The stable, non-visual name for a value in a symbol set — used for
+ * accessibilityLabel so screen readers and tests keep working (plan §5). In
+ * "numbers" mode this is just the digit string, so today's labels are unchanged.
+ */
+export function getSymbolLabel(setId, value) {
+  return resolveSymbol(setId, value).label;
+}


### PR DESCRIPTION
Implements **Step 1** of the Fungiku plan (`docs/fungiku-plan.md` §2, §6 item 1) — the rendering seam, and nothing beyond it. Refs #65.

## What this does
Fungiku only changes how a value is **drawn**. This PR introduces the `value → glyph` seam and routes cell values through it, with the symbol set **hardcoded to `numbers`** so the board is pixel-identical to today. No toggle/state yet — that's Step 2.

**Golden rule honored:** no game logic touched. The generator (`sudoku-gen`), the `GameContext` reducer, notes, undo/redo, feedback, and win detection are all unchanged. Cell values stay numeric `1..9` internally.

## Changes
- **`SudokuApp/utils/symbolSets.js`** (new) — `numbers` and `fungiku` symbol sets.
  - Fungiku = 8 color swatches + the MaterialCommunityIcons `mushroom` glyph fixed to value `1`.
  - Swatch palette is the **Okabe–Ito colorblind-safe set** (distinct hue *and* lightness) with a **distinct per-swatch corner/shape cue** (`corners`), so color is never the only channel (§3/§6).
  - `resolveSymbol(setId, value)` returns a drawable descriptor; `getSymbolLabel(setId, value)` returns a stable per-symbol accessibility name (§5).
- **`SudokuApp/components/Symbol.js`** (new) — owns `value → glyph` for the active set. The `numbers` path returns today's digit `<Text>` **verbatim** via the caller's `textStyle`, so the default path is visually identical. Icons import via `import { MaterialCommunityIcons } from '@expo/vector-icons'`.
- **`SudokuApp/components/Cell.js`** — renders its value through `<Symbol>` with `symbolSet` hardcoded to `numbers`. `accessibilityLabel` now sourced from `getSymbolLabel` (identical string in numbers mode). Notes rendering untouched (Step 3).

## Verification (from `SudokuApp/`)
- `npx expo-doctor` → **18/18 checks passed**
- `npx expo export --platform all` → **web + iOS + Android** bundles all build

## Testing note
This is a "prove zero visual change" step. Opening this PR triggers CI to publish an Expo Go preview and comment a QR below. Please test the preview in Expo Go and confirm the board looks **exactly as it does today** — digits, feedback colors, notes, themes all unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C56dQ6WJBg1GN2vAcUBYvs)_