### PR TITLE
Fungiku Step 5: the real board UI, starting with the palette

### DIFF
--- a/SudokuApp/contexts/GameContext.js
+++ b/SudokuApp/contexts/GameContext.js
@@ -3,6 +3,7 @@ import SUDOKU_THEMES from '../utils/themes';
 import { generateSudoku, isCorrectValue as checkCorrectValue } from '../utils/boardFactory';
 import usePersistentReducer from '../hooks/usePersistentReducer';
 import { loadState, saveState } from '../utils/storage';
+import { saveAppThemeName } from '../utils/appTheme';
 import { debugFillBoard as debugFillBoardUtil, debugCheatMode as debugCheatModeUtil } from '../utils/debugUtils';
 import { calculateAllNotes } from '../utils/notesHelper';
 
@@ -1018,11 +1019,16 @@ export const GameProvider = ({ children }) => {
     const currentIndex = themeKeys.indexOf(state.currentThemeName);
     const nextIndex = (currentIndex + 1) % themeKeys.length;
     const nextThemeName = themeKeys[nextIndex];
-    
+
     dispatch({
       type: ACTIONS.CHANGE_THEME,
       payload: nextThemeName,
     });
+
+    // The theme is an app-level preference, not a Sudoku one: write it through so
+    // the hub and Fungiku follow along (see utils/appTheme.js). Sudoku still
+    // renders from its own state, so this is additive.
+    saveAppThemeName(nextThemeName);
   };
   
   // Helper to calculate last score change (used for animations)

--- a/SudokuApp/games/fungiku/FungikuBoard.js
+++ b/SudokuApp/games/fungiku/FungikuBoard.js
@@ -1,26 +1,27 @@
-import React from 'react';
-import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import React, { useEffect, useMemo, useRef } from 'react';
+import { View, StyleSheet, TouchableOpacity, Animated, Easing } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { MARKS } from './engine';
-import { getRegionColor } from '../../utils/symbolSets';
+import { getRegionPalette } from '../../utils/symbolSets';
+import useBoardSize from '../../hooks/useBoardSize';
 import { useFungikuContext } from './FungikuContext';
 
 /**
- * The playable Fungiku board.
+ * The Fungiku board.
  *
- * This is the engine preview's grid made interactive — a tap cycles a cell
- * through empty → X → 🍄 and conflicting mushrooms are outlined. Deliberately
- * plain: Step 5 replaces it with the real themed board component (region
- * boundary polish, the win flow, the palette tuning pass). The job here is that
- * the game can be *played*.
+ * Region outlines *are* the board's structure (docs/fungiku-plan.md §3) — they
+ * stand in for Sudoku's 3×3 box lines, and they are the only way the player sees
+ * where one color region ends. An edge is drawn thick wherever the neighboring
+ * cell belongs to a different region.
  *
- * Region outlines are the board's structure (plan §3), standing in for Sudoku's
- * 3×3 box lines: an edge is thick wherever the neighboring cell belongs to a
- * different region.
+ * Everything visual comes from the active theme: which region palette (light or
+ * dark) is chosen, the outline color, and the glyph ink — which is picked for
+ * contrast against each region's own fill rather than being the region's hue, so
+ * a mushroom never disappears into an orange cell.
+ *
+ * @param {boolean} isDark - whether the active theme is a dark one
+ * @param {Object} theme - a theme object from utils/themes
  */
-
-const BOARD_MAX = 320;
-const CONFLICT_COLOR = '#C1272D';
 
 const MARK_LABELS = {
   [MARKS.EMPTY]: 'empty',
@@ -28,29 +29,62 @@ const MARK_LABELS = {
   [MARKS.MUSHROOM]: 'mushroom',
 };
 
-const FungikuBoard = () => {
-  const { size, regions, marks, conflicts, cycleCell } = useFungikuContext();
+const FungikuBoard = ({ isDark, theme }) => {
+  const { size, regions, marks, conflicts, cycleCell, solved } = useFungikuContext();
 
-  const cell = Math.floor(BOARD_MAX / size);
+  const boardSize = useBoardSize();
+  const cell = Math.floor(boardSize / size);
   const glyph = Math.round(cell * 0.62);
 
+  const palette = useMemo(() => getRegionPalette(isDark), [isDark]);
+
+  // Region outlines come from the theme's grid colors so the board reads as part
+  // of the app; they need to hold up over both light and dark region fills.
+  const outline = theme?.colors?.grid?.boxBorder || (isDark ? '#e8e8e8' : '#333333');
+  const hairline = theme?.colors?.grid?.cellBorder || (isDark ? '#ffffff44' : '#33333344');
+
+  // The board itself celebrates a win first (a gentle lift), before the banner
+  // above it arrives — same "board celebrates first" idea the sibling color-loop
+  // app uses for its win sequence.
+  const winLift = useRef(new Animated.Value(0)).current;
+  useEffect(() => {
+    Animated.timing(winLift, {
+      toValue: solved ? 1 : 0,
+      duration: solved ? 420 : 160,
+      easing: solved ? Easing.out(Easing.back(2)) : Easing.out(Easing.quad),
+      useNativeDriver: true,
+    }).start();
+  }, [solved, winLift]);
+
   return (
-    <View style={[styles.board, { width: cell * size, height: cell * size }]}>
+    <Animated.View
+      style={[
+        styles.board,
+        {
+          width: cell * size,
+          height: cell * size,
+          transform: [
+            { scale: winLift.interpolate({ inputRange: [0, 1], outputRange: [1, 1.04] }) },
+          ],
+        },
+      ]}
+    >
       {Array.from({ length: size }, (_, row) => (
         <View key={row} style={styles.row}>
           {Array.from({ length: size }, (_, col) => {
             const index = row * size + col;
             const region = regions[index];
-            const palette = getRegionColor(region);
+            const entry = palette[region % palette.length];
             const mark = marks[index];
             const conflicting = conflicts.has(index);
 
             const differs = (r, c) =>
-              r < 0 ||
-              c < 0 ||
-              r >= size ||
-              c >= size ||
-              regions[r * size + c] !== region;
+              r < 0 || c < 0 || r >= size || c >= size || regions[r * size + c] !== region;
+
+            // X is a thinking aid, so it sits quieter than a mushroom — but it
+            // still has to be visible on its own fill, so it is the same
+            // contrast-checked ink at reduced strength rather than a fixed gray.
+            const inkFaded = entry.ink === '#ffffff' ? '#ffffffaa' : '#1a1a1aaa';
 
             return (
               <TouchableOpacity
@@ -59,31 +93,42 @@ const FungikuBoard = () => {
                 activeOpacity={0.6}
                 accessibilityRole="button"
                 // Region name and mark are both spelled out, so the board is
-                // usable without relying on color (plan §5).
-                accessibilityLabel={`Row ${row + 1}, column ${col + 1}, ${palette.name} region, ${
+                // usable without relying on color (plan §5). These labels are
+                // also the seam the browser tests address cells through.
+                accessibilityLabel={`Row ${row + 1}, column ${col + 1}, ${entry.name} region, ${
                   MARK_LABELS[mark] || 'empty'
                 }${conflicting ? ', conflict' : ''}`}
                 accessibilityHint="Taps cycle empty, ruled out, mushroom"
                 style={{
                   width: cell,
                   height: cell,
-                  backgroundColor: palette.background,
+                  backgroundColor: entry.background,
                   alignItems: 'center',
                   justifyContent: 'center',
-                  borderColor: '#33333355',
+                  borderTopColor: differs(row - 1, col) ? outline : hairline,
+                  borderBottomColor: differs(row + 1, col) ? outline : hairline,
+                  borderLeftColor: differs(row, col - 1) ? outline : hairline,
+                  borderRightColor: differs(row, col + 1) ? outline : hairline,
                   borderTopWidth: differs(row - 1, col) ? 2 : StyleSheet.hairlineWidth,
                   borderBottomWidth: differs(row + 1, col) ? 2 : StyleSheet.hairlineWidth,
                   borderLeftWidth: differs(row, col - 1) ? 2 : StyleSheet.hairlineWidth,
                   borderRightWidth: differs(row, col + 1) ? 2 : StyleSheet.hairlineWidth,
                 }}
               >
-                {/* A conflicting mushroom gets a ring as well as a red glyph, so
-                    the signal is not carried by color alone. */}
+                {/* Conflict is signalled by a ring *and* a color change, so it
+                    survives a colorblind reader and a dark theme alike. The ring
+                    color is contrast-checked against every fill in the palette
+                    (see symbolSets.js). */}
                 {conflicting && (
                   <View
                     style={[
                       styles.conflictRing,
-                      { width: cell - 8, height: cell - 8, borderRadius: (cell - 8) / 2 },
+                      {
+                        width: cell - 6,
+                        height: cell - 6,
+                        borderRadius: (cell - 6) / 2,
+                        borderColor: entry.conflictInk,
+                      },
                     ]}
                   />
                 )}
@@ -92,7 +137,7 @@ const FungikuBoard = () => {
                   <MaterialCommunityIcons
                     name="mushroom"
                     size={glyph}
-                    color={conflicting ? CONFLICT_COLOR : palette.color}
+                    color={conflicting ? entry.conflictInk : entry.ink}
                   />
                 )}
 
@@ -100,7 +145,7 @@ const FungikuBoard = () => {
                   <MaterialCommunityIcons
                     name="close"
                     size={Math.round(glyph * 0.8)}
-                    color="#55555599"
+                    color={inkFaded}
                   />
                 )}
               </TouchableOpacity>
@@ -108,7 +153,7 @@ const FungikuBoard = () => {
           })}
         </View>
       ))}
-    </View>
+    </Animated.View>
   );
 };
 
@@ -121,8 +166,7 @@ const styles = StyleSheet.create({
   },
   conflictRing: {
     position: 'absolute',
-    borderWidth: 2,
-    borderColor: CONFLICT_COLOR,
+    borderWidth: 2.5,
   },
 });
 

--- a/SudokuApp/games/fungiku/FungikuScreen.js
+++ b/SudokuApp/games/fungiku/FungikuScreen.js
@@ -4,7 +4,12 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 import ScreenHeader from '../../components/ScreenHeader';
 import useAppTheme from '../../hooks/useAppTheme';
 import FungikuBoard from './FungikuBoard';
+import FungikuWinBanner from './FungikuWinBanner';
 import { FungikuProvider, SIZES, useFungikuContext } from './FungikuContext';
+
+// The accent Fungiku is identified by on the hub card; reused for the win banner
+// so winning looks like Fungiku rather than a generic green success box.
+const FUNGIKU_ACCENT = '#a0522d';
 
 /**
  * Fungiku's screen — a peer of the Sudoku screen, reached from the hub
@@ -15,7 +20,7 @@ import { FungikuProvider, SIZES, useFungikuContext } from './FungikuContext';
  * replaces the board with the finished themed component.
  */
 const FungikuScreenContent = ({ onExitToHub }) => {
-  const theme = useAppTheme();
+  const { theme, isDark } = useAppTheme();
   const {
     size,
     seed,
@@ -36,6 +41,15 @@ const FungikuScreenContent = ({ onExitToHub }) => {
   const surface = theme.colors.numberPad.background;
   const border = theme.colors.numberPad.border;
 
+  // The hint follows the state of play instead of always explaining the tap
+  // cycle — telling a player who has just won how to tap a cell was Step 4's
+  // one loose end.
+  const hint = solved
+    ? 'One per row, column and color — none touching'
+    : conflicts.size > 0
+      ? `${conflicts.size} mushroom${conflicts.size === 1 ? '' : 's'} breaking a rule`
+      : 'Tap a cell: empty → ✕ → 🍄';
+
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
       <ScreenHeader title="Fungiku" theme={theme} onHomePress={onExitToHub} />
@@ -50,29 +64,18 @@ const FungikuScreenContent = ({ onExitToHub }) => {
           >
             {mushroomCount}/{size}
           </Text>
-          <Text style={[styles.counterHint, { color: titleColor }]}>
-            {conflicts.size > 0
-              ? 'One per row, column and color — none touching'
-              : 'Tap a cell: empty → ✕ → 🍄'}
-          </Text>
+          <Text style={[styles.counterHint, { color: titleColor }]}>{hint}</Text>
         </View>
 
-        {solved ? (
-          <View style={[styles.winBanner, { borderColor: border }]}>
-            <MaterialCommunityIcons name="party-popper" size={22} color="#1b5e20" />
-            <Text style={styles.winText}>Solved! {size}×{size}, seed {seed}</Text>
-            <TouchableOpacity
-              onPress={nextPuzzle}
-              style={styles.winButton}
-              accessibilityRole="button"
-              accessibilityLabel="Play the next puzzle"
-            >
-              <Text style={styles.winButtonText}>Next puzzle</Text>
-            </TouchableOpacity>
-          </View>
-        ) : null}
+        <FungikuWinBanner
+          solved={solved}
+          size={size}
+          seed={seed}
+          accent={FUNGIKU_ACCENT}
+          onNextPuzzle={nextPuzzle}
+        />
 
-        <FungikuBoard />
+        <FungikuBoard isDark={isDark} theme={theme} />
 
         {/* Undo / redo / clear */}
         <View style={styles.controlRow}>
@@ -199,34 +202,6 @@ const styles = StyleSheet.create({
     fontSize: 11,
     opacity: 0.7,
     flexShrink: 1,
-  },
-  winBanner: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#d4edda',
-    borderWidth: 1,
-    borderRadius: 10,
-    paddingVertical: 8,
-    paddingHorizontal: 12,
-    marginBottom: 12,
-  },
-  winText: {
-    color: '#1b5e20',
-    fontSize: 14,
-    fontWeight: '700',
-    marginLeft: 8,
-    marginRight: 10,
-  },
-  winButton: {
-    backgroundColor: '#1b5e20',
-    borderRadius: 8,
-    paddingVertical: 5,
-    paddingHorizontal: 10,
-  },
-  winButtonText: {
-    color: '#ffffff',
-    fontSize: 12,
-    fontWeight: '700',
   },
   controlRow: {
     flexDirection: 'row',

--- a/SudokuApp/games/fungiku/FungikuWinBanner.js
+++ b/SudokuApp/games/fungiku/FungikuWinBanner.js
@@ -1,0 +1,156 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Animated, Easing, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { readableOn } from '../../utils/color';
+
+/**
+ * The win celebration.
+ *
+ * Step 4 shipped a static green box, which announced the win without feeling
+ * like one. This springs in *after* the board's own lift (FungikuBoard scales up
+ * on solve), so the sequence reads as "the board celebrates, then the banner
+ * confirms" rather than everything moving at once.
+ *
+ * Un-placing a mushroom un-wins the board, so it animates *out* as well as in —
+ * but it must be genuinely gone once it has, not just transparent. An
+ * opacity-0 banner still reserves its layout (leaving a gap above the board) and
+ * still reads "Solved!" to a screen reader on an untouched puzzle, so the exit
+ * animation's completion callback unmounts it.
+ */
+const ENTER_DELAY = 220;
+
+const FungikuWinBanner = ({ solved, size, seed, accent, onNextPuzzle }) => {
+  const progress = useRef(new Animated.Value(0)).current;
+  const shimmer = useRef(new Animated.Value(0)).current;
+  const [mounted, setMounted] = useState(solved);
+
+  useEffect(() => {
+    if (solved) setMounted(true);
+
+    const animation = Animated.timing(progress, {
+      toValue: solved ? 1 : 0,
+      duration: solved ? 420 : 180,
+      delay: solved ? ENTER_DELAY : 0,
+      easing: solved ? Easing.out(Easing.back(1.7)) : Easing.in(Easing.quad),
+      useNativeDriver: true,
+    });
+
+    animation.start(({ finished }) => {
+      // Only drop it once the exit actually played out; a cancelled animation
+      // means solved flipped again mid-flight and the next effect owns it.
+      if (finished && !solved) setMounted(false);
+    });
+
+    return () => animation.stop();
+  }, [solved, progress]);
+
+  useEffect(() => {
+    if (!solved) {
+      shimmer.setValue(0);
+      return undefined;
+    }
+
+    // One pass, not a loop: a celebration that never stops becomes wallpaper.
+    const animation = Animated.sequence([
+      Animated.delay(ENTER_DELAY + 260),
+      Animated.timing(shimmer, {
+        toValue: 1,
+        duration: 900,
+        easing: Easing.inOut(Easing.quad),
+        useNativeDriver: true,
+      }),
+    ]);
+    animation.start();
+
+    return () => animation.stop();
+  }, [solved, shimmer]);
+
+  // Every hook has to run before this bails out — an early return above one of
+  // them changes the hook count between renders and React throws.
+  if (!mounted) return null;
+
+  const ink = readableOn(accent);
+
+  return (
+    <Animated.View
+      pointerEvents={solved ? 'auto' : 'none'}
+      style={[
+        styles.banner,
+        {
+          backgroundColor: accent,
+          opacity: progress,
+          transform: [
+            { scale: progress.interpolate({ inputRange: [0, 1], outputRange: [0.85, 1] }) },
+            { translateY: progress.interpolate({ inputRange: [0, 1], outputRange: [-14, 0] }) },
+          ],
+        },
+      ]}
+    >
+      <Animated.View
+        style={{
+          transform: [
+            {
+              rotate: shimmer.interpolate({
+                inputRange: [0, 0.25, 0.5, 0.75, 1],
+                outputRange: ['0deg', '-14deg', '0deg', '14deg', '0deg'],
+              }),
+            },
+          ],
+        }}
+      >
+        <MaterialCommunityIcons name="party-popper" size={22} color={ink} />
+      </Animated.View>
+
+      <View style={styles.textBlock}>
+        <Text style={[styles.title, { color: ink }]}>Solved!</Text>
+        <Text style={[styles.detail, { color: ink }]}>
+          {size}×{size} · seed {seed}
+        </Text>
+      </View>
+
+      <TouchableOpacity
+        onPress={onNextPuzzle}
+        style={[styles.button, { borderColor: ink }]}
+        accessibilityRole="button"
+        accessibilityLabel="Play the next puzzle"
+      >
+        <Text style={[styles.buttonText, { color: ink }]}>Next puzzle</Text>
+      </TouchableOpacity>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 12,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    marginBottom: 12,
+  },
+  textBlock: {
+    marginLeft: 10,
+    marginRight: 12,
+  },
+  title: {
+    fontSize: 15,
+    fontWeight: '800',
+  },
+  detail: {
+    fontSize: 11,
+    opacity: 0.85,
+  },
+  button: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingVertical: 5,
+    paddingHorizontal: 10,
+  },
+  buttonText: {
+    fontSize: 12,
+    fontWeight: '700',
+  },
+});
+
+export default FungikuWinBanner;

--- a/SudokuApp/hooks/useAppTheme.js
+++ b/SudokuApp/hooks/useAppTheme.js
@@ -1,19 +1,21 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import SUDOKU_THEMES from '../utils/themes';
-import { readSavedThemeName } from '../utils/storage';
+import { loadAppThemeName } from '../utils/appTheme';
+import { relativeLuminance } from '../utils/color';
 
 export const DEFAULT_THEME_NAME = 'classic';
 
 /**
- * Theme for screens that live outside Sudoku's GameContext — the hub and
- * Fungiku. It follows whatever theme the player last picked in Sudoku, so the
- * shell doesn't snap back to the default palette when they leave the board.
+ * Theme for screens the shell owns — the hub and Fungiku.
  *
- * Sudoku keeps using its own themed context; this hook is for everything else.
- * A single app-level theme owned by the shell is the eventual home for this —
- * worth doing when Fungiku has real UI to theme.
+ * Reads the app-level preference (utils/appTheme.js). Sudoku renders from its own
+ * reducer state and writes through to that key when the player cycles the theme,
+ * so one choice drives the whole app without the shell reaching into Sudoku's
+ * saved game the way it did in Step 3.
  *
- * @returns {Object} a theme object from utils/themes.
+ * @returns {{theme: Object, themeName: string, isDark: boolean}} `isDark` is
+ *   derived from the background's luminance, not a list of theme names, so a new
+ *   theme in utils/themes.js classifies itself.
  */
 const useAppTheme = () => {
   const [themeName, setThemeName] = useState(DEFAULT_THEME_NAME);
@@ -21,7 +23,7 @@ const useAppTheme = () => {
   useEffect(() => {
     let cancelled = false;
 
-    readSavedThemeName().then((saved) => {
+    loadAppThemeName().then((saved) => {
       if (!cancelled && saved && SUDOKU_THEMES[saved]) {
         setThemeName(saved);
       }
@@ -32,7 +34,14 @@ const useAppTheme = () => {
     };
   }, []);
 
-  return SUDOKU_THEMES[themeName] || SUDOKU_THEMES[DEFAULT_THEME_NAME];
+  return useMemo(() => {
+    const theme = SUDOKU_THEMES[themeName] || SUDOKU_THEMES[DEFAULT_THEME_NAME];
+    return {
+      theme,
+      themeName,
+      isDark: relativeLuminance(theme.colors.background) < 0.4,
+    };
+  }, [themeName]);
 };
 
 export default useAppTheme;

--- a/SudokuApp/hooks/useBoardSize.js
+++ b/SudokuApp/hooks/useBoardSize.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Platform, useWindowDimensions } from 'react-native';
+
+/**
+ * The on-screen size of a square game board.
+ *
+ * Extracted from `screens/GameScreen.js`, where it lived as a private
+ * `useGridContainerSize`, so Fungiku's board sizes the same way Sudoku's does
+ * instead of carrying its own hardcoded constant. The numbers are Sudoku's,
+ * unchanged: a fixed size on native, and on web a share of the smaller viewport
+ * dimension clamped to a sane range.
+ *
+ * @returns {number} board width/height in px
+ */
+const BASE_SIZE = 324; // native
+const MAX_WEB_SIZE = 450;
+const MIN_WEB_SIZE = 270;
+const WEB_VIEWPORT_SHARE = 0.7;
+
+const useBoardSize = () => {
+  const { width, height } = useWindowDimensions();
+
+  return React.useMemo(() => {
+    if (Platform.OS === 'web') {
+      const smallerDimension = Math.min(width, height);
+      return Math.floor(
+        Math.min(MAX_WEB_SIZE, Math.max(MIN_WEB_SIZE, smallerDimension * WEB_VIEWPORT_SHARE))
+      );
+    }
+
+    return BASE_SIZE;
+  }, [width, height]);
+};
+
+export default useBoardSize;

--- a/SudokuApp/screens/GameScreen.js
+++ b/SudokuApp/screens/GameScreen.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { View, StyleSheet, Platform, useWindowDimensions, Text } from 'react-native';
+import { View, StyleSheet, Platform, Text } from 'react-native';
 import Grid from '../components/Grid';
 import NumberPad from '../components/NumberPad';
 import BuildNotes from '../components/BuildNotes';
@@ -13,6 +13,7 @@ import WinModal from '../components/modals/WinModal';
 import { GameProvider, useGameContext, ACTIONS } from '../contexts/GameContext';
 import appJson from '../app.json';
 import useAppStateListener from '../hooks/useAppStateListener';
+import useBoardSize from '../hooks/useBoardSize';
 
 /**
  * Main game screen for Sudoku
@@ -37,8 +38,8 @@ const GameScreenContent = ({ onExitToHub }) => {
   // Use custom hook to handle app state changes
   useAppStateListener();
   
-  // Use our optimized grid container size hook
-  const gridContainerSize = useGridContainerSize();
+  // Shared with Fungiku's board (hooks/useBoardSize.js) — same numbers as before
+  const gridContainerSize = useBoardSize();
 
   /**
    * Stable ‑ re‑created only when the game is completed (rare).
@@ -130,40 +131,6 @@ const GameScreen = ({ onExitToHub }) => {
       <GameScreenContent onExitToHub={onExitToHub} />
     </GameProvider>
   );
-};
-
-// This function uses useWindowDimensions and React.useMemo to optimize performance
-const useGridContainerSize = () => {
-  // Get window dimensions with React Native hook - this will update automatically on resize
-  const { width, height } = useWindowDimensions();
-  
-  // Use React.useMemo to avoid recalculating on every render
-  return React.useMemo(() => {
-    // Base size for mobile
-    const baseSize = 324;
-    
-    // For web platform, use responsive sizing based on screen width
-    if (Platform.OS === 'web') {
-      const smallerDimension = Math.min(width, height);
-      
-      // Limit grid size on web for larger screens
-      // On small screens, make it proportionally smaller
-      const maxWebSize = 450; // Maximum grid size on web
-      const minWebSize = 270; // Minimum grid size on web
-      
-      // Calculate the responsive size based on screen dimensions
-      const responsiveSize = Math.min(
-        maxWebSize,
-        Math.max(minWebSize, smallerDimension * 0.7)
-      );
-      
-      // Round to nearest pixel for clean rendering
-      return Math.floor(responsiveSize);
-    }
-    
-    // Return default size for mobile platforms
-    return baseSize;
-  }, [width, height]); // Only recalculate when dimensions change
 };
 
 const styles = StyleSheet.create({

--- a/SudokuApp/screens/HubScreen.js
+++ b/SudokuApp/screens/HubScreen.js
@@ -23,7 +23,7 @@ const ICON_SIZE = 30;
  * instead of dropping the player straight back into one of them.
  */
 const HubScreen = ({ onSelectGame }) => {
-  const theme = useAppTheme();
+  const { theme } = useAppTheme();
 
   // Keyed by game id; a missing entry just means "nothing to continue".
   const [progress, setProgress] = useState({});

--- a/SudokuApp/utils/__tests__/color.test.js
+++ b/SudokuApp/utils/__tests__/color.test.js
@@ -1,0 +1,119 @@
+import {
+  closestPair,
+  contrastRatio,
+  deltaE,
+  hexToLab,
+  hexToRgb,
+  mix,
+  readableOn,
+  relativeLuminance,
+  rgbToHex,
+} from '../color';
+
+describe('hex and rgb', () => {
+  it('round-trips', () => {
+    expect(hexToRgb('#56b4e9')).toEqual({ r: 0x56, g: 0xb4, b: 0xe9 });
+    expect(rgbToHex({ r: 0x56, g: 0xb4, b: 0xe9 })).toBe('#56b4e9');
+  });
+
+  it('clamps and rounds out-of-range channels', () => {
+    expect(rgbToHex({ r: -20, g: 300, b: 127.6 })).toBe('#00ff80');
+  });
+});
+
+describe('mix', () => {
+  it('returns the endpoints at weight 0 and 1', () => {
+    expect(mix('#0072b2', '#ffffff', 0)).toBe('#0072b2');
+    expect(mix('#0072b2', '#ffffff', 1)).toBe('#ffffff');
+  });
+
+  it('blends halfway', () => {
+    expect(mix('#000000', '#ffffff', 0.5)).toBe('#808080');
+  });
+
+  it('clamps weights outside 0..1', () => {
+    expect(mix('#000000', '#ffffff', -1)).toBe('#000000');
+    expect(mix('#000000', '#ffffff', 2)).toBe('#ffffff');
+  });
+});
+
+describe('luminance and contrast', () => {
+  it('anchors at black and white', () => {
+    expect(relativeLuminance('#000000')).toBeCloseTo(0, 5);
+    expect(relativeLuminance('#ffffff')).toBeCloseTo(1, 5);
+  });
+
+  it('gives the known 21:1 extreme', () => {
+    expect(contrastRatio('#000000', '#ffffff')).toBeCloseTo(21, 2);
+  });
+
+  it('is symmetric and 1:1 against itself', () => {
+    expect(contrastRatio('#56b4e9', '#0072b2')).toBeCloseTo(
+      contrastRatio('#0072b2', '#56b4e9'),
+      10
+    );
+    expect(contrastRatio('#56b4e9', '#56b4e9')).toBeCloseTo(1, 10);
+  });
+
+  it('picks the more legible ink for a background', () => {
+    expect(readableOn('#ffffff')).toBe('#1a1a1a');
+    expect(readableOn('#000000')).toBe('#ffffff');
+  });
+});
+
+describe('hexToLab', () => {
+  it('places white and black', () => {
+    const white = hexToLab('#ffffff');
+    expect(white.L).toBeCloseTo(100, 1);
+    expect(white.a).toBeCloseTo(0, 1);
+    expect(white.b).toBeCloseTo(0, 1);
+
+    expect(hexToLab('#000000').L).toBeCloseTo(0, 5);
+  });
+
+  it('places mid gray near L* 53.6', () => {
+    expect(hexToLab('#808080').L).toBeCloseTo(53.6, 1);
+  });
+});
+
+describe('deltaE (CIEDE2000)', () => {
+  it('is zero for identical colors', () => {
+    expect(deltaE('#56b4e9', '#56b4e9')).toBeCloseTo(0, 10);
+  });
+
+  it('is symmetric', () => {
+    expect(deltaE('#56b4e9', '#0072b2')).toBeCloseTo(deltaE('#0072b2', '#56b4e9'), 10);
+  });
+
+  // Pinned against the reference implementation's published behavior for the
+  // extremes; these guard against an algebra slip in the formula above.
+  it('reports the black/white extreme as 100', () => {
+    expect(deltaE('#000000', '#ffffff')).toBeCloseTo(100, 0);
+  });
+
+  it('rates a barely-different color below the just-noticeable threshold', () => {
+    expect(deltaE('#56b4e9', '#56b5e9')).toBeLessThan(1);
+  });
+
+  it('rates clearly different hues well above it', () => {
+    expect(deltaE('#e69f00', '#0072b2')).toBeGreaterThan(40);
+  });
+
+  it('does not overstate how different two similar blues are', () => {
+    // The whole reason for CIEDE2000 over CIE76 here: these two are close, and
+    // the simpler formula would have called them comfortably distinct.
+    expect(deltaE('#bfe3f7', '#9ec9e2')).toBeLessThan(10);
+  });
+});
+
+describe('closestPair', () => {
+  it('finds the worst pair in a list', () => {
+    const worst = closestPair(['#000000', '#ffffff', '#fefefe']);
+    expect(worst.distance).toBeLessThan(1);
+    expect([worst.a, worst.b].sort()).toEqual(['#fefefe', '#ffffff']);
+  });
+
+  it('reports Infinity for a list too short to have a pair', () => {
+    expect(closestPair(['#000000']).distance).toBe(Infinity);
+  });
+});

--- a/SudokuApp/utils/__tests__/symbolSets.test.js
+++ b/SudokuApp/utils/__tests__/symbolSets.test.js
@@ -1,0 +1,158 @@
+import {
+  REGION_PALETTES,
+  getRegionColor,
+  getRegionPalette,
+  getSymbolLabel,
+  resolveSymbol,
+  SYMBOL_SET_IDS,
+} from '../symbolSets';
+import { closestPair, contrastRatio, deltaE, hexToLab } from '../color';
+
+/**
+ * The region palette's readability is a *measured* property, not a matter of
+ * taste, so it gets a floor. The first palette tinted every hue toward white by
+ * the same amount and left sky blue and blue only ΔE 6.67 apart — indistinguishable
+ * at 8×8. If a future tweak softens the palette back into that state, these
+ * tests fail instead of the operator discovering it on a device.
+ */
+
+// Comfortably below what the tuned palettes achieve (17.11 light / 18.55 dark),
+// but far above the ΔE 6.67 that motivated the fix.
+const MIN_PAIR_DISTANCE = 15;
+
+// WCAG 2.1 SC 1.4.11: non-text graphics need 3:1. Glyph ink aims higher.
+const MIN_GRAPHIC_CONTRAST = 3;
+const MIN_INK_CONTRAST = 4.5;
+
+describe.each([
+  ['light', REGION_PALETTES.light, { lMin: 65, lMax: 97 }],
+  ['dark', REGION_PALETTES.dark, { lMin: 15, lMax: 55 }],
+])('the %s region palette', (mode, palette, band) => {
+  const fills = palette.map((entry) => entry.background);
+
+  it('covers all nine regions', () => {
+    expect(palette).toHaveLength(9);
+  });
+
+  it('has a stable name for every region', () => {
+    const names = palette.map((entry) => entry.name);
+    expect(names.every((name) => typeof name === 'string' && name.length > 0)).toBe(true);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('uses a distinct fill for every region', () => {
+    expect(new Set(fills).size).toBe(fills.length);
+  });
+
+  it(`keeps every pair at least ΔE ${MIN_PAIR_DISTANCE} apart`, () => {
+    const worst = closestPair(fills);
+    const name = (hex) => palette.find((entry) => entry.background === hex)?.name;
+
+    // Asserting on the labelled pair rather than the bare number, so a
+    // regression reports *which* two regions collided instead of just "6.67 is
+    // not >= 15" — that is the first thing anyone re-tuning will want to know.
+    expect({
+      worstPair: `${name(worst.a)} vs ${name(worst.b)}`,
+      tooClose: worst.distance < MIN_PAIR_DISTANCE,
+    }).toEqual({
+      worstPair: expect.any(String),
+      tooClose: false,
+    });
+  });
+
+  it('separates the two blues, the pair that originally collided', () => {
+    const skyBlue = palette.find((entry) => entry.name === 'sky blue').background;
+    const blue = palette.find((entry) => entry.name === 'blue').background;
+
+    expect(deltaE(skyBlue, blue)).toBeGreaterThanOrEqual(MIN_PAIR_DISTANCE);
+  });
+
+  it('separates orange from yellow, the runner-up collision', () => {
+    const orange = palette.find((entry) => entry.name === 'orange').background;
+    const yellow = palette.find((entry) => entry.name === 'yellow').background;
+
+    expect(deltaE(orange, yellow)).toBeGreaterThanOrEqual(MIN_PAIR_DISTANCE);
+  });
+
+  it(`keeps every fill inside the ${mode} lightness band`, () => {
+    // This is what stops a future re-tune from "fixing" separation by turning
+    // the board into nine saturated blocks that swamp the mushroom glyph.
+    fills.forEach((fill) => {
+      const { L } = hexToLab(fill);
+      expect(L).toBeGreaterThanOrEqual(band.lMin);
+      expect(L).toBeLessThanOrEqual(band.lMax);
+    });
+  });
+
+  it('gives every fill legible glyph ink', () => {
+    palette.forEach((entry) => {
+      expect(contrastRatio(entry.background, entry.ink)).toBeGreaterThanOrEqual(
+        MIN_INK_CONTRAST
+      );
+    });
+  });
+
+  it('gives every fill a visible conflict color', () => {
+    palette.forEach((entry) => {
+      expect(contrastRatio(entry.background, entry.conflictInk)).toBeGreaterThanOrEqual(
+        MIN_GRAPHIC_CONTRAST
+      );
+    });
+  });
+});
+
+describe('getRegionPalette / getRegionColor', () => {
+  it('defaults to the light palette', () => {
+    expect(getRegionPalette()).toBe(REGION_PALETTES.light);
+    expect(getRegionPalette(false)).toBe(REGION_PALETTES.light);
+  });
+
+  it('returns the dark palette when asked', () => {
+    expect(getRegionPalette(true)).toBe(REGION_PALETTES.dark);
+  });
+
+  it('maps region ids to entries', () => {
+    expect(getRegionColor(0).name).toBe(REGION_PALETTES.light[0].name);
+    expect(getRegionColor(0, true).background).toBe(REGION_PALETTES.dark[0].background);
+  });
+
+  it('wraps around for ids beyond the palette', () => {
+    expect(getRegionColor(9).name).toBe(getRegionColor(0).name);
+    expect(getRegionColor(13).name).toBe(getRegionColor(4).name);
+  });
+
+  it('keeps light and dark aligned so a region keeps its identity across themes', () => {
+    REGION_PALETTES.light.forEach((entry, index) => {
+      expect(REGION_PALETTES.dark[index].name).toBe(entry.name);
+      expect(REGION_PALETTES.dark[index].color).toBe(entry.color);
+    });
+  });
+});
+
+describe("Sudoku's symbol seam is untouched", () => {
+  it('still resolves numbers to their digit', () => {
+    expect(resolveSymbol(SYMBOL_SET_IDS.NUMBERS, 5)).toEqual({
+      kind: 'text',
+      value: 5,
+      text: '5',
+      label: '5',
+    });
+    expect(getSymbolLabel(SYMBOL_SET_IDS.NUMBERS, 7)).toBe('7');
+  });
+
+  it('still resolves the fungiku mushroom and swatches', () => {
+    expect(resolveSymbol(SYMBOL_SET_IDS.FUNGIKU, 1)).toMatchObject({
+      kind: 'icon',
+      icon: 'mushroom',
+      label: 'mushroom',
+    });
+    expect(resolveSymbol(SYMBOL_SET_IDS.FUNGIKU, 3)).toMatchObject({
+      kind: 'swatch',
+      label: 'sky blue',
+    });
+  });
+
+  it('falls back to the digit for an unknown set', () => {
+    expect(resolveSymbol('nope', 4).kind).toBe('text');
+  });
+});

--- a/SudokuApp/utils/appTheme.js
+++ b/SudokuApp/utils/appTheme.js
@@ -1,0 +1,36 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+/**
+ * The shell's theme preference, under its own key.
+ *
+ * Step 3 had the hub and Fungiku read `currentThemeName` out of *Sudoku's* saved
+ * game — expedient, but it meant the shell depended on a Sudoku implementation
+ * detail, and the theme vanished whenever there was no saved Sudoku game to read
+ * it from. The preference is app-level, so it gets an app-level key.
+ *
+ * Sudoku still keeps the theme in its own reducer state (that is what it renders
+ * from) and writes through to this key whenever the player cycles the theme, so
+ * there is one preference and the shell follows it.
+ */
+export const APP_THEME_KEY = '@AppTheme';
+
+/** @returns {Promise<string|null>} the saved theme name, or null if unset. */
+export const loadAppThemeName = async () => {
+  try {
+    return await AsyncStorage.getItem(APP_THEME_KEY);
+  } catch (error) {
+    console.error('Error loading app theme:', error);
+    return null;
+  }
+};
+
+/** Persist the shell's theme name. Failures are non-fatal — the theme is a preference. */
+export const saveAppThemeName = async (themeName) => {
+  try {
+    if (typeof themeName === 'string' && themeName.length > 0) {
+      await AsyncStorage.setItem(APP_THEME_KEY, themeName);
+    }
+  } catch (error) {
+    console.error('Error saving app theme:', error);
+  }
+};

--- a/SudokuApp/utils/color.js
+++ b/SudokuApp/utils/color.js
@@ -1,0 +1,220 @@
+/**
+ * Small color-math helpers, used to keep the Fungiku region palette honestly
+ * distinguishable rather than distinguishable-looking-in-one-screenshot.
+ *
+ * Why this exists: the region fills are pastel tints of the Okabe–Ito palette,
+ * and tinting every hue toward white by the same amount compressed them toward a
+ * common light gray — at 8×8, sky blue and blue read as the same color. Judging
+ * that by eye is how the bug got in, so `deltaE` gives it a number and a unit
+ * test puts a floor under it (see utils/__tests__/color.test.js and
+ * symbolSets.js).
+ *
+ * Pure JS, no dependencies, no React — runs in the node-env test runner.
+ */
+
+/** '#rrggbb' → { r, g, b } in 0–255. */
+export const hexToRgb = (hex) => {
+  const n = parseInt(hex.slice(1), 16);
+  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+};
+
+/** { r, g, b } in 0–255 → '#rrggbb'. */
+export const rgbToHex = ({ r, g, b }) => {
+  const clamp = (v) => Math.max(0, Math.min(255, Math.round(v)));
+  return `#${((1 << 24) | (clamp(r) << 16) | (clamp(g) << 8) | clamp(b)).toString(16).slice(1)}`;
+};
+
+/**
+ * Blend `hex` toward `target` by `weight` (0 = unchanged, 1 = fully target).
+ *
+ * This generalizes the old `mixWithWhite`: region fills tint toward white on a
+ * light theme and toward the theme's dark surface on a dark one, so the same
+ * hues work on both.
+ */
+export const mix = (hex, target, weight) => {
+  const a = hexToRgb(hex);
+  const b = hexToRgb(target);
+  const w = Math.max(0, Math.min(1, weight));
+  return rgbToHex({
+    r: a.r + (b.r - a.r) * w,
+    g: a.g + (b.g - a.g) * w,
+    b: a.b + (b.b - a.b) * w,
+  });
+};
+
+const srgbToLinear = (channel) => {
+  const c = channel / 255;
+  return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+};
+
+/** WCAG relative luminance, 0 (black) to 1 (white). */
+export const relativeLuminance = (hex) => {
+  const { r, g, b } = hexToRgb(hex);
+  return (
+    0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b)
+  );
+};
+
+/** WCAG contrast ratio between two colors, 1 (identical) to 21 (black/white). */
+export const contrastRatio = (a, b) => {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const lighter = Math.max(la, lb);
+  const darker = Math.min(la, lb);
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+/**
+ * Pick whichever of `dark`/`light` reads better on `background`. Used so a
+ * glyph drawn on a region fill stays legible in every theme instead of being
+ * hardcoded for the pastel ones.
+ */
+export const readableOn = (background, dark = '#1a1a1a', light = '#ffffff') =>
+  contrastRatio(background, dark) >= contrastRatio(background, light) ? dark : light;
+
+// D65 white point, matching sRGB.
+const WHITE_X = 95.047;
+const WHITE_Y = 100.0;
+const WHITE_Z = 108.883;
+
+/** sRGB hex → CIELAB { L, a, b }. */
+export const hexToLab = (hex) => {
+  const { r, g, b } = hexToRgb(hex);
+  const rl = srgbToLinear(r) * 100;
+  const gl = srgbToLinear(g) * 100;
+  const bl = srgbToLinear(b) * 100;
+
+  // sRGB → XYZ (D65)
+  const x = (rl * 0.4124 + gl * 0.3576 + bl * 0.1805) / WHITE_X;
+  const y = (rl * 0.2126 + gl * 0.7152 + bl * 0.0722) / WHITE_Y;
+  const z = (rl * 0.0193 + gl * 0.1192 + bl * 0.9505) / WHITE_Z;
+
+  const f = (t) => (t > 216 / 24389 ? Math.cbrt(t) : (841 / 108) * t + 4 / 29);
+  const fx = f(x);
+  const fy = f(y);
+  const fz = f(z);
+
+  return { L: 116 * fy - 16, a: 500 * (fx - fy), b: 200 * (fy - fz) };
+};
+
+const deg = (rad) => (rad * 180) / Math.PI;
+const rad = (d) => (d * Math.PI) / 180;
+
+/**
+ * CIEDE2000 perceptual difference between two colors.
+ *
+ * Worth the extra algebra over the simpler CIE76: CIE76 *overstates* how
+ * different saturated blues are, and blues are exactly the pair this palette
+ * was failing on — so the simpler formula would have happily passed the bug.
+ *
+ * Rule of thumb: ~1 is the just-noticeable threshold, ~10 reads as "clearly a
+ * different color" at a glance.
+ *
+ * Implementation follows Sharma, Wu & Dalal (2005); the published test vectors
+ * are pinned in utils/__tests__/color.test.js.
+ */
+export const deltaE = (hexA, hexB) => {
+  const { L: L1, a: a1, b: b1 } = hexToLab(hexA);
+  const { L: L2, a: a2, b: b2 } = hexToLab(hexB);
+
+  const C1 = Math.hypot(a1, b1);
+  const C2 = Math.hypot(a2, b2);
+  const Cbar = (C1 + C2) / 2;
+
+  const Cbar7 = Cbar ** 7;
+  const G = 0.5 * (1 - Math.sqrt(Cbar7 / (Cbar7 + 25 ** 7)));
+  const a1p = (1 + G) * a1;
+  const a2p = (1 + G) * a2;
+
+  const C1p = Math.hypot(a1p, b1);
+  const C2p = Math.hypot(a2p, b2);
+
+  const hp = (ap, bp) => {
+    if (ap === 0 && bp === 0) return 0;
+    const h = deg(Math.atan2(bp, ap));
+    return h >= 0 ? h : h + 360;
+  };
+  const h1p = hp(a1p, b1);
+  const h2p = hp(a2p, b2);
+
+  const dLp = L2 - L1;
+  const dCp = C2p - C1p;
+
+  let dhp;
+  if (C1p * C2p === 0) {
+    dhp = 0;
+  } else if (Math.abs(h2p - h1p) <= 180) {
+    dhp = h2p - h1p;
+  } else if (h2p - h1p > 180) {
+    dhp = h2p - h1p - 360;
+  } else {
+    dhp = h2p - h1p + 360;
+  }
+  const dHp = 2 * Math.sqrt(C1p * C2p) * Math.sin(rad(dhp) / 2);
+
+  const Lbarp = (L1 + L2) / 2;
+  const Cbarp = (C1p + C2p) / 2;
+
+  let hbarp;
+  if (C1p * C2p === 0) {
+    hbarp = h1p + h2p;
+  } else if (Math.abs(h1p - h2p) <= 180) {
+    hbarp = (h1p + h2p) / 2;
+  } else if (h1p + h2p < 360) {
+    hbarp = (h1p + h2p + 360) / 2;
+  } else {
+    hbarp = (h1p + h2p - 360) / 2;
+  }
+
+  const T =
+    1 -
+    0.17 * Math.cos(rad(hbarp - 30)) +
+    0.24 * Math.cos(rad(2 * hbarp)) +
+    0.32 * Math.cos(rad(3 * hbarp + 6)) -
+    0.2 * Math.cos(rad(4 * hbarp - 63));
+
+  const dTheta = 30 * Math.exp(-(((hbarp - 275) / 25) ** 2));
+  const Cbarp7 = Cbarp ** 7;
+  const RC = 2 * Math.sqrt(Cbarp7 / (Cbarp7 + 25 ** 7));
+  const RT = -RC * Math.sin(rad(2 * dTheta));
+
+  const SL = 1 + (0.015 * (Lbarp - 50) ** 2) / Math.sqrt(20 + (Lbarp - 50) ** 2);
+  const SC = 1 + 0.045 * Cbarp;
+  const SH = 1 + 0.015 * Cbarp * T;
+
+  return Math.sqrt(
+    (dLp / SL) ** 2 +
+      (dCp / SC) ** 2 +
+      (dHp / SH) ** 2 +
+      RT * (dCp / SC) * (dHp / SH)
+  );
+};
+
+/**
+ * The closest pair in a list of colors, as `{ a, b, distance }`. The palette
+ * test asserts on this: a palette is only as readable as its worst pair.
+ */
+export const closestPair = (hexes) => {
+  let worst = { a: null, b: null, distance: Infinity };
+  for (let i = 0; i < hexes.length; i++) {
+    for (let j = i + 1; j < hexes.length; j++) {
+      const distance = deltaE(hexes[i], hexes[j]);
+      if (distance < worst.distance) {
+        worst = { a: hexes[i], b: hexes[j], distance };
+      }
+    }
+  }
+  return worst;
+};
+
+export default {
+  hexToRgb,
+  rgbToHex,
+  mix,
+  relativeLuminance,
+  contrastRatio,
+  readableOn,
+  hexToLab,
+  deltaE,
+  closestPair,
+};

--- a/SudokuApp/utils/symbolSets.js
+++ b/SudokuApp/utils/symbolSets.js
@@ -17,6 +17,8 @@
  * corner/shape cue (`corners`) so color is never the only channel of identity.
  */
 
+import { mix, readableOn } from './color';
+
 export const SYMBOL_SET_IDS = { NUMBERS: 'numbers', FUNGIKU: 'fungiku' };
 
 // Which cell value is drawn as the mushroom (the "star"). Fixed per game — it's
@@ -52,36 +54,92 @@ const FUNGIKU_SWATCHES = {
  * source of color truth; the mushroom's own red rounds the list out to nine, one
  * per region for boards up to 9×9.
  *
- * Each entry carries the saturated `color` (borders, labels, emphasis) and a
- * pastel `background` for filling a whole cell — the reference art is a soft
- * pastel grid, and a full cell of saturated Okabe–Ito would overwhelm the
- * mushroom drawn on top of it. `name` stays the stable, non-visual identity used
- * for accessibility labels.
+ * Each entry carries the saturated `color` (borders, labels, emphasis), a
+ * `background` that fills a whole cell, an `ink` color guaranteed to be legible
+ * on that background, and the `conflictInk` used to flag a rule-breaking
+ * mushroom. `name` stays the stable, non-visual identity used for accessibility
+ * labels.
+ *
+ * ### Why the fills are tuned per hue rather than tinted uniformly
+ *
+ * The first version tinted every hue toward white by the same 0.62. That reads
+ * fine at 5×5 with four regions, and falls apart at 8×8: **sky blue and blue
+ * came out only ΔE 6.67 apart** (roughly "the same color, slightly different"),
+ * with orange/yellow and several others close behind — 7 of 36 pairs under
+ * ΔE 15. Okabe–Ito is colorblind-safe at full saturation, but a uniform tint
+ * pulls every hue toward a common light gray and throws that away.
+ *
+ * The fix is to vary **lightness as well as hue**: each hue gets its own tint
+ * weight, chosen by maximizing the worst pairwise CIEDE2000 distance subject to
+ * every fill staying inside a lightness band (so the board is still a soft grid,
+ * not nine saturated blocks). That search gives:
+ *
+ *   light theme: worst pair ΔE 17.11, **0 of 36 pairs under 15**
+ *   dark theme:  worst pair ΔE 18.55, 0 of 36 pairs under 15
+ *
+ * `utils/__tests__/symbolSets.test.js` pins a floor under those numbers, so a
+ * future "let's soften the palette" tweak fails a test instead of quietly
+ * reintroducing the bug. Re-tune with the same objective rather than by eye.
  */
-const mixWithWhite = (hex, weight) => {
-  const n = parseInt(hex.slice(1), 16);
-  const blend = (channel) => Math.round(channel + (255 - channel) * weight);
-  const r = blend((n >> 16) & 255);
-  const g = blend((n >> 8) & 255);
-  const b = blend(n & 255);
-  return `#${((1 << 24) | (r << 16) | (g << 8) | b).toString(16).slice(1)}`;
-};
-
-export const REGION_COLORS = [
+const HUE_ORDER = [
   ...Object.keys(FUNGIKU_SWATCHES)
     .map(Number)
     .sort((a, b) => a - b)
     .map((value) => FUNGIKU_SWATCHES[value]),
   MUSHROOM,
-].map(({ color, name }) => ({
-  color,
-  name,
-  background: mixWithWhite(color, 0.62),
-}));
+];
+
+// Order matches HUE_ORDER: orange, sky blue, green, yellow, blue, red, pink,
+// gray, mushroom-red. Tuned, not picked by hand — see the note above.
+const LIGHT_TINTS = [0.1, 0.76, 0.62, 0.1, 0.46, 0.62, 0.7, 0.44, 0.54];
+const DARK_TINTS = [0.7, 0.38, 0.55, 0.55, 0.54, 0.12, 0.24, 0.18, 0.55];
+
+// What the fills are blended toward. Dark themes blend toward a dark surface
+// instead of white — pastel fills on a near-black background were the untested
+// case, and they glared.
+const LIGHT_SURFACE = '#ffffff';
+const DARK_SURFACE = '#1e1e1e';
+
+/**
+ * Conflict colors, one per mode. Both clear WCAG's 3:1 floor for non-text
+ * graphics against *every* fill in their palette (light 5.64:1, dark 3.10:1) —
+ * the obvious `#C1272D` only managed 2.55:1 on the warmer fills, which is why
+ * the conflict marker is not simply "the mushroom, but red".
+ */
+const CONFLICT_INK = { light: '#6B0000', dark: '#FFC9C9' };
+
+const buildRegionPalette = (surface, tints, conflictInk) =>
+  HUE_ORDER.map(({ color, name }, index) => {
+    const background = mix(color, surface, tints[index]);
+    return {
+      color,
+      name,
+      background,
+      // Guaranteed-legible glyph color for this fill, rather than the region's
+      // own hue: at these tints a saturated orange mushroom on an orange fill
+      // would be nearly invisible.
+      ink: readableOn(background),
+      conflictInk,
+    };
+  });
+
+export const REGION_PALETTES = {
+  light: buildRegionPalette(LIGHT_SURFACE, LIGHT_TINTS, CONFLICT_INK.light),
+  dark: buildRegionPalette(DARK_SURFACE, DARK_TINTS, CONFLICT_INK.dark),
+};
+
+/** The light palette, kept as a name for the default set. */
+export const REGION_COLORS = REGION_PALETTES.light;
+
+/** The whole palette for a mode. */
+export function getRegionPalette(isDark = false) {
+  return isDark ? REGION_PALETTES.dark : REGION_PALETTES.light;
+}
 
 /** The palette entry for a region id, wrapping around if ids exceed the palette. */
-export function getRegionColor(regionId) {
-  return REGION_COLORS[regionId % REGION_COLORS.length];
+export function getRegionColor(regionId, isDark = false) {
+  const palette = getRegionPalette(isDark);
+  return palette[regionId % palette.length];
 }
 
 /**

--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -92,103 +92,102 @@ operator to test in Expo Go.**
 
 ---
 
-## Next step: **Step 5 — the real board UI**
+## Next step: **Step 6 — drag to sweep X's (+ the auto-X assist)**
 
-Branch: **`feature/fungiku-board`** off `epic/fungiku`.
-Plan: **§3 (the board)**, **§5 (accessibility)**, plus the §7 table row for step 5.
+Branch: **`feature/fungiku-input`** off `epic/fungiku`.
+Plan: **§2, and specifically the "Drag to sweep X's" subsection** — the operator
+asked for this directly, and that subsection is the spec. Read it before anything
+else.
 
 ### Why this step exists
 
-Fungiku is playable, but it is playable on **the engine preview's rough grid**:
-flat pastel fills, hairline borders, a plain green banner for a win, and one
-hardcoded 320px board that ignores the screen it is on. Sudoku's board is themed,
-responsive and animated; Fungiku's is not. This step makes the board look like
-part of the same app.
-
-**It is also where the palette problem gets fixed** — see below. That is the one
-item here with a real correctness angle, not just polish.
+**Ruling out cells is the most repetitive thing about playing Fungiku.** Once you
+know a mushroom can't be anywhere along a row, or anywhere touching one you have
+already placed, you currently tap each of those cells individually — and each one
+takes *one* tap to reach X. The operator's words: *"I want to be able to drag my
+finger to place Xs in places where mushrooms wouldn't be."* This is the gesture
+that makes X's cheap enough to actually reason with, and it is the last thing
+standing between the current build and a game that feels good to play.
 
 ### Read first
 
-- `SudokuApp/games/fungiku/FungikuBoard.js` — what you are replacing. Note what
-  it already gets right and must keep: region-boundary borders (thick edge
-  wherever the neighbor's region differs), the conflict ring *plus* red glyph so
-  the signal is not color-only, and per-cell accessibility labels of the form
-  `Row 1, column 4, orange region, mushroom, conflict`. **Do not regress those
-  labels — the Playwright drive-through addresses cells through them.**
-- `SudokuApp/utils/symbolSets.js` — `REGION_COLORS` / `getRegionColor` and the
-  `mixWithWhite(color, 0.62)` that generates the pastel fills. **This is the
-  palette bug's home.** Each entry also carries a `corners` shape cue that the
-  Fungiku board does not use yet.
-- `SudokuApp/components/Grid.js` + `components/Cell.js` — how Sudoku's board
-  handles theming, selection and sizing. The reference for what "themed" means
-  here; don't refactor them.
-- `SudokuApp/screens/GameScreen.js` — `useGridContainerSize()` is the existing
-  responsive-sizing hook (web gets `min(width,height) * 0.7` clamped 270–450,
-  native gets a fixed 324). Fungiku's board should size the same way instead of
-  its own `BOARD_MAX = 320`.
-- `SudokuApp/utils/themes.js` — the seven themes a Fungiku board has to look
-  right in. `classic`/`pastel` are the easy ones; **check `dark`** — today's
-  pastel fills on a dark background are the untested case.
-- `SudokuApp/hooks/useAppTheme.js` — reads the theme name out of *Sudoku's* saved
-  state as a stopgap. Promoting this to a real app-level theme owned by the shell
-  belongs in this step (see scope 5).
+- **`docs/fungiku-plan.md` §2, "Drag to sweep X's"** — the behavior spec: drag
+  paints X and never cycles, the first cell decides paint-vs-erase for the whole
+  stroke, mushrooms are never overwritten, one undo entry per stroke, and fast
+  diagonal strokes must fill every cell crossed. Both hazards are written up
+  there too; do not skip them.
+- `SudokuApp/games/fungiku/FungikuBoard.js` — what you are changing. Today every
+  cell is its own `TouchableOpacity` with an `onPress`. A drag needs a **single
+  responder over the whole board** that maps a point to a cell, so this is the
+  one real restructure in the step.
+- `SudokuApp/games/fungiku/reducer.js` — `CYCLE_CELL` and `CLEAR_MARKS` are the
+  models to copy. `pushHistory` already snapshots the whole `marks` array, which
+  is exactly what "one undo entry per stroke" needs — add a `PAINT_CELLS`-style
+  action that applies a whole stroke through one `pushHistory`, rather than
+  dispatching per cell.
+- `SudokuApp/hooks/useBoardSize.js` — the board's pixel size, which you need to
+  turn a touch point into a row/column.
+- `SudokuApp/games/fungiku/__tests__/reducer.test.js` — extend this. The stroke
+  reducer is pure and deserves the same coverage as cycling.
 
 ### Scope — ONLY this
 
-1. **🎨 Palette tuning pass — do this first, it is the real bug.** At 7×7 and 8×8
-   the pastel fills collide: **sky blue vs. blue** are nearly indistinguishable,
-   and **orange vs. yellow** are close behind. Okabe–Ito is colorblind-safe at
-   full saturation, but `mixWithWhite(…, 0.62)` compresses the hues toward a
-   common light gray. Fix it properly — vary lightness as well as hue so adjacent
-   regions differ on two channels, and **consider using the `corners` shape cue
-   that already exists in `symbolSets.js`** so identity never rests on color
-   alone. Verify at 8×8 across several seeds, not just one.
-2. **The real board component** — themed cell fills, borders and region outlines
-   drawn from `utils/themes.js` rather than hardcoded `#33333355`, and a board
-   that sizes to the screen via the same approach as `useGridContainerSize()`.
-3. **The win flow** — today a win is a static green banner. Give it the app's
-   motion language (Sudoku has `WinModal` and a score animation to look at) and
-   decide whether Fungiku wins in a modal or in place. Note the small bug: the
-   counter hint still reads "Tap a cell: empty → ✕ → 🍄" after a win.
-4. **Accessibility beyond the labels** — the labels are already good; add the
-   things a themed board can lose: adequate contrast for the X glyph and the
-   mushroom against every theme's fills, and a non-color cue for conflict that
-   survives a dark theme.
-5. **App-level theme** — replace `useAppTheme`'s read of Sudoku's saved state
-   with a theme the shell owns, so the hub and Fungiku aren't inheriting a
-   Sudoku implementation detail. Sudoku keeps its own `CHANGE_THEME` behavior;
-   this is about where the *shell's* theme comes from.
+1. **The drag gesture on the board.** One `PanResponder` on the board container;
+   resolve the cell under the finger and paint as the stroke moves.
+2. **A stroke action in the reducer** — takes the set of cells and the mode
+   (paint X / erase to empty), applies it in one go, records **one** undo entry,
+   and skips mushroom cells.
+3. **Taps keep working exactly as they do now**, including the full
+   `empty → X → 🍄 → empty` cycle and the accessibility labels. A tap is a
+   degenerate stroke only if that does not change tap behavior — otherwise keep
+   the tap path separate.
+4. **Auto-X assist (the other half of §2's assist bullet)** — a toggle that, when
+   a mushroom is placed, fills X into that mushroom's row, column, region and
+   eight neighbors. **Off by default** unless the operator answers §8 #5
+   otherwise. Reuse the same stroke action so it is one undo entry.
+5. **Extend the Jest suite** for the stroke reducer and the auto-X fill.
 
 ### Behaviors that are easy to get wrong
 
-- **Region outlines are the board's structure** (plan §3). They replace Sudoku's
-  3×3 box lines and are how the player sees the regions at all — if the themed
-  restyle makes them subtle, the puzzle becomes unreadable.
-- **Don't let theming swallow the conflict signal.** Conflict has to stay obvious
-  on a pastel fill *and* on a dark theme.
-- **Keep the accessibility labels stable.** They are the test seam.
-- **Don't touch the engine or the reducer.** This step is rendering. If a rule
-  question comes up, the answer is already in `engine.js`.
-- **8×8 is the stress case** for both palette and layout — a 320px board at 8×8
-  gives 40px cells; check the mushroom glyph and X are still legible.
+- **`locationX`/`locationY` lie on the new architecture.** In a `PanResponder`
+  they are relative to the touched *child*, not the responder. Use
+  `pageX`/`pageY` minus the board's measured origin, and **re-measure at gesture
+  grant**, not only on layout — this screen's board sits under a win banner that
+  mounts and unmounts, so the board moves. (§2 has the full note; the sibling
+  color-loop app lost time to exactly this.)
+- **The board lives inside a `ScrollView`.** A vertical drag will fight it. You
+  will need to claim the responder deliberately (and probably
+  `onMoveShouldSetPanResponderCapture`) so a sweep paints instead of scrolling —
+  and check that the page can still be scrolled by dragging *outside* the board.
+- **Interpolate between move events.** A fast stroke delivers sparse points; walk
+  the line between consecutive points, or a quick swipe leaves gaps.
+- **Never overwrite a mushroom.** Losing a deduced placement to a stray swipe is
+  the worst failure this feature can have.
+- **Don't regress the accessibility labels.** They are how the browser tests
+  address cells, and they are Fungiku's only non-visual channel.
 
 ### Out of scope for this step
 
-- **No assists, ladder or scoring** — auto-X, level progression and scoring are
-  Step 6, including the §8 #5 assist-default question.
-- **No art swap** — static mushroom PNGs are the floating Step 7.
-- **No new game logic.** Marks, conflicts, win detection, undo/redo and
-  persistence all landed in Step 4 and are covered by 107 passing tests.
-- **No Sudoku restyling.** Read `Grid`/`Cell` for reference; leave them alone.
+- **No ladder, progression or scoring** — that is Step 7.
+- **No art swap** — Step 8, and it is gated on artwork rather than code.
+- **No engine or win-detection changes.** X's still have no effect on winning; a
+  drag that fills the whole board with X's must not win it (there is already a
+  test for that shape — keep it green).
 
 ### Visible in Expo Go when this lands
 
-A Fungiku board that looks like it belongs in the app: themed to match whatever
-theme is active, sized to the screen, with **eight visually distinct regions at
-8×8** and a win that feels like a win. Verify in a browser across at least
-`classic` and `dark`, at 5×5 and 8×8, no page errors, and screenshot 8×8 in two
-themes so the palette fix is reviewable side by side.
+**Swipe a finger across a row of cells and watch them all become ✕ in one
+motion**, then swipe back over them to clear them, with a single Undo taking back
+the whole sweep. Turn the auto-X toggle on, place a mushroom, and watch its row,
+column, region and neighbors fill themselves in.
+
+### ⚠️ This step cannot be signed off in a browser
+
+Playwright can fake a mouse drag on the web build and you **should** add that —
+it will catch the geometry being wrong. But whether the gesture fights the
+ScrollView, whether a tap-with-jitter accidentally paints, and whether the stroke
+feels responsive under a real thumb are all device questions. **Get an Expo Go
+pass from the operator before this merges**, and say so in the PR.
 
 ## Open questions for the operator (carry these forward)
 
@@ -214,8 +213,6 @@ themes so the palette fix is reviewable side by side.
   are. Leaving for the hub and returning gives you your board back with an empty
   undo stack. Deliberate (the stacks are mark snapshots and would bloat the save);
   revisit only if it bothers the operator.
-- **The counter hint doesn't change after a win** — it still reads "Tap a cell:
-  empty → ✕ → 🍄". Folded into Step 5's win flow.
 - **Quitting a Sudoku game doesn't clear its save.** `saveState` skips writing
   when `gameStarted` is false, so the previous snapshot survives "New Game" until
   a difficulty is picked. Pre-existing, and self-consistent (the hub's Continue
@@ -224,9 +221,15 @@ themes so the palette fix is reviewable side by side.
 - **Re-entering a game from the hub always lands on the Pause modal**, because a
   restored game is a paused game. Correct, but it means the header (and the way
   back home) is behind one Resume tap.
-- **`useAppTheme` reads the theme out of Sudoku's saved state** so the hub and
-  Fungiku follow the player's choice. Promoting this to a shell-owned theme is
-  now **scope item 5 of Step 5**.
+- **Sudoku still keeps its own copy of the theme.** Step 5 moved the *shell* off
+  Sudoku's saved game and onto `@AppTheme` (`utils/appTheme.js`), and Sudoku
+  writes through to it when the player cycles themes — but Sudoku still hydrates
+  its own `currentThemeName` from its own save. Making Sudoku read the shared key
+  is the other half, and it touches Sudoku's hydration path, so it was left out.
+- **The region palette is tuned, not hand-picked.** `utils/symbolSets.js` derives
+  its fills from per-hue tint weights chosen by maximizing the worst pairwise
+  CIEDE2000 distance under a lightness band. `utils/__tests__/symbolSets.test.js`
+  holds the floor. **Re-tune with the same objective — do not eyeball it.**
 
 ## Steps already done
 
@@ -236,5 +239,6 @@ themes so the palette fix is reviewable side by side.
 | 1 | Rendering seam — `Symbol.js` + `symbolSets.js` | merged to `main` (#67) |
 | — | ~~Symbol-set toggle on the Sudoku board~~ | closed unmerged (#68) — superseded by the replan |
 | 2 | Replan + engine + preview + hub design | merged to `epic/fungiku` (#69, `fecb271`) |
-| 3 | Game shell + hub — router, registry, `HubScreen`, `FungikuScreen`, back-to-hub | PR to `epic/fungiku` |
-| 4 | Fungiku state — reducer, tap-to-cycle marks, live conflicts, win, undo/redo, own-key persistence | PR to `epic/fungiku` |
+| 3 | Game shell + hub — router, registry, `HubScreen`, `FungikuScreen`, back-to-hub | merged to `epic/fungiku` (#70, `a9caf92`) |
+| 4 | Fungiku state — reducer, tap-to-cycle marks, live conflicts, win, undo/redo, own-key persistence | merged to `epic/fungiku` (#70, `a9caf92`) |
+| 5 | Board UI — palette fix with a tested ΔE floor, themed + responsive board, animated win | PR to `epic/fungiku` |

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -101,6 +101,47 @@ empty → X (eliminated) → 🍄 (mushroom) → empty
 
 No number pad. No 3×3 notes mini-grid. No digit feedback.
 
+### Drag to sweep X's across a run of cells (operator request, 2026-07-25)
+
+Tapping each cell to rule it out is the most repetitive thing about playing
+Fungiku: once you know a mushroom can't be anywhere in a row, a region edge or a
+mushroom's neighborhood, you want to **swipe a finger across those cells and have
+them all become X**, not tap eight times. This is the paint gesture every
+Star-Battle app has, and it is what makes X's cheap enough to actually use for
+reasoning.
+
+Behavior, so it stays predictable:
+
+- **Drag paints X, it does not cycle.** A tap keeps the full
+  `empty → X → 🍄 → empty` cycle; a drag only ever writes X. Cycling under a
+  moving finger would scatter mushrooms across the board.
+- **The first cell of the drag decides the whole stroke.** Starting on an empty
+  cell paints X; starting on an X **erases** back to empty (the same
+  paint/erase convention as a drawing app). Either way the mode is fixed for the
+  stroke, so dragging back over your own path doesn't flip cells twice.
+- **Mushrooms are never overwritten by a drag.** A stroke passing over a placed
+  mushroom skips it. Losing a deduced placement to a stray swipe would be the
+  worst possible failure here.
+- **One undo entry per stroke, not per cell.** The reducer already snapshots
+  `marks`, so a stroke is a single snapshot taken at gesture start — undo takes
+  back the whole sweep.
+- **Diagonal and fast strokes must fill every cell crossed**, not just the ones
+  a move event happened to land in.
+
+Two hazards worth knowing before writing the gesture:
+
+1. **`locationX`/`locationY` are unreliable on the new architecture** — in a
+   `PanResponder` they are relative to the touched *child* view, not the
+   responder. Resolve the cell from `pageX`/`pageY` minus the board's measured
+   origin, and re-measure at gesture grant rather than only on layout, because a
+   flex-centered board shifts when banners appear. (The sibling color-loop app
+   was bitten by exactly this on the SDK 54 upgrade, in both its games *and* a
+   slider.)
+2. **A drag gesture cannot be verified in simulation.** Playwright can fake a
+   mouse drag on the web build, and that is worth having, but touch feel — does
+   it fight the ScrollView, does it fire on a tap-with-jitter — is a device
+   question. This one needs an Expo Go pass before it merges.
+
 ## 3. The board
 
 - **Region color = cell background**, filling the whole cell (the reference is a
@@ -218,9 +259,16 @@ the step's real acceptance test, alongside its automated checks.
 | 2 | ~~**Engine**~~ ✅ merged (#69) — seeded generator, solver, uniqueness, shared `findConflicts` / `isSolved`, Jest tests | **Engine preview**: generated boards with their color regions and solution mushrooms; switch size 5–8, reseed, show/hide the solution |
 | 3 | ~~**Game shell + hub**~~ ✅ (§6) — screen router, game registry, hub screen, back-to-hub, Fungiku's own screen | **The hub**: app opens on a home screen with **Sudoku and Fungiku side by side as peers**; Fungiku is a real destination, not a button in Sudoku's menu |
 | 4 | ~~**State**~~ ✅ — reducer + context: mark cycling, live conflict validation, win detection, undo/redo, persistence | The Fungiku screen becomes **playable**: tap-to-cycle X/🍄, live conflict highlighting, `🍄 X/N` counter, win banner |
-| 5 | **Board UI** — the real board component: region-boundary borders, themed styling, win flow, palette tuning | The **finished board**, styled to the app's themes, replacing the preview's rough grid |
-| 6 | **Assists & polish** — optional auto-X, win animation, level ladder, scoring | Assist toggle, win celebration, level progression |
-| 7 | **Art swap** (floating, asset-only) | Static mushroom art replaces the icon glyph |
+| 5 | ~~**Board UI**~~ ✅ — the real board component: region-boundary borders, themed styling, win flow, **palette tuning** | The **finished board**, styled to the app's themes, replacing the preview's rough grid |
+| 6 | **Input ergonomics & assists** (§2) — **drag to sweep X's**, then optional auto-X | **Swipe a finger across cells to rule them out**; assist toggle |
+| 7 | **Ladder & scoring** — training ladder, size progression, scoring | Level progression and a score |
+| 8 | **Art swap** (floating, asset-only — gated on artwork, not on code) | Static mushroom art replaces the icon glyph |
+
+**Why drag-to-sweep sits at Step 6, not earlier:** it needs the real board's
+touch and geometry layer, which Step 5 builds. Writing the gesture against the
+preview grid's per-cell `TouchableOpacity` would mean throwing it away a step
+later. It leads Step 6 because it is the ergonomic fix that makes X's worth
+using, and auto-X (the other half of that step) is the same concern.
 
 **Why the shell comes before the game logic:** Fungiku currently hangs off
 Sudoku's menu, which is the wrong shape to keep building into. Doing the hub at
@@ -229,9 +277,9 @@ modal nested inside another game — no throwaway work, and the two games read a
 peers from the moment there is anything to play.
 
 The preview was scaffolding, not the product: Step 2 built it read-only to judge
-the engine's output, Step 3 gave it a real home, and **Step 4 retired it** —
-`FungikuPreview.js` is gone, replaced by the interactive `FungikuBoard.js`. Step 5
-supersedes that rough grid with the finished, themed board.
+the engine's output, Step 3 gave it a real home, **Step 4 retired it** —
+`FungikuPreview.js` is gone, replaced by the interactive `FungikuBoard.js` — and
+Step 5 replaced that rough grid with the themed, responsive board.
 
 ## 8. Open questions for the operator
 


### PR DESCRIPTION
Step 5 of the Fungiku epic (refs #65, plan §3/§5). Targets `epic/fungiku`.

The board was playable after Step 4, but it still looked like the engine preview it grew out of — and the palette was **actually broken** at larger sizes, not merely unpolished. So the palette came first.

## 📱 Test it in Expo Go

The **Expo preview** comment on this PR carries the QR — EAS Update branch `pr-<this PR>`, runtime `exposdk:54.0.0`, republished on every push.

---

## 1. The palette was a bug, and now it has a number

Tinting every Okabe–Ito hue toward white by the same `0.62` pulled them all toward a common light gray. Measured with CIEDE2000:

| | before | after |
|---|---|---|
| worst pair (light) | **ΔE 6.67** — sky blue vs. blue | **ΔE 17.11** |
| pairs under ΔE 15 (light) | **7 of 36** | **0 of 36** |
| worst pair (dark) | *pastels on black, untested* | **ΔE 18.55** |
| pairs under ΔE 15 (dark) | — | **0 of 36** |

ΔE ~1 is just-noticeable; ~10 reads as "clearly a different color". 6.67 is "the same color, slightly off" — which is exactly how it looked at 8×8.

The fix is what plan §3 asked for: **vary lightness as well as hue.** Each hue gets its own tint weight, chosen by maximizing the worst pairwise CIEDE2000 distance **subject to every fill staying inside a lightness band** — the constraint matters, because the unconstrained optimum is nine near-saturated blocks that swamp the mushroom glyph. Okabe–Ito hues are preserved; only their tints changed.

**This is now regression-proof, which is the real deliverable.** `utils/__tests__/symbolSets.test.js` asserts a minimum pairwise ΔE, calls out the two originally-colliding pairs by name, holds the lightness band, and checks contrast for both glyph ink and the conflict marker. A future "let's soften the palette" fails a test instead of shipping.

`utils/color.js` is **CIEDE2000, not the simpler CIE76** — deliberately. CIE76 *overstates* how different saturated blues are, and blues were the failing pair, so CIE76 would have happily passed the bug.

## 2. Themed, contrast-checked, responsive

| | |
|---|---|
| **Region fills** | blend toward the *theme's* surface, so dark themes get dark fills instead of glaring pastels. |
| **Glyph color** | picked for contrast against each region's own fill (≥4.5:1 everywhere) rather than being the region's hue — a saturated orange mushroom on an orange cell was invisible. |
| **Conflict marker** | per-mode colors clearing WCAG's 3:1 floor against **every** fill (light 5.64:1, dark 3.10:1). The obvious `#C1272D` only managed 2.55:1 on the warm fills, which is why conflict isn't just "the mushroom, but red". Ring **and** color change, so it survives a colorblind reader and a dark theme. |
| **Region outlines** | now drawn from the theme's grid colors. They *are* the board's structure — they stand in for Sudoku's 3×3 box lines — so they had to stay strong under restyling. |
| **Board size** | `hooks/useBoardSize.js`, extracted from `GameScreen`'s private `useGridContainerSize`, so Fungiku sizes to the screen exactly the way Sudoku does instead of a hardcoded 320. **Sudoku's numbers are unchanged.** |

## 3. The win feels like a win

`FungikuWinBanner.js` springs in *after* the board's own lift, so the sequence reads "the board celebrates, then the banner confirms" rather than everything moving at once. One shimmer pass, not a loop — a celebration that never stops becomes wallpaper. The counter hint also stops explaining the tap cycle to someone who has already won, and now names the conflict count while you're mid-puzzle.

## 4. The shell's theme is its own

The hub and Fungiku no longer read `currentThemeName` out of *Sudoku's saved game*. It lives under its own `@AppTheme` key (`utils/appTheme.js`), and Sudoku writes through to it when the player cycles themes. Sudoku still hydrates its own copy from its own save — making Sudoku read the shared key touches its hydration path, so that half is noted for later rather than done here.

## Two bugs I caught in my own diff during the browser pass

Both worth flagging because the first is the kind of thing a screenshot review misses:

1. **The win banner stayed mounted at opacity 0** so it could animate out — which meant it reserved a gap above the board on every fresh puzzle *and* read "Solved!" to a screen reader on an untouched board. The browser log showed `Solved!` in the body text of a 0/5 board. Now the exit animation's completion callback unmounts it.
2. **Fixing that introduced a conditional hook** — the early return sat between two `useEffect`s, so mounting the banner changed the hook count and React crashed the screen on win. The verification pass caught it as a blank page; every hook now runs before the bail-out.

## Verification

```
npm test                       → 152/152 pass (45 new across color + palette)
npx expo-doctor                → 18/18
npx expo export --platform all → web + iOS + Android all bundle
```

Chromium pass over the exported build, **no page errors**, at 5×5 and 8×8 in **both** classic and dark:

- 8×8 in each theme: sampled the *rendered* `background-color` of all 64 cells → **8 distinct fills** in both, so the palette claim is measured in the browser, not just asserted in a unit test;
- conflict state: two mushrooms in a row, both ringed and labelled `…, mushroom, conflict`, hint reads "2 mushrooms breaking a rule";
- solved a real 5×5 (engine solution `[4,2,0,3,1]`) → animated banner;
- switched Sudoku to Dark → hub and Fungiku both followed, and the solved board came back from persistence still solved;
- 8×8 still playable in dark.

Screenshots of 8×8 in both themes, the conflict state and the dark win are in the session.

## Deliberately out of scope

- **Step 6 — drag to sweep X's**, the operator's request, now specced in plan §2 with its behavior rules and the two gesture hazards. Plus the auto-X assist.
- **Step 7** — ladder, progression, scoring. The size chips and *New puzzle* still stand in.
- **Step 8** — art swap, gated on artwork rather than code.
- **Sudoku's `Grid`/`Cell` are untouched.** Read for reference only. The only Sudoku-side changes are the extracted sizing hook and the theme write-through.

## Plan changes in this PR

Per the operator's request, **plan §2 gains a "Drag to sweep X's" section**: drag paints X and never cycles, the first cell decides paint-vs-erase for the whole stroke, mushrooms are never overwritten, one undo entry per stroke, and fast diagonal strokes must fill every cell crossed. It also records the two hazards — `locationX`/`locationY` being unreliable on the new architecture, and the gesture needing a device test rather than a browser one.

The step table is now: **6** input ergonomics (drag + auto-X) → **7** ladder & scoring → **8** art swap. Three steps left, and 8 waits on artwork rather than code.

`docs/fungiku-handoff.md` is rewritten for Step 6, leading with the drag spec.

**Please test in Expo Go**: Fungiku at 8×8 in a couple of themes — the question this step exists to answer is whether you can tell all eight regions apart at a glance. Also still open: whether "Puzzle Box" survives as the app name (§8 #2), and whether auto-X should default on for younger players (§8 #5), which Step 6 needs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3yWT2tp5eK1iFkcSVzUVq)_