### PR TITLE
Fungiku replan + Step 2: engine, epic branch, and an engine preview you can run

### DIFF
--- a/SudokuApp/components/modals/GameMenuModal.js
+++ b/SudokuApp/components/modals/GameMenuModal.js
@@ -3,6 +3,7 @@ import { StyleSheet, Text, TouchableOpacity, Modal, Animated, View, Switch } fro
 import { useGameContext, ACTIONS } from '../../contexts/GameContext';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import appJson from '../../app.json';
+import FungikuPreview from '../../games/fungiku/FungikuPreview';
 
 // Constants for consistent sizes
 const ICON_SIZE = 24;
@@ -27,6 +28,9 @@ const GameMenuModal = () => {
 
   // Animation for menu modal
   const [menuAnim] = React.useState(new Animated.Value(0));
+
+  // Fungiku engine preview (temporary scaffolding — see the button below).
+  const [showFungikuPreview, setShowFungikuPreview] = React.useState(false);
 
   React.useEffect(() => {
     if (showMenu) {
@@ -153,6 +157,24 @@ const GameMenuModal = () => {
               </TouchableOpacity>
             )}
 
+            {/* Fungiku engine preview — scaffolding so the in-progress Fungiku
+                mode is viewable in Expo Go at every step (plan §6). Replaced by
+                the real mode entry in Step 5. */}
+            <TouchableOpacity
+              style={[styles.menuButton, styles.buildButton]}
+              onPress={() => setShowFungikuPreview(true)}
+              accessibilityLabel="Preview Fungiku puzzles"
+              accessibilityRole="button"
+            >
+              <MaterialCommunityIcons
+                name="mushroom"
+                size={ICON_SIZE}
+                color="#333"
+                style={styles.menuButtonIcon}
+              />
+              <Text style={[styles.menuButtonText, { color: theme.colors.text || '#333' }]}>Fungiku (preview)</Text>
+            </TouchableOpacity>
+
             {/* Build Notes button */}
             <TouchableOpacity
               style={[styles.menuButton, styles.buildButton]}
@@ -231,6 +253,12 @@ const GameMenuModal = () => {
           </Text>
         </View>
       </Animated.View>
+
+      <FungikuPreview
+        visible={showFungikuPreview}
+        onClose={() => setShowFungikuPreview(false)}
+        theme={theme}
+      />
     </Modal>
   );
 };

--- a/SudokuApp/components/modals/GameMenuModal.js
+++ b/SudokuApp/components/modals/GameMenuModal.js
@@ -158,8 +158,9 @@ const GameMenuModal = () => {
             )}
 
             {/* Fungiku engine preview — scaffolding so the in-progress Fungiku
-                mode is viewable in Expo Go at every step (plan §6). Replaced by
-                the real mode entry in Step 5. */}
+                mode is viewable in Expo Go at every step (plan §7). Temporary:
+                Step 3 gives Fungiku its own screen off the hub (plan §6) and
+                this entry goes away. */}
             <TouchableOpacity
               style={[styles.menuButton, styles.buildButton]}
               onPress={() => setShowFungikuPreview(true)}

--- a/SudokuApp/games/fungiku/FungikuPreview.js
+++ b/SudokuApp/games/fungiku/FungikuPreview.js
@@ -6,14 +6,15 @@ import { getRegionColor } from '../../utils/symbolSets';
 
 /**
  * FungikuPreview — a read-only look at what the engine produces
- * (docs/fungiku-plan.md §6). It exists so every delivery step, including the
+ * (docs/fungiku-plan.md §7). It exists so every delivery step, including the
  * pure-logic ones, ships something runnable in Expo Go: here you can see the
  * generated color regions and the solution mushrooms, and reseed to judge
  * whether region shapes and colors are heading the right way.
  *
  * This is deliberately NOT the real board — there is no input, no marks, no
- * conflict handling. The playable board arrives in Step 4 with its own
- * component; this preview is scaffolding to look at the engine's output.
+ * conflict handling. Step 3 moves it onto Fungiku's own screen off the hub,
+ * Step 4 makes it playable, and Step 5 supersedes it with the real board
+ * component. Until then it is scaffolding for looking at the engine's output.
  */
 
 const SIZES = [5, 6, 7, 8];

--- a/SudokuApp/games/fungiku/FungikuPreview.js
+++ b/SudokuApp/games/fungiku/FungikuPreview.js
@@ -1,0 +1,224 @@
+import React, { useMemo, useState } from 'react';
+import { Modal, View, Text, TouchableOpacity, StyleSheet, ScrollView } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { generate, MIN_SIZE } from './engine';
+import { getRegionColor } from '../../utils/symbolSets';
+
+/**
+ * FungikuPreview — a read-only look at what the engine produces
+ * (docs/fungiku-plan.md §6). It exists so every delivery step, including the
+ * pure-logic ones, ships something runnable in Expo Go: here you can see the
+ * generated color regions and the solution mushrooms, and reseed to judge
+ * whether region shapes and colors are heading the right way.
+ *
+ * This is deliberately NOT the real board — there is no input, no marks, no
+ * conflict handling. The playable board arrives in Step 4 with its own
+ * component; this preview is scaffolding to look at the engine's output.
+ */
+
+const SIZES = [5, 6, 7, 8];
+const BOARD_MAX = 320;
+
+const FungikuPreview = ({ visible, onClose, theme }) => {
+  const [size, setSize] = useState(MIN_SIZE);
+  const [seed, setSeed] = useState(1);
+  const [showSolution, setShowSolution] = useState(true);
+
+  // Generation is deterministic, so this only recomputes when size/seed change.
+  const puzzle = useMemo(() => {
+    try {
+      return generate({ size, seed });
+    } catch (error) {
+      return { error: error.message };
+    }
+  }, [size, seed]);
+
+  const cell = Math.floor(BOARD_MAX / size);
+
+  const solutionCells = useMemo(() => {
+    if (!puzzle || puzzle.error) return new Set();
+    return new Set(puzzle.solution.map((col, row) => row * size + col));
+  }, [puzzle, size]);
+
+  const titleColor = theme?.colors?.title || '#222';
+  const surface = theme?.colors?.numberPad?.background || '#fff';
+  const border = theme?.colors?.numberPad?.border || '#ccc';
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <View style={[styles.sheet, { backgroundColor: surface, borderColor: border }]}>
+          <View style={styles.headerRow}>
+            <Text style={[styles.title, { color: titleColor }]}>Fungiku — engine preview</Text>
+            <TouchableOpacity onPress={onClose} accessibilityLabel="Close Fungiku preview" accessibilityRole="button">
+              <MaterialCommunityIcons name="close" size={24} color={titleColor} />
+            </TouchableOpacity>
+          </View>
+
+          <Text style={[styles.caption, { color: titleColor }]}>
+            One mushroom per row, column and color region — none touching.
+          </Text>
+
+          <ScrollView contentContainerStyle={styles.scrollBody}>
+            {puzzle.error ? (
+              <Text style={styles.error}>{puzzle.error}</Text>
+            ) : (
+              <View style={[styles.board, { width: cell * size, height: cell * size }]}>
+                {Array.from({ length: size }, (_, row) => (
+                  <View key={row} style={styles.boardRow}>
+                    {Array.from({ length: size }, (_, col) => {
+                      const index = row * size + col;
+                      const region = puzzle.regions[index];
+                      const palette = getRegionColor(region);
+
+                      // Thick edges wherever neighboring cells belong to a
+                      // different region — the region outline *is* the board's
+                      // structure (plan §3), replacing Sudoku's 3×3 box lines.
+                      const differs = (r, c) =>
+                        r < 0 ||
+                        c < 0 ||
+                        r >= size ||
+                        c >= size ||
+                        puzzle.regions[r * size + c] !== region;
+
+                      return (
+                        <View
+                          key={col}
+                          style={{
+                            width: cell,
+                            height: cell,
+                            backgroundColor: palette.background,
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            borderColor: '#33333355',
+                            borderTopWidth: differs(row - 1, col) ? 2 : StyleSheet.hairlineWidth,
+                            borderBottomWidth: differs(row + 1, col) ? 2 : StyleSheet.hairlineWidth,
+                            borderLeftWidth: differs(row, col - 1) ? 2 : StyleSheet.hairlineWidth,
+                            borderRightWidth: differs(row, col + 1) ? 2 : StyleSheet.hairlineWidth,
+                          }}
+                        >
+                          {showSolution && solutionCells.has(index) && (
+                            <MaterialCommunityIcons
+                              name="mushroom"
+                              size={Math.round(cell * 0.62)}
+                              color={palette.color}
+                            />
+                          )}
+                        </View>
+                      );
+                    })}
+                  </View>
+                ))}
+              </View>
+            )}
+
+            <View style={styles.controls}>
+              <Text style={[styles.label, { color: titleColor }]}>Board size</Text>
+              <View style={styles.row}>
+                {SIZES.map((option) => (
+                  <TouchableOpacity
+                    key={option}
+                    onPress={() => setSize(option)}
+                    style={[
+                      styles.chip,
+                      { borderColor: border },
+                      option === size && { backgroundColor: titleColor, borderColor: titleColor },
+                    ]}
+                    accessibilityRole="button"
+                    accessibilityLabel={`${option} by ${option} board`}
+                  >
+                    <Text style={[styles.chipText, { color: option === size ? surface : titleColor }]}>
+                      {option}×{option}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+
+              <View style={styles.row}>
+                <TouchableOpacity
+                  onPress={() => setSeed((s) => s + 1)}
+                  style={[styles.wideButton, { borderColor: border }]}
+                  accessibilityRole="button"
+                  accessibilityLabel="Generate the next puzzle"
+                >
+                  <MaterialCommunityIcons name="dice-multiple" size={18} color={titleColor} />
+                  <Text style={[styles.buttonText, { color: titleColor }]}>Seed {seed}</Text>
+                </TouchableOpacity>
+
+                <TouchableOpacity
+                  onPress={() => setShowSolution((v) => !v)}
+                  style={[styles.wideButton, { borderColor: border }]}
+                  accessibilityRole="button"
+                  accessibilityLabel={showSolution ? 'Hide the solution' : 'Show the solution'}
+                >
+                  <MaterialCommunityIcons
+                    name={showSolution ? 'eye-off' : 'eye'}
+                    size={18}
+                    color={titleColor}
+                  />
+                  <Text style={[styles.buttonText, { color: titleColor }]}>
+                    {showSolution ? 'Hide' : 'Show'}
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  sheet: {
+    width: '100%',
+    maxWidth: 400,
+    maxHeight: '90%',
+    borderRadius: 12,
+    borderWidth: 1,
+    padding: 16,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  title: { fontSize: 18, fontWeight: 'bold' },
+  caption: { fontSize: 12, opacity: 0.75, marginTop: 4, marginBottom: 12 },
+  scrollBody: { alignItems: 'center' },
+  board: { alignSelf: 'center' },
+  boardRow: { flexDirection: 'row' },
+  controls: { width: '100%', marginTop: 16 },
+  label: { fontSize: 12, fontWeight: '600', marginBottom: 6 },
+  row: { flexDirection: 'row', justifyContent: 'center', marginBottom: 10 },
+  chip: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    marginHorizontal: 4,
+  },
+  chipText: { fontSize: 13, fontWeight: '600' },
+  wideButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: 8,
+    borderWidth: 1,
+    marginHorizontal: 4,
+    minWidth: 110,
+  },
+  buttonText: { fontSize: 13, fontWeight: '600', marginLeft: 6 },
+  error: { color: '#C1272D', fontSize: 13, textAlign: 'center', padding: 20 },
+});
+
+export default FungikuPreview;

--- a/SudokuApp/games/fungiku/__tests__/engine.test.js
+++ b/SudokuApp/games/fungiku/__tests__/engine.test.js
@@ -12,7 +12,7 @@ import {
   createEmptyMarks,
 } from '../engine';
 
-// Sizes the v1 ladder ships (plan §6). Kept small so the suite stays fast.
+// Sizes the v1 ladder ships (plan §8). Kept small so the suite stays fast.
 const LADDER = [5, 6, 7, 8];
 const SEEDS = [1, 2, 3, 7, 42, 1337];
 
@@ -93,7 +93,7 @@ describe('createRng', () => {
 });
 
 describe('generate', () => {
-  it.each([4, 3, 0, -1])('rejects size %i as unsolvable (plan §8)', (size) => {
+  it.each([4, 3, 0, -1])('rejects size %i as unsolvable (plan §9)', (size) => {
     expect(() => generate({ size, seed: 1 })).toThrow(/size/i);
   });
 
@@ -266,7 +266,7 @@ describe('isSolved', () => {
     expect(isSolved(marksFromSolution(puzzle), puzzle.regions, size)).toBe(true);
   });
 
-  it('stays true no matter how many X marks are sprinkled around (plan §8)', () => {
+  it('stays true no matter how many X marks are sprinkled around (plan §9)', () => {
     const marks = marksFromSolution(puzzle).map((m) => (m === MARKS.MUSHROOM ? m : MARKS.X));
     expect(isSolved(marks, puzzle.regions, size)).toBe(true);
   });

--- a/SudokuApp/games/fungiku/__tests__/engine.test.js
+++ b/SudokuApp/games/fungiku/__tests__/engine.test.js
@@ -1,0 +1,320 @@
+import {
+  MARKS,
+  MIN_SIZE,
+  nextMark,
+  createRng,
+  generate,
+  findSolutions,
+  countSolutions,
+  findConflicts,
+  isSolved,
+  countMushrooms,
+  createEmptyMarks,
+} from '../engine';
+
+// Sizes the v1 ladder ships (plan §6). Kept small so the suite stays fast.
+const LADDER = [5, 6, 7, 8];
+const SEEDS = [1, 2, 3, 7, 42, 1337];
+
+/** Orthogonal flood fill — an independent contiguity check for a region. */
+const regionIsContiguous = (regions, size, region) => {
+  const members = [];
+  for (let i = 0; i < regions.length; i++) {
+    if (regions[i] === region) members.push(i);
+  }
+  if (members.length === 0) return false;
+
+  const seen = new Set([members[0]]);
+  const stack = [members[0]];
+  while (stack.length > 0) {
+    const cell = stack.pop();
+    const row = Math.floor(cell / size);
+    const col = cell % size;
+    const neighbors = [];
+    if (row > 0) neighbors.push(cell - size);
+    if (row < size - 1) neighbors.push(cell + size);
+    if (col > 0) neighbors.push(cell - 1);
+    if (col < size - 1) neighbors.push(cell + 1);
+    for (const n of neighbors) {
+      if (regions[n] === region && !seen.has(n)) {
+        seen.add(n);
+        stack.push(n);
+      }
+    }
+  }
+  return seen.size === members.length;
+};
+
+const marksFromSolution = (puzzle) => {
+  const marks = createEmptyMarks(puzzle.size);
+  puzzle.solution.forEach((col, row) => {
+    marks[row * puzzle.size + col] = MARKS.MUSHROOM;
+  });
+  return marks;
+};
+
+describe('nextMark', () => {
+  it('cycles empty -> X -> mushroom -> empty (plan §2)', () => {
+    expect(nextMark(MARKS.EMPTY)).toBe(MARKS.X);
+    expect(nextMark(MARKS.X)).toBe(MARKS.MUSHROOM);
+    expect(nextMark(MARKS.MUSHROOM)).toBe(MARKS.EMPTY);
+  });
+
+  it('treats an unknown mark as empty so the first tap gives X', () => {
+    expect(nextMark(undefined)).toBe(MARKS.X);
+  });
+});
+
+describe('createRng', () => {
+  it('is deterministic for a given seed', () => {
+    const a = createRng(123);
+    const b = createRng(123);
+    const seqA = Array.from({ length: 20 }, () => a());
+    const seqB = Array.from({ length: 20 }, () => b());
+    expect(seqA).toEqual(seqB);
+  });
+
+  it('produces different streams for different seeds', () => {
+    const a = createRng(1);
+    const b = createRng(2);
+    expect(Array.from({ length: 10 }, () => a())).not.toEqual(
+      Array.from({ length: 10 }, () => b())
+    );
+  });
+
+  it('stays within [0, 1)', () => {
+    const rng = createRng(99);
+    for (let i = 0; i < 500; i++) {
+      const v = rng();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+});
+
+describe('generate', () => {
+  it.each([4, 3, 0, -1])('rejects size %i as unsolvable (plan §8)', (size) => {
+    expect(() => generate({ size, seed: 1 })).toThrow(/size/i);
+  });
+
+  it('rejects a non-integer size', () => {
+    expect(() => generate({ size: 5.5, seed: 1 })).toThrow(/size/i);
+  });
+
+  it(`starts the ladder at ${MIN_SIZE}`, () => {
+    expect(MIN_SIZE).toBe(5);
+    expect(() => generate({ size: MIN_SIZE, seed: 1 })).not.toThrow();
+  });
+
+  describe.each(LADDER)('size %i', (size) => {
+    const puzzles = SEEDS.map((seed) => generate({ size, seed }));
+
+    it('is deterministic — same size+seed gives an identical puzzle', () => {
+      SEEDS.forEach((seed, i) => {
+        expect(generate({ size, seed })).toEqual(puzzles[i]);
+      });
+    });
+
+    it('has exactly one solution (plan §1 rule 5)', () => {
+      puzzles.forEach((p) => {
+        // Ask for more than 2 so a wrong answer shows the real count.
+        expect(countSolutions(p.regions, size, 5)).toBe(1);
+      });
+    });
+
+    it('partitions the grid into N regions covering every cell', () => {
+      puzzles.forEach((p) => {
+        expect(p.regions).toHaveLength(size * size);
+        expect(p.regions).not.toContain(-1);
+        expect(new Set(p.regions).size).toBe(size);
+      });
+    });
+
+    it('makes every region contiguous (plan §4)', () => {
+      puzzles.forEach((p) => {
+        for (let region = 0; region < size; region++) {
+          expect(regionIsContiguous(p.regions, size, region)).toBe(true);
+        }
+      });
+    });
+
+    it('places one mushroom per row and per column', () => {
+      puzzles.forEach((p) => {
+        expect(p.solution).toHaveLength(size);
+        expect(new Set(p.solution).size).toBe(size); // a column permutation
+        p.solution.forEach((col) => {
+          expect(col).toBeGreaterThanOrEqual(0);
+          expect(col).toBeLessThan(size);
+        });
+      });
+    });
+
+    it('places one mushroom per region', () => {
+      puzzles.forEach((p) => {
+        const regionsUsed = p.solution.map((col, row) => p.regions[row * size + col]);
+        expect(new Set(regionsUsed).size).toBe(size);
+      });
+    });
+
+    it('never lets two mushrooms touch, including diagonally', () => {
+      puzzles.forEach((p) => {
+        for (let row = 0; row < size - 1; row++) {
+          expect(Math.abs(p.solution[row] - p.solution[row + 1])).toBeGreaterThanOrEqual(2);
+        }
+      });
+    });
+
+    it('reports its own solution as solved and conflict-free', () => {
+      puzzles.forEach((p) => {
+        const marks = marksFromSolution(p);
+        expect(findConflicts(marks, p.regions, size).size).toBe(0);
+        expect(isSolved(marks, p.regions, size)).toBe(true);
+      });
+    });
+
+    it('agrees with the solver — the stored solution is the one found', () => {
+      puzzles.forEach((p) => {
+        const [only] = findSolutions(p.regions, size, 2);
+        expect(only).toEqual(p.solution);
+      });
+    });
+
+    it('echoes back the size and seed it was asked for', () => {
+      SEEDS.forEach((seed, i) => {
+        expect(puzzles[i].size).toBe(size);
+        expect(puzzles[i].seed).toBe(seed);
+      });
+    });
+  });
+
+  it('produces different puzzles for different seeds', () => {
+    const a = generate({ size: 7, seed: 1 });
+    const b = generate({ size: 7, seed: 2 });
+    expect(a.regions).not.toEqual(b.regions);
+  });
+});
+
+describe('findConflicts', () => {
+  const size = 6;
+  const puzzle = generate({ size, seed: 42 });
+
+  it('flags two mushrooms in the same row', () => {
+    const marks = createEmptyMarks(size);
+    marks[0] = MARKS.MUSHROOM; // (0,0)
+    marks[3] = MARKS.MUSHROOM; // (0,3)
+    expect([...findConflicts(marks, puzzle.regions, size)].sort((a, b) => a - b)).toEqual([0, 3]);
+  });
+
+  it('flags two mushrooms in the same column', () => {
+    const marks = createEmptyMarks(size);
+    marks[0] = MARKS.MUSHROOM; // (0,0)
+    marks[3 * size] = MARKS.MUSHROOM; // (3,0)
+    expect(findConflicts(marks, puzzle.regions, size).size).toBe(2);
+  });
+
+  it('flags two mushrooms that touch diagonally', () => {
+    const marks = createEmptyMarks(size);
+    marks[0] = MARKS.MUSHROOM; // (0,0)
+    marks[size + 1] = MARKS.MUSHROOM; // (1,1)
+    expect([...findConflicts(marks, puzzle.regions, size)].sort((a, b) => a - b)).toEqual([
+      0,
+      size + 1,
+    ]);
+  });
+
+  it('flags two mushrooms sharing a region', () => {
+    // Find two same-region cells that share no row, column, and don't touch,
+    // so region membership is the only rule they can be breaking.
+    let pair = null;
+    for (let a = 0; a < size * size && !pair; a++) {
+      for (let b = a + 1; b < size * size && !pair; b++) {
+        const [ar, ac] = [Math.floor(a / size), a % size];
+        const [br, bc] = [Math.floor(b / size), b % size];
+        const touching = Math.abs(ar - br) <= 1 && Math.abs(ac - bc) <= 1;
+        if (puzzle.regions[a] === puzzle.regions[b] && ar !== br && ac !== bc && !touching) {
+          pair = [a, b];
+        }
+      }
+    }
+    // Every generated layout has at least one such pair; guard so a failure
+    // here reads as a real problem rather than a silent skip.
+    expect(pair).not.toBeNull();
+
+    const marks = createEmptyMarks(size);
+    marks[pair[0]] = MARKS.MUSHROOM;
+    marks[pair[1]] = MARKS.MUSHROOM;
+    expect(findConflicts(marks, puzzle.regions, size).size).toBe(2);
+  });
+
+  it('returns nothing for a legal partial placement', () => {
+    const marks = createEmptyMarks(size);
+    marks[0 * size + puzzle.solution[0]] = MARKS.MUSHROOM;
+    expect(findConflicts(marks, puzzle.regions, size).size).toBe(0);
+  });
+
+  it('ignores X marks entirely', () => {
+    const marks = createEmptyMarks(size).map(() => MARKS.X);
+    expect(findConflicts(marks, puzzle.regions, size).size).toBe(0);
+  });
+});
+
+describe('isSolved', () => {
+  const size = 6;
+  const puzzle = generate({ size, seed: 42 });
+
+  it('is true for the solution', () => {
+    expect(isSolved(marksFromSolution(puzzle), puzzle.regions, size)).toBe(true);
+  });
+
+  it('stays true no matter how many X marks are sprinkled around (plan §8)', () => {
+    const marks = marksFromSolution(puzzle).map((m) => (m === MARKS.MUSHROOM ? m : MARKS.X));
+    expect(isSolved(marks, puzzle.regions, size)).toBe(true);
+  });
+
+  it('is false when a mushroom is missing', () => {
+    const marks = marksFromSolution(puzzle);
+    marks[0 * size + puzzle.solution[0]] = MARKS.EMPTY;
+    expect(isSolved(marks, puzzle.regions, size)).toBe(false);
+  });
+
+  it('is false when an extra, conflicting mushroom is added', () => {
+    const marks = marksFromSolution(puzzle);
+    const free = marks.findIndex((m) => m !== MARKS.MUSHROOM);
+    marks[free] = MARKS.MUSHROOM;
+    expect(isSolved(marks, puzzle.regions, size)).toBe(false);
+  });
+
+  it('is false for an empty board', () => {
+    expect(isSolved(createEmptyMarks(size), puzzle.regions, size)).toBe(false);
+  });
+
+  it('is false when N mushrooms are placed but they conflict', () => {
+    // All N in column 0: right count, every rule broken.
+    const marks = createEmptyMarks(size);
+    for (let row = 0; row < size; row++) marks[row * size] = MARKS.MUSHROOM;
+    expect(countMushrooms(marks)).toBe(size);
+    expect(isSolved(marks, puzzle.regions, size)).toBe(false);
+  });
+});
+
+describe('countMushrooms', () => {
+  it('counts only mushrooms, never X or empty (drives the X/N counter)', () => {
+    const marks = createEmptyMarks(5);
+    marks[0] = MARKS.MUSHROOM;
+    marks[1] = MARKS.X;
+    marks[2] = MARKS.MUSHROOM;
+    expect(countMushrooms(marks)).toBe(2);
+  });
+
+  it('is 0 for a fresh board', () => {
+    expect(countMushrooms(createEmptyMarks(6))).toBe(0);
+  });
+});
+
+describe('createEmptyMarks', () => {
+  it('returns size*size empty marks', () => {
+    const marks = createEmptyMarks(7);
+    expect(marks).toHaveLength(49);
+    expect(marks.every((m) => m === MARKS.EMPTY)).toBe(true);
+  });
+});

--- a/SudokuApp/games/fungiku/engine.js
+++ b/SudokuApp/games/fungiku/engine.js
@@ -1,0 +1,437 @@
+/**
+ * Fungiku engine — the pure-logic core of the mushroom placement puzzle
+ * (docs/fungiku-plan.md §1, §4). No React, no React Native, no side effects:
+ * everything here is deterministic from a seed and unit-testable in isolation.
+ *
+ * The puzzle (Queens / Star-Battle genre): an N×N grid is partitioned into N
+ * contiguous color regions. Place N mushrooms so that there is exactly one per
+ * row, one per column, one per region, and no two mushrooms touch — including
+ * diagonally. Every generated puzzle has exactly one solution.
+ *
+ * Key simplification that drives this whole module (plan §1): one-per-row plus
+ * one-per-column means a solution is a *column permutation* — `solution[r]` is
+ * the column of the mushroom in row r. Two mushrooms can then only touch if
+ * they are in adjacent rows, so the no-touching rule collapses to
+ *
+ *     |solution[r] - solution[r + 1]| >= 2
+ *
+ * which is O(1) to check instead of scanning eight neighbors per cell.
+ */
+
+// Marks a cell can hold. X is a player aid only and never affects win
+// detection (plan §2, §8).
+export const MARKS = { EMPTY: 'empty', X: 'x', MUSHROOM: 'mushroom' };
+
+// Tap order: empty -> X -> mushroom -> empty (plan §2).
+const MARK_CYCLE = [MARKS.EMPTY, MARKS.X, MARKS.MUSHROOM];
+
+/** The next mark in the tap cycle. */
+export function nextMark(mark) {
+  const i = MARK_CYCLE.indexOf(mark);
+  // Unknown/absent mark is treated as empty, so the first tap yields X.
+  return MARK_CYCLE[((i < 0 ? 0 : i) + 1) % MARK_CYCLE.length];
+}
+
+/**
+ * Smallest solvable board. N=4 is impossible: one mushroom per column with a
+ * gap of >= 2 between adjacent rows has no arrangement (plan §8), so the ladder
+ * starts at 5.
+ */
+export const MIN_SIZE = 5;
+
+/**
+ * mulberry32 — a tiny, fast, well-distributed seeded PRNG. Deterministic across
+ * platforms, so a seed reproduces a puzzle exactly (plan §4) and a seed is
+ * shareable.
+ */
+export function createRng(seed) {
+  let a = (seed >>> 0) || 1;
+  return function rng() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** In-place Fisher-Yates using the seeded rng. */
+function shuffle(arr, rng) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+/**
+ * Find one valid mushroom placement for an empty (region-less) board:
+ * a column permutation with |col[r] - col[r+1]| >= 2. Randomized backtracking,
+ * so different seeds give different solutions. Returns null if none exists
+ * (i.e. size < MIN_SIZE).
+ */
+function findPlacement(size, rng) {
+  const solution = new Array(size).fill(-1);
+  const usedCols = new Array(size).fill(false);
+
+  const place = (row) => {
+    if (row === size) return true;
+    const cols = shuffle(
+      Array.from({ length: size }, (_, c) => c),
+      rng
+    );
+    for (const col of cols) {
+      if (usedCols[col]) continue;
+      // No-touching, reduced to the adjacent-row column gap (plan §1).
+      if (row > 0 && Math.abs(col - solution[row - 1]) < 2) continue;
+      solution[row] = col;
+      usedCols[col] = true;
+      if (place(row + 1)) return true;
+      usedCols[col] = false;
+      solution[row] = -1;
+    }
+    return false;
+  };
+
+  return place(0) ? solution : null;
+}
+
+const idx = (row, col, size) => row * size + col;
+
+/** Orthogonal neighbors of a cell, as flat indices. */
+function orthNeighbors(cell, size) {
+  const row = Math.floor(cell / size);
+  const col = cell % size;
+  const out = [];
+  if (row > 0) out.push(cell - size);
+  if (row < size - 1) out.push(cell + size);
+  if (col > 0) out.push(cell - 1);
+  if (col < size - 1) out.push(cell + 1);
+  return out;
+}
+
+/**
+ * Grow N contiguous regions from the N solution mushrooms via randomized
+ * multi-source BFS (plan §4 step 3). Each region is seeded at its mushroom, so
+ * every region ends up non-empty and contains exactly one solution mushroom —
+ * which means the placement is always a valid solution of the puzzle we build.
+ * Contiguity holds by construction: a cell only joins a region it touches.
+ *
+ * Returns a flat array of length size*size mapping cell index -> region id.
+ */
+function growRegions(size, solution, rng) {
+  const total = size * size;
+  const regions = new Array(total).fill(-1);
+
+  // Each region's frontier of candidate cells to absorb next.
+  const frontiers = solution.map((col, row) => {
+    const seed = idx(row, col, size);
+    regions[seed] = row; // region id == the row of its mushroom
+    return orthNeighbors(seed, size);
+  });
+
+  let claimed = size;
+  while (claimed < total) {
+    let progressed = false;
+    // Round-robin over regions in random order so no region is systematically
+    // favored and shapes stay irregular.
+    for (const region of shuffle(
+      Array.from({ length: size }, (_, r) => r),
+      rng
+    )) {
+      const frontier = frontiers[region];
+      // Drop cells already claimed since this frontier was last touched.
+      let pick = -1;
+      while (frontier.length > 0) {
+        const j = Math.floor(rng() * frontier.length);
+        const cell = frontier[j];
+        frontier.splice(j, 1);
+        if (regions[cell] === -1) {
+          pick = cell;
+          break;
+        }
+      }
+      if (pick === -1) continue;
+
+      regions[pick] = region;
+      claimed++;
+      progressed = true;
+      for (const n of orthNeighbors(pick, size)) {
+        if (regions[n] === -1) frontier.push(n);
+      }
+      if (claimed === total) break;
+    }
+    // Safety: no region could expand but cells remain. Can't happen while the
+    // grid is connected, but never spin forever if it somehow does.
+    if (!progressed) break;
+  }
+
+  return regions;
+}
+
+/**
+ * Solve a region layout, collecting up to `limit` solutions. Backtracks row by
+ * row, pruning on column-used, region-used, and the adjacent-row gap (plan §4).
+ * `limit = 2` is enough to answer "is this unique?" cheaply.
+ *
+ * @returns {number[][]} each entry is a solution as a column-per-row array
+ */
+export function findSolutions(regions, size, limit = 2) {
+  const usedCols = new Array(size).fill(false);
+  const usedRegions = new Array(size).fill(false);
+  const current = new Array(size).fill(-1);
+  const found = [];
+
+  const walk = (row, previousCol) => {
+    if (row === size) {
+      found.push(current.slice());
+      return;
+    }
+    for (let col = 0; col < size; col++) {
+      if (usedCols[col]) continue;
+      if (row > 0 && Math.abs(col - previousCol) < 2) continue;
+      const region = regions[idx(row, col, size)];
+      if (usedRegions[region]) continue;
+
+      usedCols[col] = true;
+      usedRegions[region] = true;
+      current[row] = col;
+      walk(row + 1, col);
+      usedCols[col] = false;
+      usedRegions[region] = false;
+      current[row] = -1;
+
+      if (found.length >= limit) return;
+    }
+  };
+
+  walk(0, -99); // row 0 is unconstrained by the gap rule
+  return found;
+}
+
+/** How many solutions a layout admits, capped at `limit` (plan §4). */
+export function countSolutions(regions, size, limit = 2) {
+  return findSolutions(regions, size, limit).length;
+}
+
+/**
+ * Try to move `cell` into region `to`, keeping every invariant intact:
+ * the donor region must stay contiguous (it always keeps its mushroom, because
+ * callers never move a mushroom cell). Mutates `regions`; reverts and returns
+ * false if the move would break contiguity.
+ */
+function tryMoveCell(regions, size, cell, to) {
+  const from = regions[cell];
+  if (from === to) return false;
+  regions[cell] = to;
+  if (regionIsContiguous(regions, size, from)) return true;
+  regions[cell] = from;
+  return false;
+}
+
+/**
+ * Break one unwanted solution (plan §4 step 4).
+ *
+ * `alt` is a solution we don't want. It already satisfies the row, column and
+ * no-touching rules — those depend only on cell positions, not on regions — so
+ * the *only* way to invalidate it is to make two of its mushrooms share a
+ * region. We do exactly that: move one of alt's cells into the region of
+ * another of alt's cells.
+ *
+ * This is safe for the puzzle's real `solution` because we never move one of
+ * its mushroom cells, so every region keeps exactly one solution mushroom and
+ * `solution` remains valid by construction.
+ *
+ * Mutates `regions`; returns true if alt was broken.
+ */
+function breakSolution(regions, size, solution, alt, rng) {
+  const solutionCells = new Set(solution.map((col, row) => idx(row, col, size)));
+  const altCells = alt.map((col, row) => idx(row, col, size));
+  const altRegions = new Set(altCells.map((cell) => regions[cell]));
+
+  for (const cell of shuffle(altCells.slice(), rng)) {
+    // Moving a real-solution mushroom would break one-per-region for `solution`.
+    if (solutionCells.has(cell)) continue;
+
+    // Neighboring regions that another alt mushroom already occupies: moving
+    // here gives alt two mushrooms in one region, invalidating it.
+    const targets = shuffle(
+      orthNeighbors(cell, size)
+        .map((n) => regions[n])
+        .filter((r) => r !== regions[cell] && altRegions.has(r)),
+      rng
+    );
+
+    for (const to of targets) {
+      if (tryMoveCell(regions, size, cell, to)) return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Fallback nudge when no targeted break is available: move an arbitrary
+ * non-mushroom boundary cell to a neighboring region. Mutates `regions`.
+ */
+function perturbRegions(regions, size, solution, rng) {
+  const total = size * size;
+  const mushroomCells = new Set(solution.map((col, row) => idx(row, col, size)));
+
+  for (const cell of shuffle(
+    Array.from({ length: total }, (_, i) => i),
+    rng
+  )) {
+    if (mushroomCells.has(cell)) continue;
+
+    const candidates = shuffle(
+      orthNeighbors(cell, size)
+        .map((n) => regions[n])
+        .filter((r) => r !== regions[cell]),
+      rng
+    );
+    for (const to of candidates) {
+      if (tryMoveCell(regions, size, cell, to)) return true;
+    }
+  }
+
+  return false;
+}
+
+/** Flood-fill check that every cell of `region` is orthogonally connected. */
+function regionIsContiguous(regions, size, region) {
+  const members = [];
+  for (let i = 0; i < regions.length; i++) {
+    if (regions[i] === region) members.push(i);
+  }
+  if (members.length === 0) return false;
+
+  const seen = new Set([members[0]]);
+  const stack = [members[0]];
+  while (stack.length > 0) {
+    const cell = stack.pop();
+    for (const n of orthNeighbors(cell, size)) {
+      if (regions[n] === region && !seen.has(n)) {
+        seen.add(n);
+        stack.push(n);
+      }
+    }
+  }
+  return seen.size === members.length;
+}
+
+// How hard to try nudging one layout to uniqueness before regenerating, and how
+// many full regenerations to attempt (plan §8: never loop forever).
+const PERTURB_BUDGET = 400;
+const REGENERATE_BUDGET = 40;
+
+/**
+ * Generate a Fungiku puzzle.
+ *
+ * @param {object}  opts
+ * @param {number}  opts.size - board size N (>= MIN_SIZE)
+ * @param {number}  opts.seed - integer seed; same seed + size => same puzzle
+ * @returns {{ size: number, seed: number, regions: number[], solution: number[] }}
+ *   `regions` is a flat size*size array of region ids; `solution[r]` is the
+ *   column of row r's mushroom.
+ */
+export function generate({ size, seed }) {
+  if (!Number.isInteger(size) || size < MIN_SIZE) {
+    throw new Error(`Fungiku board size must be an integer >= ${MIN_SIZE} (got ${size})`);
+  }
+
+  const rng = createRng(seed);
+
+  for (let attempt = 0; attempt < REGENERATE_BUDGET; attempt++) {
+    const solution = findPlacement(size, rng);
+    if (!solution) continue;
+
+    const regions = growRegions(size, solution, rng);
+
+    // Drive toward a single solution. Every move below preserves `solution`
+    // (its mushroom cells are never reassigned), so the puzzle we return always
+    // has the placement we generated as its unique answer.
+    for (let i = 0; i < PERTURB_BUDGET; i++) {
+      const sols = findSolutions(regions, size, 2);
+      if (sols.length === 1) {
+        return { size, seed, regions, solution };
+      }
+
+      // Prefer surgically breaking a solution that isn't ours; fall back to a
+      // blind nudge if no targeted move is possible.
+      const alt = sols.find((s) => !s.every((col, row) => col === solution[row])) || sols[0];
+      if (!breakSolution(regions, size, solution, alt, rng)) {
+        if (!perturbRegions(regions, size, solution, rng)) break;
+      }
+    }
+  }
+
+  throw new Error(`Fungiku generation failed for size ${size}, seed ${seed}`);
+}
+
+/** Do two cells touch, including diagonally? */
+function touches(aRow, aCol, bRow, bCol) {
+  return Math.abs(aRow - bRow) <= 1 && Math.abs(aCol - bCol) <= 1;
+}
+
+/**
+ * Find every mushroom involved in a rule violation (plan §2). Shared by the
+ * engine and the reducer so the rules exist in exactly one place.
+ *
+ * @param {string[]} marks - flat size*size array of MARKS values
+ * @returns {Set<number>} flat indices of conflicting mushrooms
+ */
+export function findConflicts(marks, regions, size) {
+  const conflicts = new Set();
+  const placed = [];
+  for (let i = 0; i < marks.length; i++) {
+    if (marks[i] === MARKS.MUSHROOM) {
+      placed.push({ cell: i, row: Math.floor(i / size), col: i % size, region: regions[i] });
+    }
+  }
+
+  for (let a = 0; a < placed.length; a++) {
+    for (let b = a + 1; b < placed.length; b++) {
+      const p = placed[a];
+      const q = placed[b];
+      if (
+        p.row === q.row ||
+        p.col === q.col ||
+        p.region === q.region ||
+        touches(p.row, p.col, q.row, q.col)
+      ) {
+        conflicts.add(p.cell);
+        conflicts.add(q.cell);
+      }
+    }
+  }
+
+  return conflicts;
+}
+
+/**
+ * Won when exactly N mushrooms are placed with no conflicts. X marks are
+ * ignored entirely (plan §8) — they are a thinking aid, never a requirement.
+ */
+export function isSolved(marks, regions, size) {
+  let count = 0;
+  for (let i = 0; i < marks.length; i++) {
+    if (marks[i] === MARKS.MUSHROOM) count++;
+  }
+  if (count !== size) return false;
+  return findConflicts(marks, regions, size).size === 0;
+}
+
+/** Count placed mushrooms — drives the `🍄 X/N` counter (plan §1). */
+export function countMushrooms(marks) {
+  let count = 0;
+  for (let i = 0; i < marks.length; i++) {
+    if (marks[i] === MARKS.MUSHROOM) count++;
+  }
+  return count;
+}
+
+/** A fresh, all-empty mark array for a board of this size. */
+export function createEmptyMarks(size) {
+  return new Array(size * size).fill(MARKS.EMPTY);
+}

--- a/SudokuApp/games/fungiku/engine.js
+++ b/SudokuApp/games/fungiku/engine.js
@@ -19,7 +19,7 @@
  */
 
 // Marks a cell can hold. X is a player aid only and never affects win
-// detection (plan §2, §8).
+// detection (plan §2, §9).
 export const MARKS = { EMPTY: 'empty', X: 'x', MUSHROOM: 'mushroom' };
 
 // Tap order: empty -> X -> mushroom -> empty (plan §2).
@@ -34,7 +34,7 @@ export function nextMark(mark) {
 
 /**
  * Smallest solvable board. N=4 is impossible: one mushroom per column with a
- * gap of >= 2 between adjacent rows has no arrangement (plan §8), so the ladder
+ * gap of >= 2 between adjacent rows has no arrangement (plan §9), so the ladder
  * starts at 5.
  */
 export const MIN_SIZE = 5;
@@ -321,7 +321,7 @@ function regionIsContiguous(regions, size, region) {
 }
 
 // How hard to try nudging one layout to uniqueness before regenerating, and how
-// many full regenerations to attempt (plan §8: never loop forever).
+// many full regenerations to attempt (plan §9: never loop forever).
 const PERTURB_BUDGET = 400;
 const REGENERATE_BUDGET = 40;
 
@@ -411,7 +411,7 @@ export function findConflicts(marks, regions, size) {
 
 /**
  * Won when exactly N mushrooms are placed with no conflicts. X marks are
- * ignored entirely (plan §8) — they are a thinking aid, never a requirement.
+ * ignored entirely (plan §9) — they are a thinking aid, never a requirement.
  */
 export function isSolved(marks, regions, size) {
   let count = 0;

--- a/SudokuApp/package-lock.json
+++ b/SudokuApp/package-lock.json
@@ -28,7 +28,10 @@
         "sudoku-gen": "^1.0.2"
       },
       "devDependencies": {
-        "@babel/core": "^7.29.0"
+        "@babel/core": "^7.29.0",
+        "@babel/preset-env": "^7.29.7",
+        "babel-jest": "^29.7.0",
+        "jest": "~29.7.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -471,6 +474,107 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.29.7.tgz",
+      "integrity": "sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.29.7.tgz",
+      "integrity": "sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.29.7.tgz",
+      "integrity": "sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.7.tgz",
+      "integrity": "sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.29.7.tgz",
+      "integrity": "sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-transform-optional-chaining": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.13.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.29.7.tgz",
+      "integrity": "sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/plugin-proposal-decorators": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.7.tgz",
@@ -496,6 +600,19 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       },
@@ -600,6 +717,22 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.29.7.tgz",
       "integrity": "sha512-ajMX6QPcyomotqwpzhkYGxcK2i/us0rs1Qo9QvUpa+Fca0FTmqrzKrctoIYLMxcOhGZldGT/BAVkRGTWBiR8gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-assertions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.29.7.tgz",
+      "integrity": "sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -782,6 +915,23 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
+      "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/plugin-transform-arrow-functions": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.29.7.tgz",
@@ -823,6 +973,22 @@
         "@babel/helper-module-imports": "^7.29.7",
         "@babel/helper-plugin-utils": "^7.29.7",
         "@babel/helper-remap-async-to-generator": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.29.7.tgz",
+      "integrity": "sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -930,6 +1096,105 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-dotall-regex": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.29.7.tgz",
+      "integrity": "sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-keys": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.29.7.tgz",
+      "integrity": "sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.7.tgz",
+      "integrity": "sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dynamic-import": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.29.7.tgz",
+      "integrity": "sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-explicit-resource-management": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.29.7.tgz",
+      "integrity": "sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-transform-destructuring": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.29.7.tgz",
+      "integrity": "sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-export-namespace-from": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.29.7.tgz",
@@ -994,6 +1259,22 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-json-strings": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.29.7.tgz",
+      "integrity": "sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-literals": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.29.7.tgz",
@@ -1024,10 +1305,79 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-member-expression-literals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.29.7.tgz",
+      "integrity": "sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-amd": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.29.7.tgz",
+      "integrity": "sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
       "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-systemjs": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
+      "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-umd": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.29.7.tgz",
+      "integrity": "sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.29.7",
@@ -1054,6 +1404,22 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-new-target": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.29.7.tgz",
+      "integrity": "sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
@@ -1097,6 +1463,23 @@
         "@babel/plugin-transform-destructuring": "^7.29.7",
         "@babel/plugin-transform-parameters": "^7.29.7",
         "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-super": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.29.7.tgz",
+      "integrity": "sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1175,6 +1558,22 @@
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.29.7",
         "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-property-literals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.29.7.tgz",
+      "integrity": "sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
@@ -1294,6 +1693,39 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-regexp-modifiers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.29.7.tgz",
+      "integrity": "sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-reserved-words": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.29.7.tgz",
+      "integrity": "sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-runtime": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.29.7.tgz",
@@ -1360,6 +1792,38 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.29.7.tgz",
+      "integrity": "sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typeof-symbol": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.29.7.tgz",
+      "integrity": "sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-typescript": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
@@ -1371,6 +1835,39 @@
         "@babel/helper-plugin-utils": "^7.29.7",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
         "@babel/plugin-syntax-typescript": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-escapes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.29.7.tgz",
+      "integrity": "sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-property-regex": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.29.7.tgz",
+      "integrity": "sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1393,6 +1890,138 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-sets-regex": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.29.7.tgz",
+      "integrity": "sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/preset-env": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.7.tgz",
+      "integrity": "sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.29.7",
+        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.29.7",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.29.7",
+        "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^7.29.7",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.29.7",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.29.7",
+        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+        "@babel/plugin-syntax-import-assertions": "^7.29.7",
+        "@babel/plugin-syntax-import-attributes": "^7.29.7",
+        "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
+        "@babel/plugin-transform-arrow-functions": "^7.29.7",
+        "@babel/plugin-transform-async-generator-functions": "^7.29.7",
+        "@babel/plugin-transform-async-to-generator": "^7.29.7",
+        "@babel/plugin-transform-block-scoped-functions": "^7.29.7",
+        "@babel/plugin-transform-block-scoping": "^7.29.7",
+        "@babel/plugin-transform-class-properties": "^7.29.7",
+        "@babel/plugin-transform-class-static-block": "^7.29.7",
+        "@babel/plugin-transform-classes": "^7.29.7",
+        "@babel/plugin-transform-computed-properties": "^7.29.7",
+        "@babel/plugin-transform-destructuring": "^7.29.7",
+        "@babel/plugin-transform-dotall-regex": "^7.29.7",
+        "@babel/plugin-transform-duplicate-keys": "^7.29.7",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.7",
+        "@babel/plugin-transform-dynamic-import": "^7.29.7",
+        "@babel/plugin-transform-explicit-resource-management": "^7.29.7",
+        "@babel/plugin-transform-exponentiation-operator": "^7.29.7",
+        "@babel/plugin-transform-export-namespace-from": "^7.29.7",
+        "@babel/plugin-transform-for-of": "^7.29.7",
+        "@babel/plugin-transform-function-name": "^7.29.7",
+        "@babel/plugin-transform-json-strings": "^7.29.7",
+        "@babel/plugin-transform-literals": "^7.29.7",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.29.7",
+        "@babel/plugin-transform-member-expression-literals": "^7.29.7",
+        "@babel/plugin-transform-modules-amd": "^7.29.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.29.7",
+        "@babel/plugin-transform-modules-systemjs": "^7.29.7",
+        "@babel/plugin-transform-modules-umd": "^7.29.7",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.7",
+        "@babel/plugin-transform-new-target": "^7.29.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.29.7",
+        "@babel/plugin-transform-numeric-separator": "^7.29.7",
+        "@babel/plugin-transform-object-rest-spread": "^7.29.7",
+        "@babel/plugin-transform-object-super": "^7.29.7",
+        "@babel/plugin-transform-optional-catch-binding": "^7.29.7",
+        "@babel/plugin-transform-optional-chaining": "^7.29.7",
+        "@babel/plugin-transform-parameters": "^7.29.7",
+        "@babel/plugin-transform-private-methods": "^7.29.7",
+        "@babel/plugin-transform-private-property-in-object": "^7.29.7",
+        "@babel/plugin-transform-property-literals": "^7.29.7",
+        "@babel/plugin-transform-regenerator": "^7.29.7",
+        "@babel/plugin-transform-regexp-modifiers": "^7.29.7",
+        "@babel/plugin-transform-reserved-words": "^7.29.7",
+        "@babel/plugin-transform-shorthand-properties": "^7.29.7",
+        "@babel/plugin-transform-spread": "^7.29.7",
+        "@babel/plugin-transform-sticky-regex": "^7.29.7",
+        "@babel/plugin-transform-template-literals": "^7.29.7",
+        "@babel/plugin-transform-typeof-symbol": "^7.29.7",
+        "@babel/plugin-transform-unicode-escapes": "^7.29.7",
+        "@babel/plugin-transform-unicode-property-regex": "^7.29.7",
+        "@babel/plugin-transform-unicode-regex": "^7.29.7",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.29.7",
+        "@babel/preset-modules": "0.1.6-no-external-plugins",
+        "babel-plugin-polyfill-corejs2": "^0.4.15",
+        "babel-plugin-polyfill-corejs3": "^0.14.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.6",
+        "core-js-compat": "^3.48.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+      "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
+        "core-js-compat": "^3.48.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/preset-modules": {
+      "version": "0.1.6-no-external-plugins",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+      "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/@babel/preset-react": {
@@ -1515,6 +2144,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@callstack/react-theme-provider": {
       "version": "3.0.9",
@@ -2430,6 +3066,88 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/create-cache-key-function": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
@@ -2457,6 +3175,33 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jest/fake-timers": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
@@ -2474,6 +3219,149 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/reporters/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -2481,6 +3369,53 @@
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3568,6 +4503,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -3614,6 +4559,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/chownr": {
@@ -3663,6 +4618,13 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "license": "MIT"
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -3709,6 +4671,24 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color": {
       "version": "3.2.1",
@@ -3881,6 +4861,28 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
@@ -3934,6 +4936,21 @@
       },
       "peerDependenciesMeta": {
         "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
           "optional": true
         }
       }
@@ -4005,6 +5022,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
@@ -4044,6 +5081,19 @@
       "integrity": "sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==",
       "license": "ISC"
     },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -4066,6 +5116,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/error-stack-parser": {
@@ -4126,6 +5186,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -4142,6 +5212,82 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/execa/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/expo": {
@@ -4940,6 +6086,19 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/getenv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
@@ -5041,6 +6200,13 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -5081,6 +6247,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
       }
     },
     "node_modules/hyphenate-style-name": {
@@ -5133,6 +6309,26 @@
         "node": ">=16.x"
       }
     },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -5183,6 +6379,13 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-core-module": {
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
@@ -5222,6 +6425,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5238,6 +6451,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-wsl": {
@@ -5281,6 +6507,342 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-config/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/jest-config/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-config/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jest-config/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-environment-node": {
@@ -5334,6 +6896,36 @@
         "fsevents": "^2.3.2"
       }
     },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/jest-message-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
@@ -5368,6 +6960,24 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-regex-util": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
@@ -5375,6 +6985,227 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-runtime/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jest-util": {
@@ -5433,6 +7264,26 @@
         "jest-get-type": "^29.6.3",
         "leven": "^3.1.0",
         "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5510,6 +7361,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -5956,6 +7814,35 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/makeerror": {
@@ -6458,6 +8345,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -6551,6 +8445,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/nullthrows": {
@@ -6798,6 +8705,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-png": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/parse-png/-/parse-png-2.1.0.tgz",
@@ -6902,6 +8828,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/plist": {
@@ -7075,6 +9014,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qrcode-terminal": {
       "version": "0.11.0",
@@ -7575,6 +9531,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -8024,6 +9993,20 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -8048,6 +10031,26 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strip-json-comments": {
@@ -8519,6 +10522,21 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
       }
     },
     "node_modules/validate-npm-package-name": {

--- a/SudokuApp/package.json
+++ b/SudokuApp/package.json
@@ -7,7 +7,33 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "jest"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "testMatch": [
+      "**/__tests__/**/*.test.js"
+    ],
+    "transform": {
+      "^.+\\.js$": [
+        "babel-jest",
+        {
+          "presets": [
+            [
+              "@babel/preset-env",
+              {
+                "targets": {
+                  "node": "current"
+                }
+              }
+            ]
+          ],
+          "babelrc": false,
+          "configFile": false
+        }
+      ]
+    }
   },
   "dependencies": {
     "@expo-google-fonts/inter": "^0.3.0",
@@ -29,7 +55,10 @@
     "sudoku-gen": "^1.0.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.29.0"
+    "@babel/core": "^7.29.0",
+    "@babel/preset-env": "^7.29.7",
+    "babel-jest": "^29.7.0",
+    "jest": "~29.7.0"
   },
   "private": true
 }

--- a/SudokuApp/utils/symbolSets.js
+++ b/SudokuApp/utils/symbolSets.js
@@ -47,6 +47,44 @@ const FUNGIKU_SWATCHES = {
 };
 
 /**
+ * Region colors for the Fungiku board (docs/fungiku-plan.md §3). Regions reuse
+ * the same colorblind-safe palette as the swatches above so there is exactly one
+ * source of color truth; the mushroom's own red rounds the list out to nine, one
+ * per region for boards up to 9×9.
+ *
+ * Each entry carries the saturated `color` (borders, labels, emphasis) and a
+ * pastel `background` for filling a whole cell — the reference art is a soft
+ * pastel grid, and a full cell of saturated Okabe–Ito would overwhelm the
+ * mushroom drawn on top of it. `name` stays the stable, non-visual identity used
+ * for accessibility labels.
+ */
+const mixWithWhite = (hex, weight) => {
+  const n = parseInt(hex.slice(1), 16);
+  const blend = (channel) => Math.round(channel + (255 - channel) * weight);
+  const r = blend((n >> 16) & 255);
+  const g = blend((n >> 8) & 255);
+  const b = blend(n & 255);
+  return `#${((1 << 24) | (r << 16) | (g << 8) | b).toString(16).slice(1)}`;
+};
+
+export const REGION_COLORS = [
+  ...Object.keys(FUNGIKU_SWATCHES)
+    .map(Number)
+    .sort((a, b) => a - b)
+    .map((value) => FUNGIKU_SWATCHES[value]),
+  MUSHROOM,
+].map(({ color, name }) => ({
+  color,
+  name,
+  background: mixWithWhite(color, 0.62),
+}));
+
+/** The palette entry for a region id, wrapping around if ids exceed the palette. */
+export function getRegionColor(regionId) {
+  return REGION_COLORS[regionId % REGION_COLORS.length];
+}
+
+/**
  * resolveSymbol(setId, value) → a plain descriptor Symbol.js knows how to draw:
  *   { kind: 'text',   value, text,  label }               // numbers
  *   { kind: 'swatch', value, color, corners, label }      // fungiku color

--- a/SudokuApp/utils/symbolSets.js
+++ b/SudokuApp/utils/symbolSets.js
@@ -11,7 +11,7 @@
  *     MaterialCommunityIcons "mushroom" glyph as a placeholder until static art
  *     lands behind this same seam (plan §3, Step 5).
  *
- * Colorblind-awareness (plan §3/§6): the swatch palette is the Okabe–Ito
+ * Colorblind-awareness (plan §3/§8): the swatch palette is the Okabe–Ito
  * colorblind-safe set, so hues stay distinct under the common CVD types, and it
  * spans a range of lightness. On top of color, each swatch carries a distinct
  * corner/shape cue (`corners`) so color is never the only channel of identity.

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -29,6 +29,20 @@ the board: *1 Cat per column & row · 1 Cat per color · Cats cannot touch*.
 - **Process:** follow `.github/dev-process.md` — the tracker is issue #65, work
   **one delivery step per branch**, commit after each step, and **prompt the
   operator to test after each step.**
+- **Branching: this feature lands on an epic branch, not `main`.** Every step
+  PR targets **`epic/fungiku`**. The epic branch merges to `main` once Fungiku
+  is playable end to end, so `main` never carries a half-built game mode.
+
+  ```
+  main ─── epic/fungiku ─── feature/fungiku-<step>   (PRs target the epic)
+  ```
+
+- **Every step must ship something the operator can look at in Expo Go.** Even
+  the pure-logic steps: if a step has no natural UI, it carries a small preview
+  or debug surface so progress is visually verifiable on a device, and direction
+  can be corrected early instead of after the whole mode is built. A step whose
+  only evidence is a passing test suite is not done. Preview scaffolding is
+  explicitly temporary — it is replaced by the real UI as later steps land.
 - **Fungiku is a separate game mode, not a change to classic Sudoku.** Classic
   Sudoku keeps working exactly as it does today. Do **not** modify the Sudoku
   generator (`sudoku-gen` / `boardFactory`), the Sudoku reducer logic, the
@@ -141,21 +155,23 @@ untouched for classic Sudoku.
 
 ## 6. Delivery steps (one branch per step, per dev-process.md)
 
-0. ~~**Pre-step — upgrade Expo to the latest SDK.**~~ ✅ merged (#66) — SDK 54.
-1. ~~**Rendering seam** — `Symbol.js` + `symbolSets.js`.~~ ✅ merged (#67). The
-   mushroom glyph and the swatch palette carry into this plan as the placed
-   marker and the region colors.
-2. **Engine** — `games/fungiku/engine.js`: seeded generator, solver, uniqueness,
-   plus the shared `findConflicts` / `isSolved` helpers. Jest unit tests. No UI.
-3. **State** — Fungiku reducer + context: mark cycling, live conflict
-   validation, win detection, undo/redo, AsyncStorage persistence.
-4. **Board UI** — region-colored grid with region-boundary borders,
-   tap-to-cycle X/🍄, conflict highlighting, `🍄 X/N` counter, win flow.
-5. **Mode entry** — how the player gets into Fungiku (mode selector alongside
-   classic Sudoku) plus size/level selection.
-6. **Assists & polish** — optional auto-X, win animation, level ladder, scoring.
-7. **Art swap** (floating, asset-only) — static mushroom PNG behind the
-   `<Symbol>` seam.
+Each step names **what the operator can see in Expo Go** when it lands — that is
+the step's real acceptance test, alongside its automated checks.
+
+| # | Step | Visible in Expo Go |
+|---|------|--------------------|
+| 0 | ~~Upgrade Expo SDK~~ ✅ merged (#66) — SDK 54 | App runs on the current SDK |
+| 1 | ~~Rendering seam — `Symbol.js` + `symbolSets.js`~~ ✅ merged (#67) | Zero visual change (that was the point) |
+| 2 | **Engine** — seeded generator, solver, uniqueness, shared `findConflicts` / `isSolved`, Jest tests | **Engine preview**: generated boards with their color regions and solution mushrooms; switch size 5–8, reseed, show/hide the solution |
+| 3 | **State** — reducer + context: mark cycling, live conflict validation, win detection, undo/redo, persistence | Preview gains **tap-to-cycle** X/🍄 with live conflict highlighting and a win banner — the puzzle becomes playable, if plain |
+| 4 | **Board UI** — the real board component: region-boundary borders, themed styling, `🍄 X/N` counter, win flow | The **actual game board**, styled to the app's themes, replacing the preview's rough grid |
+| 5 | **Mode entry** — mode selector alongside classic Sudoku, size/level selection | Fungiku reachable as a **real mode** from the menu; preview scaffolding removed |
+| 6 | **Assists & polish** — optional auto-X, win animation, level ladder, scoring | Assist toggle, win celebration, level progression |
+| 7 | **Art swap** (floating, asset-only) | Static mushroom art replaces the icon glyph |
+
+Steps 2 and 3 share the preview surface: Step 2 builds it read-only to judge the
+engine's output, Step 3 makes it interactive to prove the rules. It is
+scaffolding, not the product — Step 4 supersedes it and Step 5 deletes it.
 
 ## 7. Open questions for the operator
 

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -1,11 +1,24 @@
 # Fungiku — Feature Plan
 
-**Fungiku is a display mode for Sudoku, not a new game.** The board, the
-generator, the reducer, undo/redo, notes, feedback, and win detection all stay
-exactly as they are. What changes is *how a cell's value is drawn*: instead of
-the digits 1–9, a puzzle shows **8 color swatches plus one mushroom character**.
-It's the family "meowdoku" concept — one symbol is a creature, the rest are
-colors — dropped in as a symbol set the player can switch on.
+**Fungiku is a mushroom logic puzzle: place one mushroom per row, per column,
+and per color region, with no two mushrooms touching.** The board is a grid of
+contiguous **color regions**, and the *only* thing the player places is a
+**mushroom** (plus an "X" eliminate-mark as a thinking aid). There is no number
+pad, no digits, and no notes grid.
+
+This is the **Queens / Star-Battle** genre — the same ruleset as LinkedIn's
+*Queens* and the family-tested "meowdoku" reference, which states its rules on
+the board: *1 Cat per column & row · 1 Cat per color · Cats cannot touch*.
+
+> **Replan note (2026-07-25).** An earlier version of this document described
+> Fungiku as a *display mode for Sudoku* — a rendering skin that swapped the
+> digits 1–9 for swatches over the existing numeric 9×9 board. The reference
+> screenshots the operator supplied show that is **not** the target game: the
+> real mechanic merges the symbols into **color regions** and makes the mushroom
+> the **only input**. That is a different puzzle with a different generator,
+> different rules, a different win condition, and a different input model, so it
+> cannot be a skin over Sudoku. This document is the replanned source of truth.
+> See §9 for exactly what carried over from the old plan and what was dropped.
 
 ## For the implementer (start here)
 
@@ -13,145 +26,164 @@ colors — dropped in as a symbol set the player can switch on.
   subdirectory (Expo · React Native · JavaScript).
 - **This document is the source of truth** for scope and approach — read it end
   to end before writing code.
-- **Process:** follow `.github/dev-process.md` — open one GitHub issue with a
-  markdown-checkbox implementation plan, work **one delivery step per branch**,
-  commit after each step, and **prompt the operator to test after each step.**
-- **Order of work is fixed:** do **Step 0 (the Expo upgrade) first**, as its own
-  branch + PR, verify it in Expo Go on a device, and get it merged **before any
-  Fungiku code.** Everything in §1–§5 is a rendering skin; none of it should be
-  touched until the app runs on the current SDK.
-- **Golden rule for the feature:** Fungiku changes only how a value is *drawn*.
-  The board stays numeric (`1..9`) internally — do **not** modify the generator
-  (`sudoku-gen`), the `GameContext` reducer, notes, undo/redo, feedback logic,
-  or win detection.
+- **Process:** follow `.github/dev-process.md` — the tracker is issue #65, work
+  **one delivery step per branch**, commit after each step, and **prompt the
+  operator to test after each step.**
+- **Fungiku is a separate game mode, not a change to classic Sudoku.** Classic
+  Sudoku keeps working exactly as it does today. Do **not** modify the Sudoku
+  generator (`sudoku-gen` / `boardFactory`), the Sudoku reducer logic, the
+  number pad, or Sudoku's notes / feedback / win detection. Fungiku's logic
+  lives in its own module tree under `SudokuApp/games/fungiku/`.
 
-## Step 0 — Pre-step: upgrade Expo to the latest SDK
+## 1. The rules (exactly)
 
-The app is currently on **Expo SDK 53** (`SudokuApp/app.json` pins
-`"sdkVersion": "53.0.0"`; `expo` is `53.0.9`, React Native `0.79.2`, React
-`19.0.0`). **Expo Go only runs the newest SDK**, so on our devices the app won't
-open until it's upgraded. This is a native-level change and gets its own branch
-and PR, done and verified before Fungiku.
+For an **N×N** grid partitioned into **N contiguous color regions**:
 
-- **Pick the target:** determine the current latest Expo SDK (e.g.
-  `npm view expo version`, or the Expo release notes) and upgrade to it — don't
-  assume a specific number, "latest" moves.
-- **Upgrade** from `SudokuApp/`: `npx expo install expo@latest`, then
-  `npx expo install --fix` to realign React, React Native, and every
-  `expo-*` / `react-native-*` dependency to the versions that SDK expects.
-  **Inspect the package.json diff** — `expo install --fix` has a known habit of
-  duplicating packages across `dependencies` / `devDependencies`.
-- **Reconcile `SudokuApp/app.json`:** update the pinned `"sdkVersion"` to match
-  the new SDK (or remove the pin so it's inferred). Keep `newArchEnabled: true`.
-- **Watch these deps specifically:** `react-native-paper`,
-  `react-native-gesture-handler`, `react-native-safe-area-context`,
-  `@expo/metro-runtime`, and `react-native-vector-icons` — the Fungiku feature
-  uses `MaterialCommunityIcons` from it, so if the new SDK prefers
-  `@expo/vector-icons`, migrate and confirm the `mushroom` glyph still renders.
-- **Verify (in this order):** `npx expo-doctor` is clean → the app bundles on
-  web (`expo start --web`) → **it actually opens and plays in Expo Go on a
-  device.** The device check is the real gate; the cloud/simulator can't confirm
-  Expo Go compatibility, and gesture/touch (cell selection, the number pad)
-  especially needs a real device pass.
-- **Stop after the upgrade PR** for the operator to test in Expo Go, and get it
-  merged before starting Step 1.
+1. **One mushroom per row.**
+2. **One mushroom per column.**
+3. **One mushroom per color region.**
+4. **No two mushrooms touch** — not orthogonally, not diagonally.
+5. Every generated puzzle has **exactly one solution**.
 
-## 1. Why this belongs in expo-sudoku (and not as its own game)
+N mushrooms are placed in total. The puzzle is won when all N are placed legally
+— there is no "fill every cell" step. The header shows a **`🍄 X/N`** counter, as
+the reference does.
 
-The mechanic *is* Sudoku. Everything that makes Sudoku work already lives here:
-`sudoku-gen` generation, the `GameContext` reducer, notes, undo/redo, the timer,
-win detection, feedback mode, seven themes. A creature-and-swatches skin is a
-**rendering concern over the existing numeric board** — the cell values stay
-`1..9` internally; only their glyphs change. Building it as a standalone game
-would mean re-implementing all of the above to gain nothing.
+### A useful consequence (drives the whole engine)
 
-This also rides the grain of the app's existing **theme system**: Fungiku is
-essentially "a theme that swaps glyphs for swatches," selected the same way
-themes are today.
+Rules 1 and 2 mean the solution is a **permutation**: let `col[r]` be the column
+of the mushroom in row `r`; every column is used exactly once. Because no two
+mushrooms share a row, the only way two can touch is if they sit in **adjacent
+rows**. So rule 4 collapses to one cheap condition:
 
-## 2. The rendering seam
+```
+|col[r] − col[r+1]| ≥ 2   for every r
+```
 
-A cell's value is drawn in exactly two components — that's the entire surface:
+Region membership (rule 3) is then a separate per-region-once constraint. This
+makes both generation and solving small, fast, and easy to test.
 
-| Where | Today | Fungiku mode |
-|-------|-------|--------------|
-| `components/Cell.js` | `<Text>{value}</Text>` | `<Symbol value={value} />` |
-| `components/NumberPad.js` | digit label per button | swatch / mushroom per button |
-| `components/Cell.js` notes 3×3 grid | mini digit per note | mini swatch / mushroom |
+## 2. Input model — mushrooms only
 
-A new `components/Symbol.js` owns the mapping `value → glyph` for the active
-symbol set. Number mode returns the digit `<Text>` (today's behavior verbatim),
-so the default path is unchanged and low-risk.
+A cell is in exactly one of three **marks**, and a tap cycles them:
 
-## 3. Symbol set design
+```
+empty → X (eliminated) → 🍄 (mushroom) → empty
+```
 
-- **8 swatches + 1 mushroom** for a 9×9 board. Which value is the mushroom is
-  fixed per game (e.g. always `1`, or chosen at game start) — logically it's
-  just another symbol; cosmetically it's the star.
-- **Swatch palette** lives in a new `utils/symbolSets.js`, colorblind-checked:
-  distinct hues *and* distinct lightness, plus a subtle per-swatch shape/corner
-  treatment so color isn't the only channel. Eight highly-distinct swatches is
-  the main design risk — see §6 open questions.
-- **The mushroom**, staged so nothing blocks on art:
-  1. **Placeholder (ships first):** the `mushroom` glyph from
-     `react-native-vector-icons/MaterialCommunityIcons` — already a dependency,
-     zero new assets. It renders in a cell and on a number-pad button as-is.
-  2. **Art swap (later):** a single static transparent PNG in
-     `SudokuApp/assets/mushrooms/` behind the same `<Symbol>` seam — a pure
-     asset change, no logic touched. Sprite-sheet / frame animation is
-     deliberately out of scope; any liveliness comes from container-level
-     `Animated` transforms if we want it (placement pop, win wiggle),
-     consistent with the app's existing animation direction.
+- **X** is a player aid only. It has **no** effect on win detection and is never
+  required — the equivalent of the reference's X's, and of pencil marks.
+- **🍄** is the real placement.
+- **Conflicts show live:** any two mushrooms sharing a row, column, or region,
+  or touching each other, are highlighted (the reference glows them). Conflicts
+  do not block placement — the player fixes them.
+- **Optional assist (later step):** auto-place X's in a placed mushroom's row,
+  column, region, and neighbors. A setting, off by default.
 
-## 4. Where the toggle lives + persistence
+No number pad. No 3×3 notes mini-grid. No digit feedback.
 
-- Add a **symbol-set selector** next to `ThemeSelector` in the top strip (same
-  pattern: an icon button that cycles `Numbers → Fungiku`), or a row in the game
-  menu — pick one in review. `GameContext` gains `symbolSet` state and a
-  `cycleSymbolSet`/`setSymbolSet` action, mirroring `currentThemeName` /
-  `cycleTheme`.
-- Persist it the same way the theme is persisted (AsyncStorage via the existing
-  `usePersistentReducer`), so the family's choice survives relaunch.
-- Symbol set is **orthogonal to theme and difficulty** — any theme, any
-  difficulty, numbers or Fungiku.
+## 3. The board
 
-## 5. Edge cases to get right (cheap, but easy to miss)
+- **Region color = cell background**, filling the whole cell (the reference is a
+  solid pastel grid). Colors come from the existing colorblind-aware palette in
+  `utils/symbolSets.js` (Okabe–Ito hues, distinct in both hue and lightness).
+- **Region borders are the structural lines** — a thick border between cells of
+  *different* regions, a hairline between cells of the same region. This
+  replaces Sudoku's fixed 3×3 box borders, whose geometry does not apply here.
+- **The mushroom glyph** is the `MaterialCommunityIcons` `mushroom` placeholder
+  from Step 1, swapped for static PNG art later behind the same `<Symbol>` seam.
+- **Accessibility:** every cell keeps a stable label — region name + mark, e.g.
+  *"blue region, mushroom"* / *"green region, eliminated"* — so the board is
+  readable without relying on color.
 
-- **Feedback mode can't use text color.** Correct/incorrect today are conveyed
-  by *text* color (`correctValueText` / `incorrectValueText`). A swatch already
-  owns its color, so feedback needs a non-color channel in Fungiku mode: a
-  cell-border tint or a small ✓/✗ corner overlay. This is the one real UI
-  design decision in the feature.
-- **Notes** render as the 3×3 mini-grid — in Fungiku they become mini-swatches
-  (and a mini-mushroom). Legibility at that size needs a quick device check;
-  falling back to keeping notes as digits is an acceptable v1 if mini-swatches
-  read poorly.
-- **Accessibility:** `Cell.js` sets `accessibilityLabel={`Cell value: ${value}`}`.
-  Keep a stable label per symbol (e.g. "teal" / "mushroom") so screen readers
-  and tests still work — don't drop the numeric identity underneath.
-- **NumberPad "used-up" dimming** already counts value usage on the board; it's
-  value-based, not glyph-based, so it keeps working untouched.
+## 4. The engine (the one genuinely new piece)
 
-## 6. Delivery steps (small, one branch per step per dev-process.md)
+Pure JavaScript, no React, fully unit-tested, deterministic from a seed.
 
-0. **Pre-step — upgrade Expo to the latest SDK** (see the Step 0 section above).
-   Own branch + PR, verified in Expo Go, **merged before anything below.**
-1. `components/Symbol.js` + `utils/symbolSets.js` (numbers set + Fungiku set with
-   MCI mushroom placeholder). Wire `Cell.js` to render through `<Symbol>` — with
-   `symbolSet` hardcoded to `numbers` first, proving zero visual change.
-2. Add `symbolSet` to `GameContext` (state, action, persistence) + the selector
-   control. Now toggleable end-to-end on the board.
-3. Route `NumberPad.js` and the notes mini-grid through `<Symbol>`.
-4. Feedback-in-color-mode treatment (border/overlay) — the §5 design decision.
-5. Static-PNG art swap when mushroom art lands (floating; asset-only).
+**`generate({ size, seed })` → `{ size, seed, regions, solution }`**
+
+1. **Seeded RNG** so a puzzle is reproducible (and a seed is shareable).
+2. **Place the N mushrooms:** randomized backtracking over a column permutation
+   subject to `|col[r] − col[r+1]| ≥ 2` (§1).
+3. **Grow the regions:** seed one region at each mushroom cell, then expand by
+   randomized multi-source BFS until every cell is claimed. Contiguity holds by
+   construction (a cell is only ever added adjacent to its own region), and each
+   region contains exactly one solution mushroom, so the generated placement is
+   always *a* valid solution.
+4. **Force uniqueness:** count solutions with the solver; while more than one
+   exists, perturb the regions (move a boundary cell to a neighboring region,
+   preserving contiguity and the one-mushroom-per-region invariant) and
+   re-count. Fall back to a full regenerate if the perturbation budget runs out.
+
+**`countSolutions(regions, size, limit)`** — backtracking row by row, pruning on
+column-used, region-used, and the adjacent-row column-gap rule; stops early at
+`limit` (2 is enough to answer "is it unique?").
+
+**Shared validation helpers** used by both the engine and the reducer, so the
+rules live in exactly one place: `findConflicts(...)` and `isSolved(...)`.
+
+**Difficulty** ≈ grid size + region-shape irregularity. Sizes ship as a ladder
+(§6) starting at **5×5** — matching the reference's Level 1 → 10 progression.
+
+## 5. What is reused vs. new
+
+| Reused as-is | New for Fungiku |
+|---|---|
+| Theme system + header / top strip / timer chrome | Region+mushroom generator, solver, uniqueness |
+| `usePersistentReducer` + `utils/storage.js` pattern | Mark-cycle reducer, conflict validation, win detection |
+| Swatch palette in `utils/symbolSets.js` (→ region colors) | Region-colored board with region-boundary borders |
+| `Symbol.js` mushroom glyph + the art-swap seam | `🍄 X/N` counter, mode entry point, level ladder |
+| Undo/redo, scoring, win-modal patterns | |
+
+**Not used by this mode:** `sudoku-gen` / `boardFactory`, `NumberPad.js`, the
+notes mini-grid, digit correct/incorrect feedback. All of it stays in place and
+untouched for classic Sudoku.
+
+## 6. Delivery steps (one branch per step, per dev-process.md)
+
+0. ~~**Pre-step — upgrade Expo to the latest SDK.**~~ ✅ merged (#66) — SDK 54.
+1. ~~**Rendering seam** — `Symbol.js` + `symbolSets.js`.~~ ✅ merged (#67). The
+   mushroom glyph and the swatch palette carry into this plan as the placed
+   marker and the region colors.
+2. **Engine** — `games/fungiku/engine.js`: seeded generator, solver, uniqueness,
+   plus the shared `findConflicts` / `isSolved` helpers. Jest unit tests. No UI.
+3. **State** — Fungiku reducer + context: mark cycling, live conflict
+   validation, win detection, undo/redo, AsyncStorage persistence.
+4. **Board UI** — region-colored grid with region-boundary borders,
+   tap-to-cycle X/🍄, conflict highlighting, `🍄 X/N` counter, win flow.
+5. **Mode entry** — how the player gets into Fungiku (mode selector alongside
+   classic Sudoku) plus size/level selection.
+6. **Assists & polish** — optional auto-X, win animation, level ladder, scoring.
+7. **Art swap** (floating, asset-only) — static mushroom PNG behind the
+   `<Symbol>` seam.
 
 ## 7. Open questions for the operator
 
-1. **What's shown in the UI** — call the mode "Fungiku" (fun, on-brand with the
-   family name) or something plain like "Colors"? The internal name can stay
-   `fungiku` either way.
-2. **8-swatch legibility** at 9×9. If eight distinct swatches prove too busy for
-   kids, the faithful "simplified" fix is **smaller boards (4×4 / 6×6)** — but
-   `sudoku-gen` is 9×9-only, so that needs a size-generic generator and is a
-   separate, larger piece of work. Flagged, not assumed.
-3. **Feedback channel** in color mode (border tint vs. ✓/✗ overlay) — §5.
+1. **Mode name in the UI** — **decided: "Fungiku"** (internal id `fungiku`).
+2. **Ladder shape** — v1 ships **5×5 → 8×8**. Where should it top out, and
+   should size be a free choice or unlocked by progression?
+3. **Assist defaults** — should auto-X be on by default for younger players?
+
+## 8. Edge cases to get right
+
+- **A 4×4 board is impossible** under these rules — with one mushroom per column
+  and `|Δcol| ≥ 2` between adjacent rows, no arrangement exists for N=4 — so the
+  ladder starts at **5×5**. The generator must reject sizes it cannot satisfy.
+- **Region growth can starve** a region if BFS order is unlucky; expansion must
+  keep every region non-empty (it always retains its seed mushroom cell).
+- **Uniqueness is the expensive part** — cap the perturbation budget and fall
+  back to regenerating rather than looping forever.
+- **X marks must never affect win detection** — only mushrooms count.
+- **Persistence** stores the seed + size + the player's marks, not the whole
+  board; the puzzle is rebuilt deterministically from the seed on restore.
+
+## 9. Disposition of the pre-replan work
+
+- **Step 0 (#66, merged)** — SDK 54 upgrade. Unaffected, keep.
+- **Step 1 (#67, merged)** — `Symbol.js` + `utils/symbolSets.js`. **Kept**; the
+  palette becomes the region colors and the mushroom glyph is the placed marker.
+  The "numbers ↔ fungiku glyph swap" framing is obsolete.
+- **Old Step 2 (PR #68, closed unmerged)** — a numbers↔Fungiku toggle *on the
+  Sudoku board*. Built on the superseded "display mode" model: Fungiku is a
+  separate mode with its own board, so a symbol-set toggle over the 9×9 numeric
+  grid has no place. Closed rather than merged.

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -18,7 +18,7 @@ the board: *1 Cat per column & row · 1 Cat per color · Cats cannot touch*.
 > the **only input**. That is a different puzzle with a different generator,
 > different rules, a different win condition, and a different input model, so it
 > cannot be a skin over Sudoku. This document is the replanned source of truth.
-> See §9 for exactly what carried over from the old plan and what was dropped.
+> See §10 for exactly what carried over from the old plan and what was dropped.
 
 ## For the implementer (start here)
 
@@ -137,7 +137,7 @@ column-used, region-used, and the adjacent-row column-gap rule; stops early at
 rules live in exactly one place: `findConflicts(...)` and `isSolved(...)`.
 
 **Difficulty** ≈ grid size + region-shape irregularity. Sizes ship as a ladder
-(§6) starting at **5×5** — matching the reference's Level 1 → 10 progression.
+(§7) starting at **5×5** — matching the reference's Level 1 → 10 progression.
 
 ## 5. What is reused vs. new
 
@@ -153,7 +153,55 @@ rules live in exactly one place: `findConflicts(...)` and `isSolved(...)`.
 notes mini-grid, digit correct/incorrect feedback. All of it stays in place and
 untouched for classic Sudoku.
 
-## 6. Delivery steps (one branch per step, per dev-process.md)
+## 6. Menu, navigation, and the hub
+
+**Today the app opens straight into Sudoku, and Fungiku is reached from a button
+inside Sudoku's own game menu.** That structure says "Sudoku is the app and
+Fungiku is a guest." With two games it needs a shell where both are peers —
+otherwise every later step keeps building into the wrong shape.
+
+### The shell
+
+- **`App.js` owns a small screen router** — the route is `'hub'` or a game id.
+  No navigation library: two or three games don't justify `react-navigation`'s
+  native setup, and this matches the sibling **color-loop** app, whose hub lives
+  in `App.tsx` with each game self-contained under `games/<name>/`. Revisit only
+  if the app grows genuinely deep navigation.
+- **Game registry — `games/registry.js`.** One entry per game:
+  `{ id, title, tagline, icon, accent, Screen }`. The hub renders its cards from
+  the registry, so adding a third game is a registry entry, not a UI edit.
+- **Hub screen — `screens/HubScreen.js`.** App title, one card per game,
+  theme-aware, with a **"Continue"** affordance when a game has saved progress.
+- **Back to the hub** — every game screen gets a home affordance in its header.
+- **`games/fungiku/FungikuScreen.js`** — Fungiku becomes a real screen reached
+  from the hub. The menu-modal preview entry goes away.
+- **Sudoku's files stay where they are** for now; the registry points at the
+  existing `GameScreen`. Relocating Sudoku under `games/sudoku/` to match the
+  convention is optional tidy-up, deliberately deferred to keep the step small.
+
+### Behaviors to get right
+
+- **Resume.** Sudoku restores a saved game on launch today. With a hub in front,
+  the hub shows first and the card carries a *Continue* badge — predictable, and
+  it keeps both games discoverable. (The alternative, auto-jumping into a game in
+  progress, hides the other game; operator decision in §8.)
+- **Timer.** Leaving Sudoku for the hub must **pause its timer** — today it only
+  pauses on the menu and on backgrounding, so navigating away would leave it
+  running while nobody is playing.
+- **Difficulty.** Sudoku opens its difficulty menu when no game is in progress;
+  entering from the hub must still land there.
+- **Separate persistence keys per game**, so the two modes never clobber each
+  other's saved state.
+- **Leaving mid-game is not quitting** — navigating to the hub must not reset
+  progress.
+
+### App identity
+
+The app is titled "Sudoku" but will host two games, so the hub needs a name of
+its own. Flagged as an open question (§8) — it is a branding decision, not a
+technical one.
+
+## 7. Delivery steps (one branch per step, per dev-process.md)
 
 Each step names **what the operator can see in Expo Go** when it lands — that is
 the step's real acceptance test, alongside its automated checks.
@@ -163,24 +211,40 @@ the step's real acceptance test, alongside its automated checks.
 | 0 | ~~Upgrade Expo SDK~~ ✅ merged (#66) — SDK 54 | App runs on the current SDK |
 | 1 | ~~Rendering seam — `Symbol.js` + `symbolSets.js`~~ ✅ merged (#67) | Zero visual change (that was the point) |
 | 2 | **Engine** — seeded generator, solver, uniqueness, shared `findConflicts` / `isSolved`, Jest tests | **Engine preview**: generated boards with their color regions and solution mushrooms; switch size 5–8, reseed, show/hide the solution |
-| 3 | **State** — reducer + context: mark cycling, live conflict validation, win detection, undo/redo, persistence | Preview gains **tap-to-cycle** X/🍄 with live conflict highlighting and a win banner — the puzzle becomes playable, if plain |
-| 4 | **Board UI** — the real board component: region-boundary borders, themed styling, `🍄 X/N` counter, win flow | The **actual game board**, styled to the app's themes, replacing the preview's rough grid |
-| 5 | **Mode entry** — mode selector alongside classic Sudoku, size/level selection | Fungiku reachable as a **real mode** from the menu; preview scaffolding removed |
+| 3 | **Game shell + hub** (§6) — screen router, game registry, hub screen, back-to-hub, Fungiku's own screen | **The hub**: app opens on a home screen with **Sudoku and Fungiku side by side as peers**; Fungiku is a real destination, not a button in Sudoku's menu |
+| 4 | **State** — reducer + context: mark cycling, live conflict validation, win detection, undo/redo, persistence | The Fungiku screen becomes **playable**: tap-to-cycle X/🍄, live conflict highlighting, `🍄 X/N` counter, win banner |
+| 5 | **Board UI** — the real board component: region-boundary borders, themed styling, win flow, palette tuning | The **finished board**, styled to the app's themes, replacing the preview's rough grid |
 | 6 | **Assists & polish** — optional auto-X, win animation, level ladder, scoring | Assist toggle, win celebration, level progression |
 | 7 | **Art swap** (floating, asset-only) | Static mushroom art replaces the icon glyph |
 
-Steps 2 and 3 share the preview surface: Step 2 builds it read-only to judge the
-engine's output, Step 3 makes it interactive to prove the rules. It is
-scaffolding, not the product — Step 4 supersedes it and Step 5 deletes it.
+**Why the shell comes before the game logic:** Fungiku currently hangs off
+Sudoku's menu, which is the wrong shape to keep building into. Doing the hub at
+Step 3 means Step 4's playable board lands in a real Fungiku screen instead of a
+modal nested inside another game — no throwaway work, and the two games read as
+peers from the moment there is anything to play.
 
-## 7. Open questions for the operator
+The preview is scaffolding, not the product: Step 2 builds it read-only to judge
+the engine's output, Step 3 gives it a real home, Step 4 makes it playable, and
+Step 5 supersedes it with the finished board.
+
+## 8. Open questions for the operator
 
 1. **Mode name in the UI** — **decided: "Fungiku"** (internal id `fungiku`).
-2. **Ladder shape** — v1 ships **5×5 → 8×8**. Where should it top out, and
+2. **What is the app called now?** It ships as "Sudoku" but is about to host two
+   games as peers (§6). The hub needs a title, and the app's name, icon and
+   store listing follow from it. Options: keep "Sudoku" and treat Fungiku as a
+   bonus (undersells it), rename to a neutral puzzle-collection brand, or lead
+   with the family name. This is a branding call, not a technical one, and it
+   blocks nothing — but the hub in Step 3 will show *some* title, so a
+   placeholder gets chosen there if this is still open.
+3. **Hub vs. resume on launch** — should the app always open on the hub with a
+   *Continue* badge (recommended: both games stay discoverable), or jump
+   straight back into a game already in progress?
+4. **Ladder shape** — v1 ships **5×5 → 8×8**. Where should it top out, and
    should size be a free choice or unlocked by progression?
-3. **Assist defaults** — should auto-X be on by default for younger players?
+5. **Assist defaults** — should auto-X be on by default for younger players?
 
-## 8. Edge cases to get right
+## 9. Edge cases to get right
 
 - **A 4×4 board is impossible** under these rules — with one mushroom per column
   and `|Δcol| ≥ 2` between adjacent rows, no arrangement exists for N=4 — so the
@@ -193,7 +257,7 @@ scaffolding, not the product — Step 4 supersedes it and Step 5 deletes it.
 - **Persistence** stores the seed + size + the player's marks, not the whole
   board; the puzzle is rebuilt deterministically from the seed on restore.
 
-## 9. Disposition of the pre-replan work
+## 10. Disposition of the pre-replan work
 
 - **Step 0 (#66, merged)** — SDK 54 upgrade. Unaffected, keep.
 - **Step 1 (#67, merged)** — `Symbol.js` + `utils/symbolSets.js`. **Kept**; the


### PR DESCRIPTION
Replans Fungiku from the operator's reference screenshots, lands the engine, and sets up the epic-branch + visible-at-every-step workflow. Refs #65.

**→ Targets `epic/fungiku`, not `main`.** The epic branch merges to `main` once Fungiku is playable end to end, so `main` never carries a half-built mode.

## Why the replan

The old plan described Fungiku as a **display mode for Sudoku** — a skin swapping digits 1–9 for swatches over the numeric 9×9 board. The reference screenshots show that's not the target game. The real mechanic **merges the symbols into color regions** and makes the **mushroom the only input**:

> **1 mushroom per row & column · 1 per color region · mushrooms cannot touch**

That's the **Queens / Star-Battle** genre. Different generator, rules, win condition, and input model — it cannot be a rendering skin over the numeric board. So Fungiku becomes a **separate game mode**; classic Sudoku is untouched.

**Disposition of prior work** (plan §9): Step 0 (#66) and Step 1 (#67) both stay — the Step 1 palette and mushroom glyph carry forward as the **region colors** and the **placed marker**. Old Step 2 (#68) is **closed unmerged**.

## Process changes in this PR

Per operator feedback, two things are now baked into the plan:

1. **Epic branch** — every step PR targets `epic/fungiku`.
2. **Every step ships something runnable in Expo Go.** A step whose only evidence is a passing test suite is not done. §6 is now a table naming, for each step, exactly what you can see on device when it lands.

## The engine

`SudokuApp/games/fungiku/engine.js` — pure logic, deterministic from a seed.

**The insight that drives it:** one-per-row *and* one-per-column means a solution is a **column permutation**, so two mushrooms can only touch if they're in adjacent rows. The no-touching rule collapses to one O(1) check: `|col[r] − col[r+1]| ≥ 2`.

**Generation:** randomized backtracking finds a valid permutation, then randomized multi-source BFS grows N contiguous regions seeded at the mushrooms. Contiguity holds by construction and each region holds exactly one solution mushroom.

**Uniqueness is forced by targeting, not guessing** — the part most worth reviewing. An unwanted solution already satisfies row/column/no-touching (those depend only on positions, not regions), so the *only* way to invalidate it is to make two of its mushrooms share a region. `breakSolution` does exactly that. Real-solution cells are never moved and donor regions are contiguity-checked, so **the stored solution survives every mutation**. Blind perturbation and full regeneration back it up on capped budgets.

My first attempt used untargeted random perturbation: it converged at 5×5–6×6 but **failed outright at 7×7**. The targeted version fixed it and is fast — worst case **32 ms at 8×8**.

**`MIN_SIZE = 5`** — 4×4 is genuinely unsolvable under these rules, and `generate` rejects it.

## What you can see in Expo Go

**Game menu → 🍄 Fungiku (preview).** A read-only look at the generator's output: color regions with region-boundary borders and the solution mushrooms. Switch size **5×5–8×8**, reseed, show/hide the solution.

It's deliberately **not** the real board — no input, no marks. Step 3 makes it interactive, Step 4 supersedes it with the real board, Step 5 removes it.

I drove the web build in a browser to confirm it: boards render with **no page errors**, and placements satisfy all four rules at both 5×5 and 8×8.

### 🎨 A design issue this already surfaced

Exactly the kind of thing this feedback loop is for: at 8 regions, **sky blue and blue read very similarly as pastel fills**, and orange/yellow are close too. The Okabe–Ito palette is colorblind-safe at full saturation, but tinting to 62% toward white compresses those differences. Worth a **palette tuning pass in Step 4** — likely hand-picked pastels rather than mechanical tints, or varying lightness per region. Flagging rather than fixing, since Step 4 owns board styling.

## Region palette

`utils/symbolSets.js` exports `REGION_COLORS` / `getRegionColor`, derived from the existing swatches plus the mushroom red, so region colors and value swatches keep **one source of color truth**. Each entry carries the saturated color (borders, glyphs) and a pastel background (cell fill) — a full cell of saturated Okabe–Ito would overwhelm the mushroom on top of it.

## Test setup — a note for review

This project had **no test setup at all**. Rather than pull in `jest-expo`, this adds `jest` with a **self-contained `babel-jest` transform** (`babelrc`/`configFile` disabled, node target). `jest-expo` would need `babel-preset-expo` *and* a global `babel.config.js` this project deliberately lacks, touching the Metro/Expo build path for no benefit — the engine is pure ESM JS. Component testing can add the Expo preset later without disturbing this. Deps are `devDependencies` only, no duplication.

**67 tests**: determinism, uniqueness across 5–8, region coverage plus an *independent* flood-fill contiguity check, all four placement rules, per-rule conflict detection, and win detection including X-mark noise.

## Verification

- `npm test` → **67/67**
- `npx expo-doctor` → **18/18**
- `npx expo export --platform all` → **web + iOS + Android** all bundle
- Preview driven in a browser against the web build → renders, no page errors, rules hold at 5×5 and 8×8

## Open questions (plan §7)

1. **Mode name** — decided: **"Fungiku"**.
2. **Ladder shape** — v1 targets 5×5 → 8×8. Where should it top out, and is size a free choice or unlocked by progression?
3. **Assist defaults** — should auto-X be on by default for younger players?