### PR TITLE
Fungiku Step 2: symbol-set state + toggle

### DIFF
--- a/SudokuApp/components/Cell.js
+++ b/SudokuApp/components/Cell.js
@@ -3,21 +3,21 @@ import { View, Text, StyleSheet, Platform } from 'react-native';
 import Symbol from './Symbol';
 import { SYMBOL_SET_IDS, getSymbolLabel } from '../utils/symbolSets';
 
-// Step 1 of the Fungiku seam: values render through <Symbol>, but the symbol set
-// is hardcoded to "numbers" so the board is visually identical to before. State
-// + a toggle arrive in Step 2 (docs/fungiku-plan.md §4, §6).
-const SYMBOL_SET = SYMBOL_SET_IDS.NUMBERS;
-
-// Performance-optimized Cell component
-const Cell = ({ 
-  value, 
+// Performance-optimized Cell component. The active symbol set arrives as a prop
+// (threaded from GameContext through Grid, like `theme`) so the board's numeric
+// values render as digits or Fungiku glyphs without changing game logic
+// (docs/fungiku-plan.md §4, §6 Step 2). Defaults to "numbers" so the render is
+// unchanged if the prop is ever absent.
+const Cell = ({
+  value,
   isSelected,
-  isInitialCell, 
+  isInitialCell,
   relationType,
-  isCorrect, 
-  showFeedback, 
-  extraStyle, 
+  isCorrect,
+  showFeedback,
+  extraStyle,
   theme,
+  symbolSet = SYMBOL_SET_IDS.NUMBERS,
   notes = [] // Array of numbers 1-9 that are notes for this cell
 }) => {
   // Memoize background color calculation
@@ -110,8 +110,8 @@ const Cell = ({
   if (value !== 0) {
     // Cell has a value
     return (
-      <View style={cellStyle} accessibilityLabel={`Cell value: ${getSymbolLabel(SYMBOL_SET, value)}`}>
-        <Symbol symbolSet={SYMBOL_SET} value={value} textStyle={textStyle} />
+      <View style={cellStyle} accessibilityLabel={`Cell value: ${getSymbolLabel(symbolSet, value)}`}>
+        <Symbol symbolSet={symbolSet} value={value} textStyle={textStyle} />
       </View>
     );
   } else {

--- a/SudokuApp/components/GameHeader.js
+++ b/SudokuApp/components/GameHeader.js
@@ -3,6 +3,7 @@ import { View, StyleSheet, Text, TouchableOpacity } from 'react-native';
 import { useGameContext } from '../contexts/GameContext';
 import { ACTIONS } from '../contexts/GameContext';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
+import SymbolSetSelector from './SymbolSetSelector';
 
 // Constants for consistent sizes
 const ICON_SIZE = 24;
@@ -43,8 +44,9 @@ const GameHeader = () => {
           <Text style={[styles.title, { color: theme.colors.title }]}>Sudoku</Text>
         </View>
 
-        {/* Right: Theme Selector Button */}
+        {/* Right: Symbol-set toggle + Theme Selector Button */}
         <View style={styles.rightSection}>
+          <SymbolSetSelector />
           <TouchableOpacity
             style={[styles.themeButton, { borderColor: theme.colors.title }]}
             onPress={cycleTheme}
@@ -92,7 +94,9 @@ const styles = StyleSheet.create({
   },
   rightSection: {
     flex: 1,
-    alignItems: 'flex-end',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
     paddingRight: 8,
   },
   title: {

--- a/SudokuApp/components/Grid.js
+++ b/SudokuApp/components/Grid.js
@@ -8,10 +8,11 @@ const Grid = ({
   onCellPress, 
   selectedCell, 
   initialCells = [], 
-  theme, 
-  showFeedback = false, 
-  cellFeedback = {}, 
-  cellNotes = {}
+  theme,
+  showFeedback = false,
+  cellFeedback = {},
+  cellNotes = {},
+  symbolSet
 }) => {
   // Memoize all the cell relations based on the selected cell and board state
   // This prevents recalculating relations for all 81 cells on every render
@@ -127,12 +128,13 @@ const Grid = ({
           showFeedback={showFeedback && !isInitialCell && num !== 0}
           extraStyle={cellBorderStyles[cellKey]}
           theme={theme}
+          symbolSet={symbolSet}
           notes={notes}
         />
       </TouchableOpacity>
     );
   }, [
-    selectedCell, 
+    selectedCell,
     cellRelations,
     initialCells,
     showFeedback,
@@ -140,6 +142,7 @@ const Grid = ({
     cellNotes,
     cellBorderStyles,
     theme,
+    symbolSet,
     onCellPress
   ]);
 

--- a/SudokuApp/components/SymbolSetSelector.js
+++ b/SudokuApp/components/SymbolSetSelector.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { StyleSheet, TouchableOpacity } from 'react-native';
+import { useGameContext } from '../contexts/GameContext';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { SYMBOL_SET_IDS } from '../utils/symbolSets';
+
+// Constants for consistent sizes (matches the header's theme button)
+const ICON_SIZE = 24;
+
+/**
+ * SymbolSetSelector — an icon button that cycles the Fungiku display mode
+ * (Numbers → Fungiku), mirroring the theme selector. It only changes how a
+ * cell's value is *drawn*; the board stays numeric (docs/fungiku-plan.md §4).
+ *
+ * Placement: next to the theme selector in the header (see GameHeader.js).
+ *
+ * The button is intentionally icon-only: the visible mode label ("Fungiku" vs.
+ * a plainer "Colors") is an open question for the operator (plan §7 #1), so we
+ * avoid committing to wording in the UI. The current mode still rides the
+ * accessibilityLabel/Value so screen readers and tests can read it.
+ */
+const SYMBOL_SET_META = {
+  [SYMBOL_SET_IDS.NUMBERS]: { icon: 'numeric', label: 'Numbers' },
+  [SYMBOL_SET_IDS.FUNGIKU]: { icon: 'mushroom', label: 'Fungiku' },
+};
+
+const SymbolSetSelector = () => {
+  const { theme, symbolSet, cycleSymbolSet } = useGameContext();
+
+  const meta = SYMBOL_SET_META[symbolSet] || SYMBOL_SET_META[SYMBOL_SET_IDS.NUMBERS];
+
+  return (
+    <TouchableOpacity
+      style={[styles.button, { borderColor: theme.colors.title }]}
+      onPress={cycleSymbolSet}
+      accessibilityRole="button"
+      accessibilityLabel="Change symbol set"
+      accessibilityValue={{ text: meta.label }}
+      accessibilityHint="Cycles the board between number and Fungiku symbols"
+    >
+      <MaterialCommunityIcons
+        name={meta.icon}
+        size={ICON_SIZE}
+        color={theme.colors.title}
+      />
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  button: {
+    paddingVertical: 3,
+    paddingHorizontal: 6,
+    borderRadius: 5,
+    borderWidth: 1,
+    marginRight: 6,
+  },
+});
+
+export default SymbolSetSelector;

--- a/SudokuApp/contexts/GameContext.js
+++ b/SudokuApp/contexts/GameContext.js
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useRef, useCallback } from 'react';
 import SUDOKU_THEMES from '../utils/themes';
+import { SYMBOL_SET_IDS } from '../utils/symbolSets';
 import { generateSudoku, isCorrectValue as checkCorrectValue } from '../utils/boardFactory';
 import usePersistentReducer from '../hooks/usePersistentReducer';
 import { debugFillBoard as debugFillBoardUtil, debugCheatMode as debugCheatModeUtil } from '../utils/debugUtils';
@@ -19,6 +20,7 @@ export const ACTIONS = {
   TOGGLE_NOTES_MODE: 'TOGGLE_NOTES_MODE',
   TOGGLE_FEEDBACK: 'TOGGLE_FEEDBACK',
   CHANGE_THEME: 'CHANGE_THEME',
+  CHANGE_SYMBOL_SET: 'CHANGE_SYMBOL_SET', // Fungiku display mode (docs/fungiku-plan.md §4)
   UNDO: 'UNDO',
   REDO: 'REDO',
   FILL_IN_NOTES: 'FILL_IN_NOTES', // New action for filling in all possible notes
@@ -80,6 +82,11 @@ const initialState = {
   // Theme state
   currentThemeName: 'classic',
   theme: SUDOKU_THEMES.classic,
+
+  // Symbol-set state (Fungiku display mode) — how a cell value is *drawn*, not
+  // what it is. Orthogonal to theme and difficulty. Mirrors currentThemeName:
+  // persisted the same way, cycled the same way. (docs/fungiku-plan.md §4)
+  symbolSet: SYMBOL_SET_IDS.NUMBERS,
 
   // Undo/redo state
   undoStack: [],
@@ -556,6 +563,16 @@ function gameReducer(state, action) {
         theme: SUDOKU_THEMES[themeName],
       };
     }
+
+    case ACTIONS.CHANGE_SYMBOL_SET: {
+      // Fungiku is a rendering skin only — swapping the symbol set changes how
+      // values are drawn, never the numeric board underneath (plan §4, golden
+      // rule). No board/notes/feedback state is touched here.
+      return {
+        ...state,
+        symbolSet: action.payload,
+      };
+    }
     
     case ACTIONS.UNDO: {
       // Prevent undo if game is completed or if undo stack is empty
@@ -1017,7 +1034,24 @@ export const GameProvider = ({ children }) => {
       payload: nextThemeName,
     });
   };
-  
+
+  // Set the symbol set directly (numbers | fungiku). Mirrors CHANGE_THEME.
+  const setSymbolSet = (setId) => {
+    dispatch({
+      type: ACTIONS.CHANGE_SYMBOL_SET,
+      payload: setId,
+    });
+  };
+
+  // Cycle through the available symbol sets (Numbers → Fungiku → …), mirroring
+  // cycleTheme. Values come from SYMBOL_SET_IDS in utils/symbolSets.js.
+  const cycleSymbolSet = () => {
+    const setIds = Object.values(SYMBOL_SET_IDS);
+    const currentIndex = setIds.indexOf(state.symbolSet);
+    const nextIndex = (currentIndex + 1) % setIds.length;
+    setSymbolSet(setIds[nextIndex]);
+  };
+
   // Helper to calculate last score change (used for animations)
   const getLastScoreChange = () => {
     const lastAction = state.undoStack.length > 0 ? state.undoStack[state.undoStack.length - 1] : null;
@@ -1042,6 +1076,8 @@ export const GameProvider = ({ children }) => {
     handleNumberSelect,
     formatTime,
     cycleTheme,
+    cycleSymbolSet,
+    setSymbolSet,
     debugFillBoard,
     debugCheatMode,
     getLastScoreChange,

--- a/SudokuApp/screens/GameScreen.js
+++ b/SudokuApp/screens/GameScreen.js
@@ -31,7 +31,8 @@ const GameScreenContent = () => {
     handleNumberSelect,
     notesMode,
     showBuildNotes,
-    gameCompleted
+    gameCompleted,
+    symbolSet
   } = useGameContext();
 
   // Use custom hook to handle app state changes
@@ -79,6 +80,7 @@ const GameScreenContent = () => {
             showFeedback={showFeedback}
             cellFeedback={cellFeedback}
             cellNotes={cellNotes}
+            symbolSet={symbolSet}
           />
         </View>
 


### PR DESCRIPTION
Implements **Step 2** of the Fungiku plan (`docs/fungiku-plan.md` §4, §6 item 2) — the symbol-set state and the toggle. Refs #65.

Fungiku is a display mode: it only changes **how a cell value is drawn** (numbers ↔ 8 color swatches + 1 mushroom). The board stays numeric `1..9` internally. This PR does **not** touch the generator, reducer game logic (beyond the new state/action), notes, undo/redo, feedback, or win detection.

## What's in this step
- **State + actions (`GameContext`)** — new `symbolSet` state and a `CHANGE_SYMBOL_SET` action, with `cycleSymbolSet` / `setSymbolSet` helpers. This mirrors `currentThemeName` / `cycleTheme` exactly; the set ids come from `SYMBOL_SET_IDS` (`numbers` → `fungiku`) in `utils/symbolSets.js`.
- **Persistence** — `symbolSet` is a plain state field and is *not* stripped by `stripTransient`, so it saves and restores through the existing `usePersistentReducer` just like the theme. The choice survives relaunch. (Same as the theme, it only persists once a game is in progress.)
- **`Cell.js`** — stops hardcoding `symbolSet` (was pinned to `numbers` in Step 1). It now reads the set from a prop threaded `GameContext → GameScreen → Grid → Cell`, exactly the way `theme` flows. The stable per-symbol `accessibilityLabel` is preserved.
- **Selector control** — `components/SymbolSetSelector.js`, an icon button that cycles Numbers → Fungiku, placed **next to the theme selector in the header**.

## Decision to note for review
**Placement + form of the control.** I put the toggle in the header's right section, immediately left of the theme button — the natural sibling to the theme selector this plan says to mirror. I made it **icon-only** (numeric ↔ mushroom glyph) rather than icon+label. Two reasons: it keeps the header from crowding next to the 90px theme button, and it lets us avoid committing to visible wording while open question §7 #1 is unresolved (see below). The current mode still rides `accessibilityValue` so screen readers and tests can read "Numbers" / "Fungiku".

## Open question to surface (plan §7 #1)
**What should the mode be called in the UI — "Fungiku", or something plainer like "Colors"?** The internal id stays `fungiku` either way. Because the Step 2 control is icon-only, nothing in the UI commits to wording yet, so this is still fully open — happy to add a text label in whichever direction you choose.

## Scope boundary (expected, not a bug)
`NumberPad.js` and the notes mini-grid **stay on numbers** — that's Step 3. So in Fungiku mode the board cells show swatches + the mushroom while the number pad still shows digits. That's expected for this step.

## Verification
- `npx expo-doctor` → **18/18** checks pass
- `npx expo export --platform all` → **web + iOS + Android** all bundle

Device testing in Expo Go is the real gate for the toggle (glyph swap + persistence across reload) and is pending operator test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dZcxzgXXBdVqNo6n2zbjf

---
_Generated by [Claude Code](https://claude.ai/code/session_014dZcxzgXXBdVqNo6n2zbjf)_