### PR TITLE
Fungiku Step 6: drag to sweep X's, the auto rule-out assist, + EAS branch cleanup on PR close

### DIFF
--- a/.github/workflows/eas-publish.yml
+++ b/.github/workflows/eas-publish.yml
@@ -10,7 +10,11 @@ on:
       # step PRs -- once a step PR merges into the epic there is no open PR
       # left, so the PR-preview job below would otherwise leave nothing to test.
       - 'epic/**'
+  # `closed` is not in the default set of pull_request activity types, and the
+  # cleanup job at the bottom needs it. The other three are the default types,
+  # respelled here because naming any type replaces the defaults.
   pull_request:
+    types: [opened, synchronize, reopened, closed]
 
 permissions:
   contents: write        # for gh-pages push
@@ -119,8 +123,13 @@ jobs:
 # Open / update a PR -> publish a preview EAS Update and comment a QR code
   preview-mobile:
     name: EAS Update PR preview
-    # Only for PRs from this repo (fork PRs can't access EXPO_TOKEN)
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    # Only for PRs from this repo (fork PRs can't access EXPO_TOKEN), and never
+    # on `closed` -- that activity type exists for the cleanup job below, and
+    # publishing here would recreate the very branch that job just deleted.
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.action != 'closed'
+      && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -155,3 +164,48 @@ jobs:
             --branch pr-${{ github.event.number }}
             --message "PR #${{ github.event.number }} preview (${{ github.event.pull_request.head.sha }})"
             --environment preview
+
+# --------------------------------------------------------------------------
+# PR closed -> delete the EAS Update branch its preview published to.
+#
+# EAS Update branches are a separate namespace from git: closing or merging a PR
+# (and deleting its git branch) leaves `pr-<N>` published forever. Nothing prunes
+# them, so they accumulate -- this repo had built up 68 stale branches, including
+# duplicate pairs from an earlier workflow that published the branch's last path
+# segment as well as its full ref.
+#
+# Safe to delete unconditionally: a `pr-<N>` branch is only ever reachable
+# through the QR code in that PR's preview comment, which is dead once the PR is
+# closed. It is not mapped to a channel, so no installed build resolves updates
+# from it.
+  cleanup-preview:
+    name: Delete the PR's EAS Update branch
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.action == 'closed'
+      && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Set up EAS CLI (with token auth)
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Delete the preview branch
+        # Never fail the run over cleanup: the branch may not exist (a PR closed
+        # before any preview published), and a missing branch is the desired
+        # end state anyway.
+        continue-on-error: true
+        run: eas branch:delete "pr-${{ github.event.number }}" --non-interactive
+        working-directory: ${{ env.APP_DIR }}

--- a/SudokuApp/games/fungiku/FungikuBoard.js
+++ b/SudokuApp/games/fungiku/FungikuBoard.js
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useRef } from 'react';
-import { View, StyleSheet, TouchableOpacity, Animated, Easing, PanResponder } from 'react-native';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { View, StyleSheet, Animated, Easing, PanResponder } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { MARKS } from './engine';
 import { getRegionPalette } from '../../utils/symbolSets';
@@ -39,7 +39,7 @@ const MARK_LABELS = {
  */
 const DRAG_THRESHOLD = 6;
 
-const FungikuBoard = ({ isDark, theme }) => {
+const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
   const { size, regions, marks, conflicts, cycleCell, paintCells, beginStroke, endStroke, solved } =
     useFungikuContext();
 
@@ -49,11 +49,22 @@ const FungikuBoard = ({ isDark, theme }) => {
 
   // --- drag to sweep X's (plan §2) -----------------------------------------
   //
-  // The responder is claimed on *movement*, not on touch-down, so the per-cell
-  // Touchables keep handling simple taps — which keeps the full
-  // empty → X → 🍄 cycle and, just as importantly, their accessibility labels
-  // and screen-reader activation. Once the finger moves past the threshold the
-  // board takes over and the child's press is cancelled.
+  // The board claims every touch that starts on it, in the **capture phase, at
+  // touch-down**. That is not an optimization — it is the fix for a bug the
+  // operator hit on device: claiming on *movement* instead means racing the
+  // enclosing ScrollView, and vertically the ScrollView wins. It is already
+  // tracking the same touch, and once vertical movement passes its slop it takes
+  // it — via onInterceptTouchEvent on Android, and on iOS because
+  // canCancelContentTouches defaults to letting a scroll view cancel a child's
+  // touch. So the page scrolled instead of X's appearing.
+  //
+  // Claiming at touch-down removes the race entirely: there is no window in
+  // which the ScrollView can decide the gesture is a scroll. The cost is that
+  // taps arrive here rather than at a per-cell Touchable, so this component
+  // distinguishes them (release under the threshold = tap), and the cells keep
+  // their accessibility labels plus onAccessibilityTap for screen readers.
+  //
+  // FungikuScreen completes the fix on the ScrollView side.
   const { ref: boardRef, onLayout, measure, toLocal } = useBoardOrigin();
 
   // Refs, not state: these change many times per frame during a stroke and must
@@ -61,6 +72,10 @@ const FungikuBoard = ({ isDark, theme }) => {
   const startPoint = useRef(null);
   const lastCell = useRef(-1);
   const paintMode = useRef(PAINT_MODES.X);
+  const isStroke = useRef(false);
+
+  // Tap feedback, which the per-cell Touchables used to give for free.
+  const [pressedCell, setPressedCell] = useState(-1);
 
   // The latest marks/geometry, readable from inside gesture callbacks that were
   // created once and would otherwise close over a stale render.
@@ -73,45 +88,90 @@ const FungikuBoard = ({ isDark, theme }) => {
     return cellFromPoint({ x, y, cellSize, size: boardCells });
   };
 
+  /**
+   * Touch-down bookkeeping, shared by the capture- and bubble-phase claims.
+   * Idempotent: only one of the two ever runs for a given touch, but running it
+   * twice would do no harm.
+   */
+  const beginTouch = (event) => {
+    startPoint.current = {
+      x: event.nativeEvent.pageX,
+      y: event.nativeEvent.pageY,
+    };
+    isStroke.current = false;
+
+    // Re-measure here rather than only on layout: the win banner above the board
+    // mounts and unmounts, which moves the board.
+    measure();
+
+    // Freeze scrolling for as long as the finger is down on the board. Belt and
+    // braces with canCancelContentTouches on the screen: this is the one that
+    // reliably stops Android's ScrollView.
+    onTouchActiveChange?.(true);
+
+    setPressedCell(cellAt(startPoint.current.x, startPoint.current.y));
+  };
+
+  /** Common tail for release and terminate: hand scrolling back. */
+  const finish = () => {
+    lastCell.current = -1;
+    isStroke.current = false;
+    setPressedCell(-1);
+    onTouchActiveChange?.(false);
+  };
+
   const responder = useMemo(
     () =>
       PanResponder.create({
-        // Capture phase: observe where the touch began without claiming it, so
-        // the stroke can start from the cell the finger actually went down on
-        // rather than wherever it happened to be when the threshold tripped.
+        // Claim at touch-down, before the ScrollView can start interpreting the
+        // touch as a scroll. This is the fix.
+        //
+        // Registered in *both* phases on purpose. The capture phase is what
+        // pre-empts the ScrollView on native; but react-native-web does not
+        // appear to honour a capture-phase claim on touch start, and with the
+        // cells now plain Views that left touch taps dead — nothing handled
+        // them. The bubble-phase handler is the fallback that keeps taps working
+        // wherever capture isn't honoured. Whichever fires first wins; the other
+        // is never consulted, and `beginTouch` is safe to run either way.
         onStartShouldSetPanResponderCapture: (event) => {
-          startPoint.current = {
-            x: event.nativeEvent.pageX,
-            y: event.nativeEvent.pageY,
-          };
-          return false;
+          beginTouch(event);
+          return true;
+        },
+        onStartShouldSetPanResponder: (event) => {
+          beginTouch(event);
+          return true;
         },
 
-        onMoveShouldSetPanResponder: (_event, gesture) =>
-          Math.hypot(gesture.dx, gesture.dy) > DRAG_THRESHOLD,
+        // Already the responder, so these only matter if something upstream
+        // tries to hand the touch over mid-gesture.
+        onMoveShouldSetPanResponderCapture: () => true,
+        onMoveShouldSetPanResponder: () => true,
 
-        onPanResponderGrant: () => {
-          // Re-measure here, not just on layout: the win banner above the board
-          // mounts and unmounts, which moves the board.
-          measure();
+        onPanResponderMove: (event, gesture) => {
+          if (!isStroke.current) {
+            // Still ambiguous: a tap is a touch that never travels this far.
+            if (Math.hypot(gesture.dx, gesture.dy) <= DRAG_THRESHOLD) return;
 
-          const origin = startPoint.current;
-          const first = origin ? cellAt(origin.x, origin.y) : -1;
+            isStroke.current = true;
+            setPressedCell(-1);
 
-          // The first cell decides the whole stroke: starting on an X erases,
-          // starting anywhere else paints. Fixing the mode up front means
-          // dragging back over your own path doesn't flip cells twice.
-          paintMode.current =
-            first >= 0 && live.current.marks[first] === MARKS.X
-              ? PAINT_MODES.ERASE
-              : PAINT_MODES.X;
+            const first = startPoint.current
+              ? cellAt(startPoint.current.x, startPoint.current.y)
+              : -1;
 
-          beginStroke();
-          lastCell.current = first;
-          if (first >= 0) paintCells([first], paintMode.current);
-        },
+            // The first cell decides the whole stroke: starting on an X erases,
+            // starting anywhere else paints. Fixing the mode up front means
+            // dragging back over your own path doesn't flip cells twice.
+            paintMode.current =
+              first >= 0 && live.current.marks[first] === MARKS.X
+                ? PAINT_MODES.ERASE
+                : PAINT_MODES.X;
 
-        onPanResponderMove: (event) => {
+            beginStroke();
+            lastCell.current = first;
+            if (first >= 0) paintCells([first], paintMode.current);
+          }
+
           const next = cellAt(event.nativeEvent.pageX, event.nativeEvent.pageY);
           if (next < 0 || next === lastCell.current) return;
 
@@ -127,17 +187,30 @@ const FungikuBoard = ({ isDark, theme }) => {
         },
 
         onPanResponderRelease: () => {
-          endStroke();
-          lastCell.current = -1;
+          if (isStroke.current) {
+            endStroke();
+          } else {
+            // Never travelled: it was a tap, so run the full mark cycle. Taps
+            // land here now rather than on a per-cell Touchable, because the
+            // board owns the touch from the moment it starts.
+            const tapped = startPoint.current
+              ? cellAt(startPoint.current.x, startPoint.current.y)
+              : -1;
+            if (tapped >= 0) cycleCell(tapped);
+          }
+          finish();
         },
         onPanResponderTerminate: () => {
-          endStroke();
-          lastCell.current = -1;
+          if (isStroke.current) endStroke();
+          finish();
         },
 
         // Don't let anything steal the stroke mid-sweep (the ScrollView this
         // board sits in would happily take it).
         onPanResponderTerminationRequest: () => false,
+
+        // Android: tell the native responder — the ScrollView — to stand down.
+        onShouldBlockNativeResponder: () => true,
       }),
     // Built once: every value it touches is read through a ref.
     [beginStroke, endStroke, paintCells, measure]
@@ -197,10 +270,14 @@ const FungikuBoard = ({ isDark, theme }) => {
             const inkFaded = entry.ink === '#ffffff' ? '#ffffffaa' : '#1a1a1aaa';
 
             return (
-              <TouchableOpacity
+              <View
                 key={col}
-                onPress={() => cycleCell(index)}
-                activeOpacity={0.6}
+                // A plain View, not a Touchable: the board owns the touch from
+                // touch-down, so a child Touchable would never see a press.
+                // Taps are dispatched by the responder above; these props keep
+                // the cell a first-class accessibility target, and
+                // onAccessibilityTap is what a screen reader activates.
+                accessible
                 accessibilityRole="button"
                 // Region name and mark are both spelled out, so the board is
                 // usable without relying on color (plan §5). These labels are
@@ -209,10 +286,13 @@ const FungikuBoard = ({ isDark, theme }) => {
                   MARK_LABELS[mark] || 'empty'
                 }${conflicting ? ', conflict' : ''}`}
                 accessibilityHint="Taps cycle empty, ruled out, mushroom"
+                onAccessibilityTap={() => cycleCell(index)}
                 style={{
                   width: cell,
                   height: cell,
                   backgroundColor: entry.background,
+                  // Press feedback, previously TouchableOpacity's activeOpacity.
+                  opacity: pressedCell === index ? 0.6 : 1,
                   alignItems: 'center',
                   justifyContent: 'center',
                   borderTopColor: differs(row - 1, col) ? outline : hairline,
@@ -258,7 +338,7 @@ const FungikuBoard = ({ isDark, theme }) => {
                     color={inkFaded}
                   />
                 )}
-              </TouchableOpacity>
+              </View>
             );
           })}
         </View>

--- a/SudokuApp/games/fungiku/FungikuBoard.js
+++ b/SudokuApp/games/fungiku/FungikuBoard.js
@@ -1,9 +1,12 @@
 import React, { useEffect, useMemo, useRef } from 'react';
-import { View, StyleSheet, TouchableOpacity, Animated, Easing } from 'react-native';
+import { View, StyleSheet, TouchableOpacity, Animated, Easing, PanResponder } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { MARKS } from './engine';
 import { getRegionPalette } from '../../utils/symbolSets';
 import useBoardSize from '../../hooks/useBoardSize';
+import useBoardOrigin from '../../hooks/useBoardOrigin';
+import { cellFromPoint, cellsAlongLine } from './geometry';
+import { PAINT_MODES } from './reducer';
 import { useFungikuContext } from './FungikuContext';
 
 /**
@@ -29,12 +32,116 @@ const MARK_LABELS = {
   [MARKS.MUSHROOM]: 'mushroom',
 };
 
+/**
+ * How far the finger must travel before a touch becomes a stroke instead of a
+ * tap. Small enough that the cell you started on is still under your finger, big
+ * enough that a slightly shaky tap does not paint.
+ */
+const DRAG_THRESHOLD = 6;
+
 const FungikuBoard = ({ isDark, theme }) => {
-  const { size, regions, marks, conflicts, cycleCell, solved } = useFungikuContext();
+  const { size, regions, marks, conflicts, cycleCell, paintCells, beginStroke, endStroke, solved } =
+    useFungikuContext();
 
   const boardSize = useBoardSize();
   const cell = Math.floor(boardSize / size);
   const glyph = Math.round(cell * 0.62);
+
+  // --- drag to sweep X's (plan §2) -----------------------------------------
+  //
+  // The responder is claimed on *movement*, not on touch-down, so the per-cell
+  // Touchables keep handling simple taps — which keeps the full
+  // empty → X → 🍄 cycle and, just as importantly, their accessibility labels
+  // and screen-reader activation. Once the finger moves past the threshold the
+  // board takes over and the child's press is cancelled.
+  const { ref: boardRef, onLayout, measure, toLocal } = useBoardOrigin();
+
+  // Refs, not state: these change many times per frame during a stroke and must
+  // never trigger a re-render of their own.
+  const startPoint = useRef(null);
+  const lastCell = useRef(-1);
+  const paintMode = useRef(PAINT_MODES.X);
+
+  // The latest marks/geometry, readable from inside gesture callbacks that were
+  // created once and would otherwise close over a stale render.
+  const live = useRef({ marks, cell, size });
+  live.current = { marks, cell, size };
+
+  const cellAt = (pageX, pageY) => {
+    const { x, y } = toLocal(pageX, pageY);
+    const { cell: cellSize, size: boardCells } = live.current;
+    return cellFromPoint({ x, y, cellSize, size: boardCells });
+  };
+
+  const responder = useMemo(
+    () =>
+      PanResponder.create({
+        // Capture phase: observe where the touch began without claiming it, so
+        // the stroke can start from the cell the finger actually went down on
+        // rather than wherever it happened to be when the threshold tripped.
+        onStartShouldSetPanResponderCapture: (event) => {
+          startPoint.current = {
+            x: event.nativeEvent.pageX,
+            y: event.nativeEvent.pageY,
+          };
+          return false;
+        },
+
+        onMoveShouldSetPanResponder: (_event, gesture) =>
+          Math.hypot(gesture.dx, gesture.dy) > DRAG_THRESHOLD,
+
+        onPanResponderGrant: () => {
+          // Re-measure here, not just on layout: the win banner above the board
+          // mounts and unmounts, which moves the board.
+          measure();
+
+          const origin = startPoint.current;
+          const first = origin ? cellAt(origin.x, origin.y) : -1;
+
+          // The first cell decides the whole stroke: starting on an X erases,
+          // starting anywhere else paints. Fixing the mode up front means
+          // dragging back over your own path doesn't flip cells twice.
+          paintMode.current =
+            first >= 0 && live.current.marks[first] === MARKS.X
+              ? PAINT_MODES.ERASE
+              : PAINT_MODES.X;
+
+          beginStroke();
+          lastCell.current = first;
+          if (first >= 0) paintCells([first], paintMode.current);
+        },
+
+        onPanResponderMove: (event) => {
+          const next = cellAt(event.nativeEvent.pageX, event.nativeEvent.pageY);
+          if (next < 0 || next === lastCell.current) return;
+
+          // Fill everything between the last point and this one — at speed a
+          // finger can skip several cells between move events.
+          const span =
+            lastCell.current >= 0
+              ? cellsAlongLine(lastCell.current, next, live.current.size)
+              : [next];
+
+          lastCell.current = next;
+          paintCells(span, paintMode.current);
+        },
+
+        onPanResponderRelease: () => {
+          endStroke();
+          lastCell.current = -1;
+        },
+        onPanResponderTerminate: () => {
+          endStroke();
+          lastCell.current = -1;
+        },
+
+        // Don't let anything steal the stroke mid-sweep (the ScrollView this
+        // board sits in would happily take it).
+        onPanResponderTerminationRequest: () => false,
+      }),
+    // Built once: every value it touches is read through a ref.
+    [beginStroke, endStroke, paintCells, measure]
+  );
 
   const palette = useMemo(() => getRegionPalette(isDark), [isDark]);
 
@@ -58,6 +165,9 @@ const FungikuBoard = ({ isDark, theme }) => {
 
   return (
     <Animated.View
+      ref={boardRef}
+      onLayout={onLayout}
+      {...responder.panHandlers}
       style={[
         styles.board,
         {

--- a/SudokuApp/games/fungiku/FungikuContext.js
+++ b/SudokuApp/games/fungiku/FungikuContext.js
@@ -63,6 +63,25 @@ export const FungikuProvider = ({ children }) => {
     [dispatch]
   );
 
+  // --- drag-to-sweep (plan §2) ---------------------------------------------
+  // A stroke is many paints across many frames but exactly one undoable action:
+  // beginStroke arms the undo entry, the first effective paint spends it.
+  const beginStroke = useCallback(
+    () => dispatch({ type: FUNGIKU_ACTIONS.BEGIN_STROKE }),
+    [dispatch]
+  );
+  const paintCells = useCallback(
+    (cells, mode) => dispatch({ type: FUNGIKU_ACTIONS.PAINT_CELLS, payload: { cells, mode } }),
+    [dispatch]
+  );
+  const endStroke = useCallback(() => dispatch({ type: FUNGIKU_ACTIONS.END_STROKE }), [dispatch]);
+
+  const setAutoX = useCallback(
+    (value) => dispatch({ type: FUNGIKU_ACTIONS.SET_AUTO_X, payload: value }),
+    [dispatch]
+  );
+  const toggleAutoX = useCallback(() => setAutoX(!state.autoX), [setAutoX, state.autoX]);
+
   /**
    * Start a puzzle. Generation happens here rather than in the reducer so a
    * failure surfaces as a caught error instead of a throw mid-dispatch.
@@ -72,13 +91,15 @@ export const FungikuProvider = ({ children }) => {
       try {
         dispatch({
           type: FUNGIKU_ACTIONS.NEW_PUZZLE,
-          payload: buildPuzzleState({ size, seed }),
+          // The assist is a preference, not part of the puzzle — it has to
+          // survive starting a new board.
+          payload: buildPuzzleState({ size, seed, autoX: state.autoX }),
         });
       } catch (error) {
         console.error('Fungiku generation failed:', error);
       }
     },
-    [dispatch, state.size, state.seed]
+    [dispatch, state.size, state.seed, state.autoX]
   );
 
   const nextPuzzle = useCallback(
@@ -106,6 +127,11 @@ export const FungikuProvider = ({ children }) => {
       canRedo: selectCanRedo(state),
       minSize: MIN_SIZE,
       cycleCell,
+      beginStroke,
+      paintCells,
+      endStroke,
+      setAutoX,
+      toggleAutoX,
       startPuzzle,
       nextPuzzle,
       changeSize,
@@ -113,7 +139,25 @@ export const FungikuProvider = ({ children }) => {
       undo,
       redo,
     }),
-    [state, conflicts, mushroomCount, solved, hasMarks, cycleCell, startPuzzle, nextPuzzle, changeSize, clearMarks, undo, redo]
+    [
+      state,
+      conflicts,
+      mushroomCount,
+      solved,
+      hasMarks,
+      cycleCell,
+      beginStroke,
+      paintCells,
+      endStroke,
+      setAutoX,
+      toggleAutoX,
+      startPuzzle,
+      nextPuzzle,
+      changeSize,
+      clearMarks,
+      undo,
+      redo,
+    ]
   );
 
   // Wait for hydration so a saved board never flashes as an empty one.

--- a/SudokuApp/games/fungiku/FungikuContext.js
+++ b/SudokuApp/games/fungiku/FungikuContext.js
@@ -13,6 +13,7 @@ import {
   selectConflicts,
   selectIsSolved,
   selectMushroomCount,
+  selectRuleOutCells,
 } from './reducer';
 
 /**
@@ -26,7 +27,7 @@ import {
  */
 const FungikuContext = createContext();
 
-/** Board sizes offered today. The real ladder arrives in Step 6. */
+/** Board sizes offered today. The real ladder arrives in a later step. */
 export const SIZES = [5, 6, 7, 8];
 
 // Stable object identity, so the persistence hook never sees a "new" adapter.
@@ -58,6 +59,13 @@ export const FungikuProvider = ({ children }) => {
     [state.marks]
   );
 
+  // How many cells one tap of "Rule out" would fill. Drives whether the button
+  // is enabled, so it never sits there offering to do nothing.
+  const ruleOutCount = useMemo(
+    () => selectRuleOutCells(state).size,
+    [state.marks, state.regions, state.size]
+  );
+
   const cycleCell = useCallback(
     (cell) => dispatch({ type: FUNGIKU_ACTIONS.CYCLE_CELL, payload: { cell } }),
     [dispatch]
@@ -76,11 +84,8 @@ export const FungikuProvider = ({ children }) => {
   );
   const endStroke = useCallback(() => dispatch({ type: FUNGIKU_ACTIONS.END_STROKE }), [dispatch]);
 
-  const setAutoX = useCallback(
-    (value) => dispatch({ type: FUNGIKU_ACTIONS.SET_AUTO_X, payload: value }),
-    [dispatch]
-  );
-  const toggleAutoX = useCallback(() => setAutoX(!state.autoX), [setAutoX, state.autoX]);
+  /** One tap: mark everything the placed mushrooms forbid (plan §2). */
+  const ruleOut = useCallback(() => dispatch({ type: FUNGIKU_ACTIONS.RULE_OUT }), [dispatch]);
 
   /**
    * Start a puzzle. Generation happens here rather than in the reducer so a
@@ -91,15 +96,13 @@ export const FungikuProvider = ({ children }) => {
       try {
         dispatch({
           type: FUNGIKU_ACTIONS.NEW_PUZZLE,
-          // The assist is a preference, not part of the puzzle — it has to
-          // survive starting a new board.
-          payload: buildPuzzleState({ size, seed, autoX: state.autoX }),
+          payload: buildPuzzleState({ size, seed }),
         });
       } catch (error) {
         console.error('Fungiku generation failed:', error);
       }
     },
-    [dispatch, state.size, state.seed, state.autoX]
+    [dispatch, state.size, state.seed]
   );
 
   const nextPuzzle = useCallback(
@@ -130,8 +133,8 @@ export const FungikuProvider = ({ children }) => {
       beginStroke,
       paintCells,
       endStroke,
-      setAutoX,
-      toggleAutoX,
+      ruleOut,
+      ruleOutCount,
       startPuzzle,
       nextPuzzle,
       changeSize,
@@ -149,8 +152,8 @@ export const FungikuProvider = ({ children }) => {
       beginStroke,
       paintCells,
       endStroke,
-      setAutoX,
-      toggleAutoX,
+      ruleOut,
+      ruleOutCount,
       startPuzzle,
       nextPuzzle,
       changeSize,

--- a/SudokuApp/games/fungiku/FungikuScreen.js
+++ b/SudokuApp/games/fungiku/FungikuScreen.js
@@ -16,8 +16,8 @@ const FUNGIKU_ACCENT = '#a0522d';
  * (docs/fungiku-plan.md §6), and as of Step 4 an actually playable game.
  *
  * Layout: header, the `🍄 X/N` counter, the board, then controls. The size and
- * "next puzzle" controls stand in for the training ladder until Step 6; Step 5
- * replaces the board with the finished themed component.
+ * "next puzzle" controls stand in for the training ladder until the ladder step
+ * lands (plan §7).
  */
 const FungikuScreenContent = ({ onExitToHub }) => {
   const { theme, isDark } = useAppTheme();
@@ -40,8 +40,8 @@ const FungikuScreenContent = ({ onExitToHub }) => {
     clearMarks,
     changeSize,
     nextPuzzle,
-    autoX,
-    toggleAutoX,
+    ruleOut,
+    ruleOutCount,
   } = useFungikuContext();
 
   const titleColor = theme.colors.title;
@@ -128,36 +128,36 @@ const FungikuScreenContent = ({ onExitToHub }) => {
           />
         </View>
 
-        {/* Assist toggle (plan §2). Off by default: left on it does most of the
-            deduction for you, which is the whole game. */}
+        {/* Rule out (plan §2). An action the player asks for, not a mode that
+            acts behind them: one tap marks everything the mushrooms already on
+            the board forbid. Disabled when there is nothing left to mark, so it
+            never offers to do nothing. */}
         <View style={styles.controlRow}>
           <TouchableOpacity
-            onPress={toggleAutoX}
+            onPress={ruleOut}
+            disabled={ruleOutCount === 0}
             style={[
               styles.wideButton,
               { borderColor: border },
-              autoX && { backgroundColor: titleColor, borderColor: titleColor },
+              ruleOutCount === 0 && styles.toolButtonDisabled,
             ]}
-            accessibilityRole="switch"
-            accessibilityState={{ checked: autoX }}
-            // The state is named in the label as well as in accessibilityState:
-            // `checked` does not survive to `aria-checked` on web, so the label
-            // is the only place a screen reader (or a test) can read it reliably.
-            accessibilityLabel={`Auto rule-out, ${autoX ? 'on' : 'off'}`}
-            accessibilityHint="When on, placing a mushroom rules out its row, column, color and neighbours"
+            accessibilityRole="button"
+            accessibilityState={{ disabled: ruleOutCount === 0 }}
+            accessibilityLabel={
+              ruleOutCount === 0
+                ? 'Rule out, nothing to mark'
+                : `Rule out ${ruleOutCount} cell${ruleOutCount === 1 ? '' : 's'}`
+            }
+            accessibilityHint="Marks every cell the mushrooms you have placed forbid"
           >
-            <MaterialCommunityIcons
-              name={autoX ? 'checkbox-marked' : 'checkbox-blank-outline'}
-              size={18}
-              color={autoX ? surface : titleColor}
-            />
-            <Text style={[styles.buttonText, { color: autoX ? surface : titleColor }]}>
-              Auto rule-out
+            <MaterialCommunityIcons name="auto-fix" size={18} color={titleColor} />
+            <Text style={[styles.buttonText, { color: titleColor }]}>
+              {ruleOutCount === 0 ? 'Rule out' : `Rule out ${ruleOutCount}`}
             </Text>
           </TouchableOpacity>
         </View>
 
-        {/* Board size + next puzzle — the stand-in for Step 7's ladder */}
+        {/* Board size + next puzzle — the stand-in for the ladder step */}
         <Text style={[styles.label, { color: titleColor }]}>Board size</Text>
         <View style={styles.controlRow}>
           {SIZES.map((option) => (

--- a/SudokuApp/games/fungiku/FungikuScreen.js
+++ b/SudokuApp/games/fungiku/FungikuScreen.js
@@ -35,6 +35,8 @@ const FungikuScreenContent = ({ onExitToHub }) => {
     clearMarks,
     changeSize,
     nextPuzzle,
+    autoX,
+    toggleAutoX,
   } = useFungikuContext();
 
   const titleColor = theme.colors.title;
@@ -48,7 +50,7 @@ const FungikuScreenContent = ({ onExitToHub }) => {
     ? 'One per row, column and color — none touching'
     : conflicts.size > 0
       ? `${conflicts.size} mushroom${conflicts.size === 1 ? '' : 's'} breaking a rule`
-      : 'Tap a cell: empty → ✕ → 🍄';
+      : 'Tap to cycle · drag to sweep ✕';
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
@@ -102,7 +104,36 @@ const FungikuScreenContent = ({ onExitToHub }) => {
           />
         </View>
 
-        {/* Board size + next puzzle — the stand-in for Step 6's ladder */}
+        {/* Assist toggle (plan §2). Off by default: left on it does most of the
+            deduction for you, which is the whole game. */}
+        <View style={styles.controlRow}>
+          <TouchableOpacity
+            onPress={toggleAutoX}
+            style={[
+              styles.wideButton,
+              { borderColor: border },
+              autoX && { backgroundColor: titleColor, borderColor: titleColor },
+            ]}
+            accessibilityRole="switch"
+            accessibilityState={{ checked: autoX }}
+            // The state is named in the label as well as in accessibilityState:
+            // `checked` does not survive to `aria-checked` on web, so the label
+            // is the only place a screen reader (or a test) can read it reliably.
+            accessibilityLabel={`Auto rule-out, ${autoX ? 'on' : 'off'}`}
+            accessibilityHint="When on, placing a mushroom rules out its row, column, color and neighbours"
+          >
+            <MaterialCommunityIcons
+              name={autoX ? 'checkbox-marked' : 'checkbox-blank-outline'}
+              size={18}
+              color={autoX ? surface : titleColor}
+            />
+            <Text style={[styles.buttonText, { color: autoX ? surface : titleColor }]}>
+              Auto rule-out
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        {/* Board size + next puzzle — the stand-in for Step 7's ladder */}
         <Text style={[styles.label, { color: titleColor }]}>Board size</Text>
         <View style={styles.controlRow}>
           {SIZES.map((option) => (

--- a/SudokuApp/games/fungiku/FungikuScreen.js
+++ b/SudokuApp/games/fungiku/FungikuScreen.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { View, Text, StyleSheet, Platform, ScrollView, TouchableOpacity } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import ScreenHeader from '../../components/ScreenHeader';
@@ -21,6 +21,11 @@ const FUNGIKU_ACCENT = '#a0522d';
  */
 const FungikuScreenContent = ({ onExitToHub }) => {
   const { theme, isDark } = useAppTheme();
+
+  // True while a finger is down on the board, which freezes scrolling so a
+  // vertical sweep paints instead of scrolling the page.
+  const [boardTouchActive, setBoardTouchActive] = useState(false);
+
   const {
     size,
     seed,
@@ -56,7 +61,22 @@ const FungikuScreenContent = ({ onExitToHub }) => {
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
       <ScreenHeader title="Fungiku" theme={theme} onHomePress={onExitToHub} />
 
-      <ScrollView contentContainerStyle={styles.body}>
+      {/* Two halves of one fix for "a vertical drag scrolls instead of painting"
+          (the board claims the touch at touch-down; see FungikuBoard):
+            scrollEnabled       — frozen while a finger is down on the board.
+                                  This is what reliably stops Android's
+                                  ScrollView from intercepting the drag.
+            canCancelContentTouches (iOS only) — stops UIScrollView cancelling a
+                                  touch the board has already claimed.
+          The trade-off is deliberate: you cannot scroll this screen by dragging
+          on the board. Drag anywhere else. The content fits without scrolling on
+          a normal phone even at 8×8, so the ScrollView is really insurance for
+          small or landscape screens. */}
+      <ScrollView
+        contentContainerStyle={styles.body}
+        scrollEnabled={!boardTouchActive}
+        {...(Platform.OS === 'ios' ? { canCancelContentTouches: false } : null)}
+      >
         {/* The `🍄 X/N` counter (plan §1) — how the player tracks the goal. */}
         <View style={[styles.counterRow, { backgroundColor: surface, borderColor: border }]}>
           <MaterialCommunityIcons name="mushroom" size={20} color={titleColor} />
@@ -77,7 +97,11 @@ const FungikuScreenContent = ({ onExitToHub }) => {
           onNextPuzzle={nextPuzzle}
         />
 
-        <FungikuBoard isDark={isDark} theme={theme} />
+        <FungikuBoard
+          isDark={isDark}
+          theme={theme}
+          onTouchActiveChange={setBoardTouchActive}
+        />
 
         {/* Undo / redo / clear */}
         <View style={styles.controlRow}>

--- a/SudokuApp/games/fungiku/__tests__/engine.test.js
+++ b/SudokuApp/games/fungiku/__tests__/engine.test.js
@@ -10,6 +10,7 @@ import {
   isSolved,
   countMushrooms,
   createEmptyMarks,
+  cellsRuledOutBy,
 } from '../engine';
 
 // Sizes the v1 ladder ships (plan §8). Kept small so the suite stays fast.
@@ -316,5 +317,67 @@ describe('createEmptyMarks', () => {
     const marks = createEmptyMarks(7);
     expect(marks).toHaveLength(49);
     expect(marks.every((m) => m === MARKS.EMPTY)).toBe(true);
+  });
+});
+
+describe('cellsRuledOutBy', () => {
+  const size = 5;
+  // A deliberately simple region layout: five horizontal bands, so "same region"
+  // is "same row" and the region rule is easy to reason about separately.
+  const bands = Array.from({ length: size * size }, (_, i) => Math.floor(i / size));
+
+  it('excludes the cell itself', () => {
+    expect(cellsRuledOutBy(12, bands, size).has(12)).toBe(false);
+  });
+
+  it('rules out the whole row and column', () => {
+    const out = cellsRuledOutBy(12, bands, size); // row 2, col 2
+
+    for (let i = 0; i < size; i++) {
+      if (i !== 2) {
+        expect(out.has(2 * size + i)).toBe(true); // row
+        expect(out.has(i * size + 2)).toBe(true); // column
+      }
+    }
+  });
+
+  it('rules out the eight touching cells, diagonals included', () => {
+    const out = cellsRuledOutBy(12, bands, size);
+
+    [6, 7, 8, 11, 13, 16, 17, 18].forEach((n) => expect(out.has(n)).toBe(true));
+  });
+
+  it('rules out every cell of the same region', () => {
+    const regions = [...bands];
+    regions[24] = regions[12]; // put a far-away cell in the same region
+
+    expect(cellsRuledOutBy(12, regions, size).has(24)).toBe(true);
+  });
+
+  it('leaves cells that break no rule alone', () => {
+    // Row 0, col 4 with band regions: different row, different column,
+    // different region, not touching row 2.
+    expect(cellsRuledOutBy(12, bands, size).has(4)).toBe(false);
+  });
+
+  it('clips at the board edges for a corner cell', () => {
+    const out = cellsRuledOutBy(0, bands, size);
+
+    expect(out.has(1)).toBe(true);
+    expect(out.has(size)).toBe(true);
+    expect(out.has(size + 1)).toBe(true); // the one diagonal neighbour
+    expect([...out].every((c) => c >= 0 && c < size * size)).toBe(true);
+  });
+
+  it('agrees with findConflicts: a second mushroom on a ruled-out cell conflicts', () => {
+    const out = cellsRuledOutBy(12, bands, size);
+
+    out.forEach((cell) => {
+      const marks = createEmptyMarks(size);
+      marks[12] = MARKS.MUSHROOM;
+      marks[cell] = MARKS.MUSHROOM;
+
+      expect(findConflicts(marks, bands, size).size).toBeGreaterThan(0);
+    });
   });
 });

--- a/SudokuApp/games/fungiku/__tests__/geometry.test.js
+++ b/SudokuApp/games/fungiku/__tests__/geometry.test.js
@@ -1,0 +1,133 @@
+import { cellFromPoint, cellsAlongLine } from '../geometry';
+
+describe('cellFromPoint', () => {
+  const grid = { cellSize: 40, size: 5 };
+
+  it('maps a point to the cell containing it', () => {
+    expect(cellFromPoint({ x: 0, y: 0, ...grid })).toBe(0);
+    expect(cellFromPoint({ x: 39, y: 39, ...grid })).toBe(0);
+    expect(cellFromPoint({ x: 40, y: 0, ...grid })).toBe(1);
+    expect(cellFromPoint({ x: 0, y: 40, ...grid })).toBe(5);
+    expect(cellFromPoint({ x: 199, y: 199, ...grid })).toBe(24);
+  });
+
+  it('puts cell boundaries on the lower cell', () => {
+    // 40 belongs to column 1, not column 0 — an off-by-one here means a stroke
+    // paints the wrong cell at every boundary it crosses.
+    expect(cellFromPoint({ x: 80, y: 120, ...grid })).toBe(3 * 5 + 2);
+  });
+
+  it('rejects points off the board', () => {
+    expect(cellFromPoint({ x: -1, y: 10, ...grid })).toBe(-1);
+    expect(cellFromPoint({ x: 10, y: -1, ...grid })).toBe(-1);
+    expect(cellFromPoint({ x: 200, y: 10, ...grid })).toBe(-1);
+    expect(cellFromPoint({ x: 10, y: 200, ...grid })).toBe(-1);
+  });
+
+  it('rejects nonsense geometry rather than returning a bogus cell', () => {
+    expect(cellFromPoint({ x: NaN, y: 10, ...grid })).toBe(-1);
+    expect(cellFromPoint({ x: 10, y: undefined, ...grid })).toBe(-1);
+    expect(cellFromPoint({ x: 10, y: 10, cellSize: 0, size: 5 })).toBe(-1);
+    expect(cellFromPoint({ x: 10, y: 10, cellSize: 40, size: 0 })).toBe(-1);
+  });
+
+  it('works for a bigger board', () => {
+    expect(cellFromPoint({ x: 5, y: 5, cellSize: 25, size: 8 })).toBe(0);
+    expect(cellFromPoint({ x: 199, y: 199, cellSize: 25, size: 8 })).toBe(63);
+  });
+});
+
+describe('cellsAlongLine', () => {
+  const size = 5;
+  const at = (row, col) => row * size + col;
+
+  it('returns the single cell when both ends are the same', () => {
+    expect(cellsAlongLine(at(2, 2), at(2, 2), size)).toEqual([at(2, 2)]);
+  });
+
+  it('fills a horizontal run', () => {
+    expect(cellsAlongLine(at(1, 0), at(1, 4), size)).toEqual([
+      at(1, 0),
+      at(1, 1),
+      at(1, 2),
+      at(1, 3),
+      at(1, 4),
+    ]);
+  });
+
+  it('fills a vertical run', () => {
+    expect(cellsAlongLine(at(0, 3), at(4, 3), size)).toEqual([
+      at(0, 3),
+      at(1, 3),
+      at(2, 3),
+      at(3, 3),
+      at(4, 3),
+    ]);
+  });
+
+  it('fills a diagonal', () => {
+    expect(cellsAlongLine(at(0, 0), at(4, 4), size)).toEqual([
+      at(0, 0),
+      at(1, 1),
+      at(2, 2),
+      at(3, 3),
+      at(4, 4),
+    ]);
+  });
+
+  it('works backwards as well as forwards', () => {
+    const forward = cellsAlongLine(at(0, 0), at(0, 4), size);
+    const backward = cellsAlongLine(at(0, 4), at(0, 0), size);
+
+    expect(backward).toEqual([...forward].reverse());
+  });
+
+  it('includes both endpoints on a shallow diagonal', () => {
+    const line = cellsAlongLine(at(0, 0), at(1, 4), size);
+
+    expect(line[0]).toBe(at(0, 0));
+    expect(line[line.length - 1]).toBe(at(1, 4));
+  });
+
+  it('never returns a cell twice, so a stroke cannot double back on itself', () => {
+    const line = cellsAlongLine(at(0, 0), at(4, 3), size);
+    expect(new Set(line).size).toBe(line.length);
+  });
+
+  it('stays on the board for every pair of cells', () => {
+    const total = size * size;
+    for (let from = 0; from < total; from++) {
+      for (let to = 0; to < total; to++) {
+        const line = cellsAlongLine(from, to, size);
+        expect(line[0]).toBe(from);
+        expect(line[line.length - 1]).toBe(to);
+        line.forEach((c) => {
+          expect(c).toBeGreaterThanOrEqual(0);
+          expect(c).toBeLessThan(total);
+        });
+      }
+    }
+  });
+
+  it('moves only to a touching cell at each step', () => {
+    // This is the property that matters for painting: a gap in the chain is a
+    // gap in the stroke.
+    const line = cellsAlongLine(0, 24, size);
+    for (let i = 1; i < line.length; i++) {
+      const prevRow = Math.floor(line[i - 1] / size);
+      const prevCol = line[i - 1] % size;
+      const row = Math.floor(line[i] / size);
+      const col = line[i] % size;
+
+      expect(Math.abs(row - prevRow)).toBeLessThanOrEqual(1);
+      expect(Math.abs(col - prevCol)).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('rejects invalid input', () => {
+    expect(cellsAlongLine(-1, 3, size)).toEqual([]);
+    expect(cellsAlongLine(3, 25, size)).toEqual([]);
+    expect(cellsAlongLine(1.5, 3, size)).toEqual([]);
+    expect(cellsAlongLine(0, 3, 0)).toEqual([]);
+  });
+});

--- a/SudokuApp/games/fungiku/__tests__/reducer.test.js
+++ b/SudokuApp/games/fungiku/__tests__/reducer.test.js
@@ -1,6 +1,7 @@
 import {
   DEFAULT_SEED,
   FUNGIKU_ACTIONS,
+  PAINT_MODES,
   buildPuzzleState,
   createInitialFungikuState,
   fungikuReducer,
@@ -276,5 +277,192 @@ describe('unknown actions', () => {
   it('leave state untouched', () => {
     const state = createInitialFungikuState();
     expect(fungikuReducer(state, { type: 'NOPE' })).toBe(state);
+  });
+});
+
+describe('drag strokes', () => {
+  const initial = buildPuzzleState({ size: 5, seed: 1 });
+  const begin = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.BEGIN_STROKE });
+  const end = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.END_STROKE });
+  const paint = (state, cells, mode = PAINT_MODES.X) =>
+    fungikuReducer(state, { type: FUNGIKU_ACTIONS.PAINT_CELLS, payload: { cells, mode } });
+  const undoOne = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.UNDO });
+
+  /** A whole stroke, the way the gesture drives it. */
+  const stroke = (state, batches, mode = PAINT_MODES.X) =>
+    end(batches.reduce((acc, cells) => paint(acc, cells, mode), begin(state)));
+
+  it('paints X across every cell of the stroke', () => {
+    const state = stroke(initial, [[0], [1, 2], [3, 4]]);
+
+    expect(state.marks.slice(0, 5)).toEqual([MARKS.X, MARKS.X, MARKS.X, MARKS.X, MARKS.X]);
+  });
+
+  it('records one undo entry for the whole stroke, not one per cell', () => {
+    const state = stroke(initial, [[0], [1, 2], [3, 4]]);
+
+    expect(state.undoStack).toHaveLength(1);
+    expect(undoOne(state).marks).toEqual(initial.marks);
+  });
+
+  it('erases back to empty when the stroke is an erase', () => {
+    const painted = stroke(initial, [[0, 1, 2]]);
+    const erased = stroke(painted, [[0, 1, 2]], PAINT_MODES.ERASE);
+
+    expect(erased.marks.slice(0, 3)).toEqual([MARKS.EMPTY, MARKS.EMPTY, MARKS.EMPTY]);
+    expect(erased.undoStack).toHaveLength(2); // one per stroke
+  });
+
+  it('never overwrites a mushroom', () => {
+    // Losing a deduced placement to a stray swipe is the worst failure here.
+    const withMushroom = placeMushroom(initial, 2);
+    const swept = stroke(withMushroom, [[0, 1, 2, 3, 4]]);
+
+    expect(swept.marks[2]).toBe(MARKS.MUSHROOM);
+    expect(swept.marks[1]).toBe(MARKS.X);
+    expect(swept.marks[3]).toBe(MARKS.X);
+  });
+
+  it('does not overwrite a mushroom on an erase stroke either', () => {
+    const withMushroom = placeMushroom(initial, 2);
+    const swept = stroke(withMushroom, [[0, 1, 2, 3, 4]], PAINT_MODES.ERASE);
+
+    expect(swept.marks[2]).toBe(MARKS.MUSHROOM);
+  });
+
+  it('is a no-op when the stroke changes nothing, leaving no undo entry', () => {
+    const painted = stroke(initial, [[0, 1]]);
+    const again = stroke(painted, [[0, 1]]);
+
+    expect(again.marks).toEqual(painted.marks);
+    expect(again.undoStack).toHaveLength(painted.undoStack.length);
+  });
+
+  it('still records one entry when the first cells of a stroke change nothing', () => {
+    // The stroke starts over an existing X (no change), then reaches blanks —
+    // the undo entry has to survive until the first cell that actually paints.
+    const seeded = stroke(initial, [[0]]);
+    const swept = stroke(seeded, [[0], [1], [2]]);
+
+    expect(swept.marks.slice(0, 3)).toEqual([MARKS.X, MARKS.X, MARKS.X]);
+    expect(swept.undoStack).toHaveLength(2);
+    expect(undoOne(swept).marks).toEqual(seeded.marks);
+  });
+
+  it('ignores cells outside the board', () => {
+    const state = stroke(initial, [[-1, 0, 25, 1.5]]);
+
+    expect(state.marks[0]).toBe(MARKS.X);
+    expect(state.marks).toHaveLength(25);
+  });
+
+  it('ignores an empty paint', () => {
+    const opened = begin(initial);
+    expect(paint(opened, [])).toBe(opened);
+    expect(paint(opened, null)).toBe(opened);
+  });
+
+  it('keeps strokeOpen out of the way once spent', () => {
+    const opened = begin(initial);
+    expect(opened.strokeOpen).toBe(true);
+
+    const painted = paint(opened, [0]);
+    expect(painted.strokeOpen).toBe(false);
+    expect(end(painted).strokeOpen).toBe(false);
+  });
+
+  it('cannot win the board by sweeping X everywhere', () => {
+    const all = Array.from({ length: 25 }, (_, i) => i);
+    const swept = stroke(initial, [all]);
+
+    expect(selectIsSolved(swept)).toBe(false);
+    expect(selectMushroomCount(swept)).toBe(0);
+  });
+});
+
+describe('the auto rule-out assist', () => {
+  const base = buildPuzzleState({ size: 5, seed: 1 });
+  const setAutoX = (state, value) =>
+    fungikuReducer(state, { type: FUNGIKU_ACTIONS.SET_AUTO_X, payload: value });
+
+  it('is off by default', () => {
+    expect(base.autoX).toBe(false);
+  });
+
+  it('does nothing when off', () => {
+    const placed = placeMushroom(base, 12);
+
+    expect(placed.marks.filter((m) => m !== MARKS.EMPTY)).toEqual([MARKS.MUSHROOM]);
+  });
+
+  it('rules out the row, column, region and neighbours when on', () => {
+    const on = setAutoX(base, true);
+    const cell = 12; // row 2, col 2
+    const placed = placeMushroom(on, cell);
+
+    expect(placed.marks[cell]).toBe(MARKS.MUSHROOM);
+
+    for (let i = 0; i < 5; i++) {
+      if (i !== 2) {
+        expect(placed.marks[2 * 5 + i]).toBe(MARKS.X);
+        expect(placed.marks[i * 5 + 2]).toBe(MARKS.X);
+      }
+    }
+    [6, 7, 8, 11, 13, 16, 17, 18].forEach((n) => {
+      expect(placed.marks[n]).toBe(MARKS.X);
+    });
+    const region = on.regions[cell];
+    on.regions.forEach((r, i) => {
+      if (r === region && i !== cell) expect(placed.marks[i]).toBe(MARKS.X);
+    });
+  });
+
+  it('fills as part of the same undo entry as the placement', () => {
+    const on = setAutoX(base, true);
+    const placed = placeMushroom(on, 12);
+    const back = fungikuReducer(placed, { type: FUNGIKU_ACTIONS.UNDO });
+
+    // One undo returns to the intermediate X of the two-tap placement, not to a
+    // board still littered with assist marks.
+    expect(back.marks[12]).toBe(MARKS.X);
+    expect(back.marks.filter((m) => m === MARKS.X)).toHaveLength(1);
+  });
+
+  it('never disturbs an existing mushroom', () => {
+    const on = setAutoX(base, true);
+    const second = placeMushroom(placeMushroom(on, 0), 12);
+
+    expect(second.marks[0]).toBe(MARKS.MUSHROOM);
+  });
+
+  it('only fires on the tap that places a mushroom', () => {
+    const on = setAutoX(base, true);
+    const toX = cycle(on, 12);
+
+    // First tap is just an X — nothing is ruled out by an X.
+    expect(toX.marks.filter((m) => m !== MARKS.EMPTY)).toEqual([MARKS.X]);
+  });
+
+  it('leaves its X marks behind when the mushroom is cycled away', () => {
+    // Deliberate: assist marks become ordinary X marks the moment they land.
+    // Retracting them would mean tracking which mushroom placed each one, and
+    // that is ambiguous as soon as two mushrooms rule out the same cell. Undo is
+    // the way to take a placement and its marks back together (covered above).
+    const on = setAutoX(base, true);
+    const placed = placeMushroom(on, 12);
+    const cycledAway = cycle(placed, 12);
+
+    expect(cycledAway.marks[12]).toBe(MARKS.EMPTY);
+    expect(cycledAway.marks.filter((m) => m === MARKS.X).length).toBeGreaterThan(0);
+  });
+
+  it('survives starting a new puzzle', () => {
+    expect(buildPuzzleState({ size: 6, seed: 2, autoX: true }).autoX).toBe(true);
+  });
+
+  it('still cannot win a board on X marks alone', () => {
+    const on = setAutoX(base, true);
+
+    expect(selectIsSolved(placeMushroom(on, 12))).toBe(false);
   });
 });

--- a/SudokuApp/games/fungiku/__tests__/reducer.test.js
+++ b/SudokuApp/games/fungiku/__tests__/reducer.test.js
@@ -10,6 +10,7 @@ import {
   selectConflicts,
   selectIsSolved,
   selectMushroomCount,
+  selectRuleOutCells,
 } from '../reducer';
 import { MARKS, MIN_SIZE, createEmptyMarks } from '../engine';
 
@@ -380,89 +381,94 @@ describe('drag strokes', () => {
   });
 });
 
-describe('the auto rule-out assist', () => {
+describe('the rule-out button', () => {
   const base = buildPuzzleState({ size: 5, seed: 1 });
-  const setAutoX = (state, value) =>
-    fungikuReducer(state, { type: FUNGIKU_ACTIONS.SET_AUTO_X, payload: value });
+  const ruleOut = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.RULE_OUT });
+  const undo = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.UNDO });
 
-  it('is off by default', () => {
-    expect(base.autoX).toBe(false);
+  it('does nothing on an empty board', () => {
+    // Nothing is placed, so nothing is forbidden yet.
+    expect(selectRuleOutCells(base).size).toBe(0);
+    expect(ruleOut(base)).toBe(base);
   });
 
-  it('does nothing when off', () => {
-    const placed = placeMushroom(base, 12);
-
-    expect(placed.marks.filter((m) => m !== MARKS.EMPTY)).toEqual([MARKS.MUSHROOM]);
-  });
-
-  it('rules out the row, column, region and neighbours when on', () => {
-    const on = setAutoX(base, true);
+  it('marks the row, column, region and neighbours of a placed mushroom', () => {
     const cell = 12; // row 2, col 2
-    const placed = placeMushroom(on, cell);
+    const placed = placeMushroom(base, cell);
+    const after = ruleOut(placed);
 
-    expect(placed.marks[cell]).toBe(MARKS.MUSHROOM);
+    expect(after.marks[cell]).toBe(MARKS.MUSHROOM);
 
     for (let i = 0; i < 5; i++) {
       if (i !== 2) {
-        expect(placed.marks[2 * 5 + i]).toBe(MARKS.X);
-        expect(placed.marks[i * 5 + 2]).toBe(MARKS.X);
+        expect(after.marks[2 * 5 + i]).toBe(MARKS.X);
+        expect(after.marks[i * 5 + 2]).toBe(MARKS.X);
       }
     }
-    [6, 7, 8, 11, 13, 16, 17, 18].forEach((n) => {
-      expect(placed.marks[n]).toBe(MARKS.X);
+    [6, 7, 8, 11, 13, 16, 17, 18].forEach((n) => expect(after.marks[n]).toBe(MARKS.X));
+
+    const region = base.regions[cell];
+    base.regions.forEach((r, i) => {
+      if (r === region && i !== cell) expect(after.marks[i]).toBe(MARKS.X);
     });
-    const region = on.regions[cell];
-    on.regions.forEach((r, i) => {
-      if (r === region && i !== cell) expect(placed.marks[i]).toBe(MARKS.X);
-    });
   });
 
-  it('fills as part of the same undo entry as the placement', () => {
-    const on = setAutoX(base, true);
-    const placed = placeMushroom(on, 12);
-    const back = fungikuReducer(placed, { type: FUNGIKU_ACTIONS.UNDO });
+  it('accounts for every placed mushroom at once, not just the last', () => {
+    const two = placeMushroom(placeMushroom(base, 0), 12);
+    const after = ruleOut(two);
 
-    // One undo returns to the intermediate X of the two-tap placement, not to a
-    // board still littered with assist marks.
-    expect(back.marks[12]).toBe(MARKS.X);
-    expect(back.marks.filter((m) => m === MARKS.X)).toHaveLength(1);
+    // Row 0 belongs to the mushroom at 0; row 2 to the one at 12.
+    expect(after.marks[1]).toBe(MARKS.X);
+    expect(after.marks[14]).toBe(MARKS.X);
   });
 
-  it('never disturbs an existing mushroom', () => {
-    const on = setAutoX(base, true);
-    const second = placeMushroom(placeMushroom(on, 0), 12);
+  it('is one undoable action however many cells it fills', () => {
+    const placed = placeMushroom(base, 12);
+    const after = ruleOut(placed);
 
-    expect(second.marks[0]).toBe(MARKS.MUSHROOM);
+    expect(after.undoStack).toHaveLength(placed.undoStack.length + 1);
+    expect(undo(after).marks).toEqual(placed.marks);
   });
 
-  it('only fires on the tap that places a mushroom', () => {
-    const on = setAutoX(base, true);
-    const toX = cycle(on, 12);
+  it('never disturbs a mushroom, including a conflicting one', () => {
+    // Two mushrooms in row 0 conflict; each rules the other's cell out, and
+    // neither may be overwritten — the player is mid-deduction.
+    const conflicting = placeMushroom(placeMushroom(base, 0), 3);
+    const after = ruleOut(conflicting);
 
-    // First tap is just an X — nothing is ruled out by an X.
-    expect(toX.marks.filter((m) => m !== MARKS.EMPTY)).toEqual([MARKS.X]);
+    expect(after.marks[0]).toBe(MARKS.MUSHROOM);
+    expect(after.marks[3]).toBe(MARKS.MUSHROOM);
+  });
+
+  it('only fills blanks, leaving existing marks alone', () => {
+    const placed = placeMushroom(base, 12);
+    const after = ruleOut(placed);
+    const again = ruleOut(after);
+
+    // Second tap has nothing left to do, so it is a no-op with no undo entry.
+    expect(again).toBe(after);
+    expect(selectRuleOutCells(after).size).toBe(0);
+  });
+
+  it('reports how many cells it would fill, for the button label', () => {
+    const placed = placeMushroom(base, 12);
+
+    expect(selectRuleOutCells(placed).size).toBeGreaterThan(0);
+    expect(selectRuleOutCells(placed).has(12)).toBe(false);
   });
 
   it('leaves its X marks behind when the mushroom is cycled away', () => {
-    // Deliberate: assist marks become ordinary X marks the moment they land.
-    // Retracting them would mean tracking which mushroom placed each one, and
-    // that is ambiguous as soon as two mushrooms rule out the same cell. Undo is
-    // the way to take a placement and its marks back together (covered above).
-    const on = setAutoX(base, true);
-    const placed = placeMushroom(on, 12);
-    const cycledAway = cycle(placed, 12);
+    // Deliberate: they become ordinary X marks the moment they land. Retracting
+    // them would need per-mark provenance, which is ambiguous as soon as two
+    // mushrooms rule out the same cell. Undo is how you take the assist back.
+    const after = ruleOut(placeMushroom(base, 12));
+    const cycledAway = cycle(after, 12);
 
     expect(cycledAway.marks[12]).toBe(MARKS.EMPTY);
     expect(cycledAway.marks.filter((m) => m === MARKS.X).length).toBeGreaterThan(0);
   });
 
-  it('survives starting a new puzzle', () => {
-    expect(buildPuzzleState({ size: 6, seed: 2, autoX: true }).autoX).toBe(true);
-  });
-
-  it('still cannot win a board on X marks alone', () => {
-    const on = setAutoX(base, true);
-
-    expect(selectIsSolved(placeMushroom(on, 12))).toBe(false);
+  it('cannot win a board on its own', () => {
+    expect(selectIsSolved(ruleOut(placeMushroom(base, 12)))).toBe(false);
   });
 });

--- a/SudokuApp/games/fungiku/engine.js
+++ b/SudokuApp/games/fungiku/engine.js
@@ -435,3 +435,41 @@ export function countMushrooms(marks) {
 export function createEmptyMarks(size) {
   return new Array(size * size).fill(MARKS.EMPTY);
 }
+
+/**
+ * Every cell a mushroom at `cell` rules out: its whole row, its whole column,
+ * its whole color region, and the eight cells touching it (plan §1). `cell`
+ * itself is not included.
+ *
+ * This lives in the engine because it is a restatement of the rules, and the
+ * rules exist in exactly one place. It powers the optional auto-X assist
+ * (plan §2), which is precisely "mark everything this placement forbids".
+ *
+ * @returns {Set<number>} flat indices
+ */
+export function cellsRuledOutBy(cell, regions, size) {
+  const out = new Set();
+  const row = Math.floor(cell / size);
+  const col = cell % size;
+  const region = regions[cell];
+
+  for (let i = 0; i < size; i++) {
+    out.add(idx(row, i, size)); // rule 1: one per row
+    out.add(idx(i, col, size)); // rule 2: one per column
+  }
+
+  // rule 3: one per region
+  for (let i = 0; i < regions.length; i++) {
+    if (regions[i] === region) out.add(i);
+  }
+
+  // rule 4: no two mushrooms touch, diagonals included
+  for (let r = row - 1; r <= row + 1; r++) {
+    for (let c = col - 1; c <= col + 1; c++) {
+      if (r >= 0 && c >= 0 && r < size && c < size) out.add(idx(r, c, size));
+    }
+  }
+
+  out.delete(cell);
+  return out;
+}

--- a/SudokuApp/games/fungiku/geometry.js
+++ b/SudokuApp/games/fungiku/geometry.js
@@ -1,0 +1,85 @@
+/**
+ * Turning touch points into board cells.
+ *
+ * Pure functions, deliberately: this is the part of the drag gesture that can be
+ * unit-tested, and gesture bugs are otherwise only findable on a device. The
+ * component's job is reduced to "measure the board, hand over points".
+ *
+ * Nothing here knows about React Native — see FungikuBoard.js for the
+ * PanResponder that feeds it, and docs/fungiku-plan.md §2 for the behavior spec.
+ */
+
+/**
+ * Which cell contains a point expressed **relative to the board's top-left**?
+ *
+ * @param {object} opts
+ * @param {number} opts.x - px from the board's left edge
+ * @param {number} opts.y - px from the board's top edge
+ * @param {number} opts.cellSize - px per cell
+ * @param {number} opts.size - board size N
+ * @returns {number} flat cell index, or -1 when the point is off the board
+ */
+export const cellFromPoint = ({ x, y, cellSize, size }) => {
+  if (!Number.isFinite(x) || !Number.isFinite(y) || !(cellSize > 0) || !(size > 0)) {
+    return -1;
+  }
+
+  const col = Math.floor(x / cellSize);
+  const row = Math.floor(y / cellSize);
+
+  if (row < 0 || col < 0 || row >= size || col >= size) return -1;
+
+  return row * size + col;
+};
+
+/**
+ * Every cell on the straight line between two cells, inclusive.
+ *
+ * A finger moving quickly delivers sparse move events — at speed you can jump
+ * three cells between two frames. Without this, a fast sweep leaves gaps
+ * (plan §2: "diagonal and fast strokes must fill every cell crossed"). Bresenham
+ * over (row, col) is exact, integer-only, and handles diagonals.
+ *
+ * @returns {number[]} indices from `from` to `to`; `[]` if either is invalid
+ */
+export const cellsAlongLine = (from, to, size) => {
+  if (!(size > 0)) return [];
+  const total = size * size;
+  if (!Number.isInteger(from) || !Number.isInteger(to)) return [];
+  if (from < 0 || to < 0 || from >= total || to >= total) return [];
+  if (from === to) return [from];
+
+  let row = Math.floor(from / size);
+  let col = from % size;
+  const endRow = Math.floor(to / size);
+  const endCol = to % size;
+
+  const dRow = Math.abs(endRow - row);
+  const dCol = Math.abs(endCol - col);
+  const stepRow = row < endRow ? 1 : -1;
+  const stepCol = col < endCol ? 1 : -1;
+
+  let error = dCol - dRow;
+  const cells = [];
+
+  // Bounded by the grid's diagonal, so this cannot run away even if the
+  // arithmetic is fed something unexpected.
+  for (let guard = 0; guard <= dRow + dCol + 1; guard++) {
+    cells.push(row * size + col);
+    if (row === endRow && col === endCol) break;
+
+    const doubled = 2 * error;
+    if (doubled > -dRow) {
+      error -= dRow;
+      col += stepCol;
+    }
+    if (doubled < dCol) {
+      error += dCol;
+      row += stepRow;
+    }
+  }
+
+  return cells;
+};
+
+export default { cellFromPoint, cellsAlongLine };

--- a/SudokuApp/games/fungiku/reducer.js
+++ b/SudokuApp/games/fungiku/reducer.js
@@ -17,6 +17,7 @@
 import {
   MARKS,
   MIN_SIZE,
+  cellsRuledOutBy,
   createEmptyMarks,
   countMushrooms,
   findConflicts,
@@ -32,7 +33,19 @@ export const FUNGIKU_ACTIONS = {
   UNDO: 'FUNGIKU_UNDO',
   REDO: 'FUNGIKU_REDO',
   RESTORE_SAVED_GAME: 'FUNGIKU_RESTORE_SAVED_GAME',
+
+  // Drag-to-sweep (plan §2). A stroke paints many cells over many frames but
+  // must undo as one action, so the gesture opens a stroke, paints repeatedly,
+  // and closes it.
+  BEGIN_STROKE: 'FUNGIKU_BEGIN_STROKE',
+  PAINT_CELLS: 'FUNGIKU_PAINT_CELLS',
+  END_STROKE: 'FUNGIKU_END_STROKE',
+
+  SET_AUTO_X: 'FUNGIKU_SET_AUTO_X',
 };
+
+/** What a drag stroke does to the cells it crosses. */
+export const PAINT_MODES = { X: 'x', ERASE: 'erase' };
 
 export const DEFAULT_SIZE = MIN_SIZE;
 export const DEFAULT_SEED = 1;
@@ -44,7 +57,12 @@ export const DEFAULT_SEED = 1;
  *
  * @param {{size: number, seed: number, marks?: string[]}} opts
  */
-export const buildPuzzleState = ({ size = DEFAULT_SIZE, seed = DEFAULT_SEED, marks } = {}) => {
+export const buildPuzzleState = ({
+  size = DEFAULT_SIZE,
+  seed = DEFAULT_SEED,
+  marks,
+  autoX = false,
+} = {}) => {
   const puzzle = generate({ size, seed });
 
   return {
@@ -59,6 +77,13 @@ export const buildPuzzleState = ({ size = DEFAULT_SIZE, seed = DEFAULT_SEED, mar
         : createEmptyMarks(puzzle.size),
     undoStack: [],
     redoStack: [],
+    // Assist preference (plan §2). Off by default until the operator says
+    // otherwise (§8 #5) — it removes most of the deduction if left on.
+    autoX: !!autoX,
+    // Transient: true between BEGIN_STROKE and the stroke's first effective
+    // paint, which is the paint that records the single undo entry. Never
+    // persisted (see ./storage.js).
+    strokeOpen: false,
   };
 };
 
@@ -94,7 +119,63 @@ export function fungikuReducer(state, action) {
       // shown, never blocked — spotting and fixing them is the puzzle.
       const marks = state.marks.slice();
       marks[cell] = nextMark(marks[cell]);
+
+      // The auto-X assist rides along inside the same action, so placing a
+      // mushroom and the X's it implies are a single undo (plan §2).
+      //
+      // Note the marks it places are *ordinary* X marks: cycling the mushroom
+      // away later leaves them behind, and undo is how you take a placement and
+      // its marks back together. Retracting them on removal would mean tracking
+      // which mushroom placed each mark, which is ambiguous the moment two
+      // mushrooms rule out the same cell.
+      if (state.autoX && marks[cell] === MARKS.MUSHROOM) {
+        cellsRuledOutBy(cell, state.regions, state.size).forEach((ruled) => {
+          // Only fill blanks: never disturb another mushroom, and never
+          // overwrite an X the player placed deliberately.
+          if (marks[ruled] === MARKS.EMPTY) marks[ruled] = MARKS.X;
+        });
+      }
+
       return pushHistory(state, marks);
+    }
+
+    case FUNGIKU_ACTIONS.SET_AUTO_X:
+      return { ...state, autoX: !!action.payload };
+
+    case FUNGIKU_ACTIONS.BEGIN_STROKE:
+      // Nothing is painted yet; the first effective paint spends this flag on
+      // the stroke's one undo entry.
+      return state.strokeOpen ? state : { ...state, strokeOpen: true };
+
+    case FUNGIKU_ACTIONS.END_STROKE:
+      return state.strokeOpen ? { ...state, strokeOpen: false } : state;
+
+    case FUNGIKU_ACTIONS.PAINT_CELLS: {
+      const { cells, mode } = action.payload;
+      if (!Array.isArray(cells) || cells.length === 0) return state;
+
+      const target = mode === PAINT_MODES.ERASE ? MARKS.EMPTY : MARKS.X;
+
+      let marks = null;
+      cells.forEach((cell) => {
+        if (!Number.isInteger(cell) || cell < 0 || cell >= state.marks.length) return;
+
+        // A stroke never disturbs a mushroom (plan §2) — losing a deduced
+        // placement to a stray swipe is the worst thing this gesture could do.
+        const current = (marks || state.marks)[cell];
+        if (current === MARKS.MUSHROOM || current === target) return;
+
+        if (!marks) marks = state.marks.slice();
+        marks[cell] = target;
+      });
+
+      // Nothing actually changed: leave the stroke open so the *next* cell it
+      // reaches is the one that records the undo entry.
+      if (!marks) return state;
+
+      return state.strokeOpen
+        ? { ...pushHistory(state, marks), strokeOpen: false }
+        : { ...state, marks };
     }
 
     case FUNGIKU_ACTIONS.CLEAR_MARKS: {

--- a/SudokuApp/games/fungiku/reducer.js
+++ b/SudokuApp/games/fungiku/reducer.js
@@ -41,7 +41,9 @@ export const FUNGIKU_ACTIONS = {
   PAINT_CELLS: 'FUNGIKU_PAINT_CELLS',
   END_STROKE: 'FUNGIKU_END_STROKE',
 
-  SET_AUTO_X: 'FUNGIKU_SET_AUTO_X',
+  // "Rule out" — one tap marks every cell the mushrooms already on the board
+  // forbid. An action the player asks for, not a mode that acts behind them.
+  RULE_OUT: 'FUNGIKU_RULE_OUT',
 };
 
 /** What a drag stroke does to the cells it crosses. */
@@ -57,12 +59,7 @@ export const DEFAULT_SEED = 1;
  *
  * @param {{size: number, seed: number, marks?: string[]}} opts
  */
-export const buildPuzzleState = ({
-  size = DEFAULT_SIZE,
-  seed = DEFAULT_SEED,
-  marks,
-  autoX = false,
-} = {}) => {
+export const buildPuzzleState = ({ size = DEFAULT_SIZE, seed = DEFAULT_SEED, marks } = {}) => {
   const puzzle = generate({ size, seed });
 
   return {
@@ -77,9 +74,6 @@ export const buildPuzzleState = ({
         : createEmptyMarks(puzzle.size),
     undoStack: [],
     redoStack: [],
-    // Assist preference (plan §2). Off by default until the operator says
-    // otherwise (§8 #5) — it removes most of the deduction if left on.
-    autoX: !!autoX,
     // Transient: true between BEGIN_STROKE and the stroke's first effective
     // paint, which is the paint that records the single undo entry. Never
     // persisted (see ./storage.js).
@@ -119,28 +113,25 @@ export function fungikuReducer(state, action) {
       // shown, never blocked — spotting and fixing them is the puzzle.
       const marks = state.marks.slice();
       marks[cell] = nextMark(marks[cell]);
-
-      // The auto-X assist rides along inside the same action, so placing a
-      // mushroom and the X's it implies are a single undo (plan §2).
-      //
-      // Note the marks it places are *ordinary* X marks: cycling the mushroom
-      // away later leaves them behind, and undo is how you take a placement and
-      // its marks back together. Retracting them on removal would mean tracking
-      // which mushroom placed each mark, which is ambiguous the moment two
-      // mushrooms rule out the same cell.
-      if (state.autoX && marks[cell] === MARKS.MUSHROOM) {
-        cellsRuledOutBy(cell, state.regions, state.size).forEach((ruled) => {
-          // Only fill blanks: never disturb another mushroom, and never
-          // overwrite an X the player placed deliberately.
-          if (marks[ruled] === MARKS.EMPTY) marks[ruled] = MARKS.X;
-        });
-      }
-
       return pushHistory(state, marks);
     }
 
-    case FUNGIKU_ACTIONS.SET_AUTO_X:
-      return { ...state, autoX: !!action.payload };
+    case FUNGIKU_ACTIONS.RULE_OUT: {
+      const ruled = selectRuleOutCells(state);
+      if (ruled.size === 0) return state;
+
+      const marks = state.marks.slice();
+      ruled.forEach((cell) => {
+        marks[cell] = MARKS.X;
+      });
+
+      // One undo entry for the whole sweep, same as a drag stroke. The marks it
+      // places are *ordinary* X marks from here on: removing a mushroom later
+      // leaves them behind, and undo is how you take the whole assist back.
+      // Retracting them per-mushroom would need per-mark provenance, which is
+      // ambiguous the moment two mushrooms rule out the same cell.
+      return pushHistory(state, marks);
+    }
 
     case FUNGIKU_ACTIONS.BEGIN_STROKE:
       // Nothing is painted yet; the first effective paint spends this flag on
@@ -220,6 +211,27 @@ export const selectMushroomCount = (state) => countMushrooms(state.marks);
 
 /** Won when N mushrooms sit legally. X marks are ignored entirely (plan §9). */
 export const selectIsSolved = (state) => isSolved(state.marks, state.regions, state.size);
+
+/**
+ * Empty cells that the mushrooms already on the board forbid — what one tap of
+ * "Rule out" fills in (plan §2).
+ *
+ * Only blanks: an existing X is already correct, and a mushroom is never
+ * disturbed, not even a conflicting one (the player is mid-deduction and it is
+ * theirs to move).
+ */
+export const selectRuleOutCells = (state) => {
+  const out = new Set();
+
+  state.marks.forEach((mark, cell) => {
+    if (mark !== MARKS.MUSHROOM) return;
+    cellsRuledOutBy(cell, state.regions, state.size).forEach((ruled) => {
+      if (state.marks[ruled] === MARKS.EMPTY) out.add(ruled);
+    });
+  });
+
+  return out;
+};
 
 export const selectCanUndo = (state) => state.undoStack.length > 0;
 export const selectCanRedo = (state) => state.redoStack.length > 0;

--- a/SudokuApp/games/fungiku/storage.js
+++ b/SudokuApp/games/fungiku/storage.js
@@ -35,7 +35,12 @@ export const loadFungikuState = async () => {
 
     // Rebuilding through buildPuzzleState also validates the save: a `marks`
     // array of the wrong length for this size is discarded, not rendered.
-    return buildPuzzleState({ size: saved.size, seed: saved.seed, marks: saved.marks });
+    return buildPuzzleState({
+      size: saved.size,
+      seed: saved.seed,
+      marks: saved.marks,
+      autoX: saved.autoX,
+    });
   } catch (error) {
     console.error('Error loading Fungiku state:', error);
     return null;
@@ -52,6 +57,9 @@ export const saveFungikuState = debounce(async (state) => {
         size: state.size,
         seed: state.seed,
         marks: state.marks,
+        // The assist preference persists; `strokeOpen` deliberately does not —
+        // it is transient gesture bookkeeping.
+        autoX: !!state.autoX,
       })
     );
   } catch (error) {

--- a/SudokuApp/games/fungiku/storage.js
+++ b/SudokuApp/games/fungiku/storage.js
@@ -35,12 +35,7 @@ export const loadFungikuState = async () => {
 
     // Rebuilding through buildPuzzleState also validates the save: a `marks`
     // array of the wrong length for this size is discarded, not rendered.
-    return buildPuzzleState({
-      size: saved.size,
-      seed: saved.seed,
-      marks: saved.marks,
-      autoX: saved.autoX,
-    });
+    return buildPuzzleState({ size: saved.size, seed: saved.seed, marks: saved.marks });
   } catch (error) {
     console.error('Error loading Fungiku state:', error);
     return null;
@@ -57,9 +52,9 @@ export const saveFungikuState = debounce(async (state) => {
         size: state.size,
         seed: state.seed,
         marks: state.marks,
-        // The assist preference persists; `strokeOpen` deliberately does not —
-        // it is transient gesture bookkeeping.
-        autoX: !!state.autoX,
+        // `strokeOpen` deliberately does not persist — it is transient gesture
+        // bookkeeping. Nor does anything about the rule-out assist: it is an
+        // action the player taps, not a mode with a remembered setting.
       })
     );
   } catch (error) {

--- a/SudokuApp/hooks/useBoardOrigin.js
+++ b/SudokuApp/hooks/useBoardOrigin.js
@@ -1,0 +1,59 @@
+import { useCallback, useRef } from 'react';
+
+/**
+ * The board's top-left position in window coordinates.
+ *
+ * **This exists because `locationX`/`locationY` cannot be trusted.** On the new
+ * architecture, a `PanResponder`'s `locationX`/`locationY` are relative to the
+ * *child* view the touch landed on — a single cell — not to the responder. Any
+ * gesture that needs "where on the board am I?" has to use `pageX`/`pageY` minus
+ * the board's own origin. (The sibling color-loop app hit this in both of its
+ * games and a slider on the SDK 54 upgrade; docs/fungiku-plan.md §2 records it.)
+ *
+ * The origin is re-measured **at gesture grant**, not only on layout, because a
+ * flex-centered board moves when something above it appears — Fungiku's win
+ * banner mounts and unmounts, which shifts the board by its whole height.
+ *
+ * Usage:
+ *   const { ref, onLayout, measure, toLocal } = useBoardOrigin();
+ *   <View ref={ref} onLayout={onLayout} {...responder.panHandlers} />
+ *   // in onPanResponderGrant: measure();
+ *   // then: toLocal(nativeEvent.pageX, nativeEvent.pageY)
+ */
+const useBoardOrigin = () => {
+  const ref = useRef(null);
+  const origin = useRef({ x: 0, y: 0 });
+
+  /**
+   * Re-read the origin. Asynchronous by nature (it round-trips to the native
+   * layout), so callers get the previous value until it resolves — which is why
+   * `onLayout` primes it and grant only refreshes it.
+   */
+  const measure = useCallback(() => {
+    const node = ref.current;
+    if (node && typeof node.measureInWindow === 'function') {
+      node.measureInWindow((x, y) => {
+        if (Number.isFinite(x) && Number.isFinite(y)) {
+          origin.current = { x, y };
+        }
+      });
+    }
+  }, []);
+
+  const onLayout = useCallback(() => {
+    measure();
+  }, [measure]);
+
+  /** Convert a window-space point to board-space. */
+  const toLocal = useCallback(
+    (pageX, pageY) => ({
+      x: pageX - origin.current.x,
+      y: pageY - origin.current.y,
+    }),
+    []
+  );
+
+  return { ref, onLayout, measure, toLocal };
+};
+
+export default useBoardOrigin;

--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -192,10 +192,16 @@ ladder.
 
 ### Noted in passing, for a later step
 
-- **Dragging on the board never scrolls the page.** The stroke claims the
-  responder and refuses to hand it back mid-sweep, which is what makes painting
-  reliable — but it means the board is not a place you can scroll from. Drag
-  outside the board instead. Fine on a tall phone; revisit if the screen grows.
+- **Dragging on the board never scrolls the page.** The board claims every touch
+  at touch-down — that is the fix for the operator's device report that a vertical
+  drag scrolled instead of painting (plan §2, "The ScrollView race"). It means the
+  board is not a place you can scroll from; drag outside it. Fine on a tall phone
+  even at 8×8; revisit if the screen grows.
+- **Web cells are no longer keyboard-focusable.** They were `TouchableOpacity`
+  (focusable buttons) and are now plain `View`s, because the board owns the touch
+  and a child Touchable would never see a press. Labels and `onAccessibilityTap`
+  are intact; keyboard tabbing to a cell is not. Revisit if web keyboard play
+  ever matters.
 - **Auto rule-out marks are ordinary X marks once placed.** Cycling the mushroom
   away leaves them behind; undo takes the placement and its marks back together.
   Retracting them on removal would need per-mark provenance, which is ambiguous

--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -92,85 +92,95 @@ operator to test in Expo Go.**
 
 ---
 
-## Next step: **Step 7 — the training ladder and scoring**
+## Next step: **Step 7 — feedback on your moves, and hints**
 
-Branch: **`feature/fungiku-ladder`** off `epic/fungiku`.
-Plan: the §7 table row for step 7, plus **§8 #4**, which this step needs answered
-(or defaulted, with the default stated in the PR).
+Branch: **`feature/fungiku-feedback`** off `epic/fungiku`.
+Plan: **§11**, which is the whole spec — read it end to end. Also §8 #6 and #7,
+the two questions this step raises.
 
 ### Why this step exists
 
-Fungiku is a complete puzzle you can play, but it has **no shape as a game**. You
-pick a size from four chips and press "New puzzle" for a random seed; nothing
-tracks what you have done, nothing gets harder, nothing tells you that you are
-improving. This step turns a puzzle generator into something worth coming back
-to.
+Two gaps, both requested by the operator. Today the board tells you when you have
+**broken a rule** and nothing else: it never tells you a legal move was *wrong*,
+and when you are genuinely stuck your only options are guess or walk away.
+
+It comes before the ladder and scoring on purpose: **scoring has to know what a
+mistake and a hint are worth.** Building scoring first would mean guessing at the
+currency it is denominated in.
 
 ### Read first
 
-- `SudokuApp/games/fungiku/reducer.js` and `FungikuContext.js` — where progress
-  state has to live, and how `size`/`seed` currently change (`changeSize` resets
-  to seed 1; `nextPuzzle` bumps the seed).
-- `SudokuApp/games/fungiku/storage.js` — persistence is `size` + `seed` + `marks`
-  + `autoX`. Ladder progress is the first thing that needs a **schema change**;
-  bump `FUNGIKU_STORAGE_VERSION` and decide what an old save migrates to (today
-  a version mismatch returns null and the board starts fresh — that is fine for
-  a board, less fine for someone's progress).
-- `SudokuApp/utils/gameProgress.js` + `games/registry.js` — `describeFungikuProgress`
-  feeds the hub's Continue badge. With a ladder, the badge probably wants to say
-  which *level* you are on rather than which board size.
-- **The sibling color-loop app is the reference for this exact problem** — it has
-  a training ladder in `games/colorloop/levels.ts` with per-level star
-  thresholds, and its `docs/game-design.md` covers the progression thinking.
-  Worth reading before designing a second one from scratch.
-- `SudokuApp/contexts/GameContext.js` — Sudoku's scoring (time-based, with
-  completion bonuses) is a model for what "scoring" can mean here. Fungiku has no
-  timer at all today, which is a decision this step has to make deliberately.
+- **`docs/fungiku-plan.md` §11** — the spec. Four kinds of feedback (§11.1) and a
+  four-rung hint ladder (§11.2), with what each costs to build.
+- `SudokuApp/games/fungiku/engine.js` — `generate()` already returns `solution`,
+  and `findSolutions(regions, size, limit)` recovers it from a layout. That is all
+  correctness feedback and the revealing hints need. What the engine does **not**
+  have is any notion of a move being *forced*, which is what hint rung 2 needs.
+- `SudokuApp/games/fungiku/reducer.js` — `selectConflicts` is the model to copy
+  for a `selectMistakes`-style selector: **derive it, never store it**, or undo
+  will leave stale flags behind. `selectRuleOutCells` shows the shape for "cells a
+  hint would touch".
+- `SudokuApp/games/fungiku/FungikuBoard.js` — where a mistake marker has to
+  render. Note conflicts already own the ring and the recoloured glyph, so a
+  mistake needs a *different* visual channel; and note the accessibility label
+  format, which must grow to carry the new state.
+- `SudokuApp/contexts/GameContext.js` + `components/modals/GameMenuModal.js` —
+  Sudoku's **"Show Mistakes"** switch, its `showFeedback` flag and its
+  `cellFeedback` map. Match its wording and placement so the app has one
+  vocabulary for the idea. Read it; don't refactor it.
+- `SudokuApp/games/fungiku/__tests__/reducer.test.js` — the style to extend. The
+  selectors are pure and deserve the same coverage the others got.
 
 ### Scope — ONLY this
 
-1. **A level ladder** — an ordered list of levels, each pinning a `size` and a
-   `seed` (both already deterministic, so a level *is* a `{size, seed}` pair).
-   Keep it data, in its own module, so tuning is editing a table.
-2. **Progression + persistence** — which levels are complete, and what unlocks.
-   Bump the storage version and migrate rather than discarding progress.
-3. **A level-select surface** on the Fungiku screen, replacing the raw size chips
-   as the primary path. Keep a way to play an arbitrary size — the chips are
-   useful for testing, and "free play" is a reasonable answer to §8 #4.
-4. **Scoring** — decide what it measures and say why in the PR. If it needs a
-   timer, add one, and note that Fungiku deliberately had none until now.
-5. **Hub integration** — the Continue badge should reflect ladder position.
-6. **Tests** — the ladder table and progression logic are pure; cover them. Pin
-   that every level in the table actually generates (a bad `{size, seed}` pair
-   would otherwise only fail when a player reaches it).
+1. **Correctness feedback, opt-in** — a selector flagging mushrooms not in the
+   solution, a switch to turn it on, and a board treatment distinct from
+   conflicts. Off by default pending §8 #7.
+2. **Positive confirmation** — a correct placement should *feel* correct, not
+   merely fail to turn red. A settle or pulse in the app's motion language.
+   §11.1 calls this the most-often-skipped half of feedback; do not skip it.
+3. **Hint rungs 3 and 4** — reveal a correct mushroom, and point out a mistake.
+   Both are trivial given the solution, both are one undoable action.
+4. **Hint rung 2 (the nudge) — attempt it, and be honest if it does not land.**
+   Naming a row/column/region where a deduction is *available* needs constraint
+   propagation, not the existing backtracking solver. It is the real work here
+   and the best hint in a teaching game. If it proves too big, ship rungs 3–4 and
+   say plainly in the PR that the nudge is deferred — **do not fake it** by
+   dressing up a reveal as a nudge.
+5. **Count hints used per puzzle** — the ladder step needs it, and it is far
+   easier to record now than to retrofit.
+6. **Tests** for every new selector, and for the hint invariants below.
 
 ### Behaviors that are easy to get wrong
 
-- **Every level must be generatable.** `generate()` throws for `size < 5`; a
-  typo in the table becomes a crash for whoever reaches that level. Assert the
-  whole table in a test.
-- **Don't lose existing progress on the schema change.** A player mid-board today
-  has `{size, seed, marks, autoX}` and no ladder state; that has to migrate to
-  something sensible, not to a wiped save.
-- **Star thresholds and difficulty curves are guesses until played.** Draft them,
-  say in the PR that they are estimates, and flag them for the operator to tune
-  on device — the same way color-loop's ladder was left.
-- **Keep free play reachable.** Locking size behind progression makes the 8×8
-  regression cases harder to check; a dev/test path must survive.
+- **X marks are never wrong.** Correctness feedback applies to **mushrooms only**
+  (§11.1). Flagging a "wrong" X is telling the player how to think.
+- **There is no complete-but-wrong board.** Uniqueness means N mushrooms placed
+  with no conflicts *is* the solution, so correctness feedback is purely a
+  mid-solve aid — it can never be what tells you a finished board is wrong.
+  A test asserting "a legal full board is never flagged" is worth having.
+- **A hint must never place a conflicting mushroom.** Worse than no hint.
+- **Derive feedback, don't store it.** Same reason conflicts are a selector: undo
+  must not be able to leave a stale mistake marker on the board.
+- **Conflicts and mistakes are different things** and can coexist on one cell. Do
+  not let one visual treatment swallow the other, and keep both readable without
+  color (plan §5) and on a dark theme.
+- **Don't regress the cell accessibility labels** — they are the test seam. Extend
+  the format, don't reshape it.
 
 ### Out of scope for this step
 
-- **No art swap** — Step 8, gated on artwork rather than code.
-- **No new input features.** Tap, drag-to-sweep and auto-X are done; don't
-  revisit them.
-- **No engine changes.** Levels are `{size, seed}` pairs over the existing
-  generator.
+- **No ladder, progression or scoring** — Step 8. Count hints, don't price them.
+- **No art swap** — Step 9, gated on artwork rather than code.
+- **No Sudoku changes.** Its "Show Mistakes" is a reference for wording and
+  placement, not something to refactor or share code with.
 
 ### Visible in Expo Go when this lands
 
-A **level list** you progress through, with completed levels marked, and a score
-or rating when you solve one. The hub's Fungiku card says where you are in the
-ladder.
+Turn **Show Mistakes** on, place a mushroom that breaks no rule but is in the
+wrong cell, and see it flagged as a mistake rather than as a conflict. Get stuck
+and **ask for a hint**, and get help proportional to what you asked for. A correct
+placement feels like one.
 
 ## Open questions for the operator (carry these forward)
 
@@ -202,15 +212,14 @@ ladder.
   and a child Touchable would never see a press. Labels and `onAccessibilityTap`
   are intact; keyboard tabbing to a cell is not. Revisit if web keyboard play
   ever matters.
-- **Auto rule-out marks are ordinary X marks once placed.** Cycling the mushroom
-  away leaves them behind; undo takes the placement and its marks back together.
-  Retracting them on removal would need per-mark provenance, which is ambiguous
-  as soon as two mushrooms rule out the same cell. Revisit only if it annoys the
-  operator in practice.
-- **`accessibilityState.checked` does not reach `aria-checked` on web.** The
-  auto rule-out toggle names its state in its `accessibilityLabel`
-  ("Auto rule-out, on") because that is the only place a screen reader or a test
-  can read it reliably. Worth remembering for any future toggle.
+- **Rule-out marks are ordinary X marks once placed.** Removing the mushroom that
+  implied them leaves them behind; undo takes the whole fill back instead.
+  Retracting them per-mushroom would need per-mark provenance, which is ambiguous
+  as soon as two mushrooms rule out the same cell.
+- **`accessibilityState.checked` does not reach `aria-checked` on web.** Any
+  toggle has to name its state in its `accessibilityLabel` — that is the only
+  place a screen reader or a test can read it reliably. Step 7 adds a
+  "Show Mistakes" switch; it will need the same treatment.
 
 - **Fungiku's undo history is not persisted** — only `size` + `seed` + `marks`
   are. Leaving for the hub and returning gives you your board back with an empty
@@ -245,4 +254,4 @@ ladder.
 | 3 | Game shell + hub — router, registry, `HubScreen`, `FungikuScreen`, back-to-hub | merged to `epic/fungiku` (#70, `a9caf92`) |
 | 4 | Fungiku state — reducer, tap-to-cycle marks, live conflicts, win, undo/redo, own-key persistence | merged to `epic/fungiku` (#70, `a9caf92`) |
 | 5 | Board UI — palette fix with a tested ΔE floor, themed + responsive board, animated win | merged to `epic/fungiku` (#71, `905bfa2`) |
-| 6 | Input ergonomics — drag to sweep X's, auto rule-out assist | PR to `epic/fungiku` |
+| 6 | Input ergonomics — drag to sweep X's, rule-out button | PR to `epic/fungiku` |

--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -92,102 +92,85 @@ operator to test in Expo Go.**
 
 ---
 
-## Next step: **Step 6 — drag to sweep X's (+ the auto-X assist)**
+## Next step: **Step 7 — the training ladder and scoring**
 
-Branch: **`feature/fungiku-input`** off `epic/fungiku`.
-Plan: **§2, and specifically the "Drag to sweep X's" subsection** — the operator
-asked for this directly, and that subsection is the spec. Read it before anything
-else.
+Branch: **`feature/fungiku-ladder`** off `epic/fungiku`.
+Plan: the §7 table row for step 7, plus **§8 #4**, which this step needs answered
+(or defaulted, with the default stated in the PR).
 
 ### Why this step exists
 
-**Ruling out cells is the most repetitive thing about playing Fungiku.** Once you
-know a mushroom can't be anywhere along a row, or anywhere touching one you have
-already placed, you currently tap each of those cells individually — and each one
-takes *one* tap to reach X. The operator's words: *"I want to be able to drag my
-finger to place Xs in places where mushrooms wouldn't be."* This is the gesture
-that makes X's cheap enough to actually reason with, and it is the last thing
-standing between the current build and a game that feels good to play.
+Fungiku is a complete puzzle you can play, but it has **no shape as a game**. You
+pick a size from four chips and press "New puzzle" for a random seed; nothing
+tracks what you have done, nothing gets harder, nothing tells you that you are
+improving. This step turns a puzzle generator into something worth coming back
+to.
 
 ### Read first
 
-- **`docs/fungiku-plan.md` §2, "Drag to sweep X's"** — the behavior spec: drag
-  paints X and never cycles, the first cell decides paint-vs-erase for the whole
-  stroke, mushrooms are never overwritten, one undo entry per stroke, and fast
-  diagonal strokes must fill every cell crossed. Both hazards are written up
-  there too; do not skip them.
-- `SudokuApp/games/fungiku/FungikuBoard.js` — what you are changing. Today every
-  cell is its own `TouchableOpacity` with an `onPress`. A drag needs a **single
-  responder over the whole board** that maps a point to a cell, so this is the
-  one real restructure in the step.
-- `SudokuApp/games/fungiku/reducer.js` — `CYCLE_CELL` and `CLEAR_MARKS` are the
-  models to copy. `pushHistory` already snapshots the whole `marks` array, which
-  is exactly what "one undo entry per stroke" needs — add a `PAINT_CELLS`-style
-  action that applies a whole stroke through one `pushHistory`, rather than
-  dispatching per cell.
-- `SudokuApp/hooks/useBoardSize.js` — the board's pixel size, which you need to
-  turn a touch point into a row/column.
-- `SudokuApp/games/fungiku/__tests__/reducer.test.js` — extend this. The stroke
-  reducer is pure and deserves the same coverage as cycling.
+- `SudokuApp/games/fungiku/reducer.js` and `FungikuContext.js` — where progress
+  state has to live, and how `size`/`seed` currently change (`changeSize` resets
+  to seed 1; `nextPuzzle` bumps the seed).
+- `SudokuApp/games/fungiku/storage.js` — persistence is `size` + `seed` + `marks`
+  + `autoX`. Ladder progress is the first thing that needs a **schema change**;
+  bump `FUNGIKU_STORAGE_VERSION` and decide what an old save migrates to (today
+  a version mismatch returns null and the board starts fresh — that is fine for
+  a board, less fine for someone's progress).
+- `SudokuApp/utils/gameProgress.js` + `games/registry.js` — `describeFungikuProgress`
+  feeds the hub's Continue badge. With a ladder, the badge probably wants to say
+  which *level* you are on rather than which board size.
+- **The sibling color-loop app is the reference for this exact problem** — it has
+  a training ladder in `games/colorloop/levels.ts` with per-level star
+  thresholds, and its `docs/game-design.md` covers the progression thinking.
+  Worth reading before designing a second one from scratch.
+- `SudokuApp/contexts/GameContext.js` — Sudoku's scoring (time-based, with
+  completion bonuses) is a model for what "scoring" can mean here. Fungiku has no
+  timer at all today, which is a decision this step has to make deliberately.
 
 ### Scope — ONLY this
 
-1. **The drag gesture on the board.** One `PanResponder` on the board container;
-   resolve the cell under the finger and paint as the stroke moves.
-2. **A stroke action in the reducer** — takes the set of cells and the mode
-   (paint X / erase to empty), applies it in one go, records **one** undo entry,
-   and skips mushroom cells.
-3. **Taps keep working exactly as they do now**, including the full
-   `empty → X → 🍄 → empty` cycle and the accessibility labels. A tap is a
-   degenerate stroke only if that does not change tap behavior — otherwise keep
-   the tap path separate.
-4. **Auto-X assist (the other half of §2's assist bullet)** — a toggle that, when
-   a mushroom is placed, fills X into that mushroom's row, column, region and
-   eight neighbors. **Off by default** unless the operator answers §8 #5
-   otherwise. Reuse the same stroke action so it is one undo entry.
-5. **Extend the Jest suite** for the stroke reducer and the auto-X fill.
+1. **A level ladder** — an ordered list of levels, each pinning a `size` and a
+   `seed` (both already deterministic, so a level *is* a `{size, seed}` pair).
+   Keep it data, in its own module, so tuning is editing a table.
+2. **Progression + persistence** — which levels are complete, and what unlocks.
+   Bump the storage version and migrate rather than discarding progress.
+3. **A level-select surface** on the Fungiku screen, replacing the raw size chips
+   as the primary path. Keep a way to play an arbitrary size — the chips are
+   useful for testing, and "free play" is a reasonable answer to §8 #4.
+4. **Scoring** — decide what it measures and say why in the PR. If it needs a
+   timer, add one, and note that Fungiku deliberately had none until now.
+5. **Hub integration** — the Continue badge should reflect ladder position.
+6. **Tests** — the ladder table and progression logic are pure; cover them. Pin
+   that every level in the table actually generates (a bad `{size, seed}` pair
+   would otherwise only fail when a player reaches it).
 
 ### Behaviors that are easy to get wrong
 
-- **`locationX`/`locationY` lie on the new architecture.** In a `PanResponder`
-  they are relative to the touched *child*, not the responder. Use
-  `pageX`/`pageY` minus the board's measured origin, and **re-measure at gesture
-  grant**, not only on layout — this screen's board sits under a win banner that
-  mounts and unmounts, so the board moves. (§2 has the full note; the sibling
-  color-loop app lost time to exactly this.)
-- **The board lives inside a `ScrollView`.** A vertical drag will fight it. You
-  will need to claim the responder deliberately (and probably
-  `onMoveShouldSetPanResponderCapture`) so a sweep paints instead of scrolling —
-  and check that the page can still be scrolled by dragging *outside* the board.
-- **Interpolate between move events.** A fast stroke delivers sparse points; walk
-  the line between consecutive points, or a quick swipe leaves gaps.
-- **Never overwrite a mushroom.** Losing a deduced placement to a stray swipe is
-  the worst failure this feature can have.
-- **Don't regress the accessibility labels.** They are how the browser tests
-  address cells, and they are Fungiku's only non-visual channel.
+- **Every level must be generatable.** `generate()` throws for `size < 5`; a
+  typo in the table becomes a crash for whoever reaches that level. Assert the
+  whole table in a test.
+- **Don't lose existing progress on the schema change.** A player mid-board today
+  has `{size, seed, marks, autoX}` and no ladder state; that has to migrate to
+  something sensible, not to a wiped save.
+- **Star thresholds and difficulty curves are guesses until played.** Draft them,
+  say in the PR that they are estimates, and flag them for the operator to tune
+  on device — the same way color-loop's ladder was left.
+- **Keep free play reachable.** Locking size behind progression makes the 8×8
+  regression cases harder to check; a dev/test path must survive.
 
 ### Out of scope for this step
 
-- **No ladder, progression or scoring** — that is Step 7.
-- **No art swap** — Step 8, and it is gated on artwork rather than code.
-- **No engine or win-detection changes.** X's still have no effect on winning; a
-  drag that fills the whole board with X's must not win it (there is already a
-  test for that shape — keep it green).
+- **No art swap** — Step 8, gated on artwork rather than code.
+- **No new input features.** Tap, drag-to-sweep and auto-X are done; don't
+  revisit them.
+- **No engine changes.** Levels are `{size, seed}` pairs over the existing
+  generator.
 
 ### Visible in Expo Go when this lands
 
-**Swipe a finger across a row of cells and watch them all become ✕ in one
-motion**, then swipe back over them to clear them, with a single Undo taking back
-the whole sweep. Turn the auto-X toggle on, place a mushroom, and watch its row,
-column, region and neighbors fill themselves in.
-
-### ⚠️ This step cannot be signed off in a browser
-
-Playwright can fake a mouse drag on the web build and you **should** add that —
-it will catch the geometry being wrong. But whether the gesture fights the
-ScrollView, whether a tap-with-jitter accidentally paints, and whether the stroke
-feels responsive under a real thumb are all device questions. **Get an Expo Go
-pass from the operator before this merges**, and say so in the PR.
+A **level list** you progress through, with completed levels marked, and a score
+or rating when you solve one. The hub's Fungiku card says where you are in the
+ladder.
 
 ## Open questions for the operator (carry these forward)
 
@@ -208,6 +191,20 @@ pass from the operator before this merges**, and say so in the PR.
    *(Step 6 concern.)*
 
 ### Noted in passing, for a later step
+
+- **Dragging on the board never scrolls the page.** The stroke claims the
+  responder and refuses to hand it back mid-sweep, which is what makes painting
+  reliable — but it means the board is not a place you can scroll from. Drag
+  outside the board instead. Fine on a tall phone; revisit if the screen grows.
+- **Auto rule-out marks are ordinary X marks once placed.** Cycling the mushroom
+  away leaves them behind; undo takes the placement and its marks back together.
+  Retracting them on removal would need per-mark provenance, which is ambiguous
+  as soon as two mushrooms rule out the same cell. Revisit only if it annoys the
+  operator in practice.
+- **`accessibilityState.checked` does not reach `aria-checked` on web.** The
+  auto rule-out toggle names its state in its `accessibilityLabel`
+  ("Auto rule-out, on") because that is the only place a screen reader or a test
+  can read it reliably. Worth remembering for any future toggle.
 
 - **Fungiku's undo history is not persisted** — only `size` + `seed` + `marks`
   are. Leaving for the hub and returning gives you your board back with an empty
@@ -241,4 +238,5 @@ pass from the operator before this merges**, and say so in the PR.
 | 2 | Replan + engine + preview + hub design | merged to `epic/fungiku` (#69, `fecb271`) |
 | 3 | Game shell + hub — router, registry, `HubScreen`, `FungikuScreen`, back-to-hub | merged to `epic/fungiku` (#70, `a9caf92`) |
 | 4 | Fungiku state — reducer, tap-to-cycle marks, live conflicts, win, undo/redo, own-key persistence | merged to `epic/fungiku` (#70, `a9caf92`) |
-| 5 | Board UI — palette fix with a tested ΔE floor, themed + responsive board, animated win | PR to `epic/fungiku` |
+| 5 | Board UI — palette fix with a tested ΔE floor, themed + responsive board, animated win | merged to `epic/fungiku` (#71, `905bfa2`) |
+| 6 | Input ergonomics — drag to sweep X's, auto rule-out assist | PR to `epic/fungiku` |

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -142,6 +142,49 @@ Two hazards worth knowing before writing the gesture:
    it fight the ScrollView, does it fire on a tap-with-jitter — is a device
    question. This one needs an Expo Go pass before it merges.
 
+### The ScrollView race, and how it was settled (device finding, 2026-07-25)
+
+The first implementation claimed the responder on **movement**, past a small
+threshold. On device that lost to the enclosing `ScrollView`: **a vertical drag
+scrolled the page instead of painting.** The ScrollView is tracking the same
+touch, and once vertical movement passes *its* slop it takes the gesture — via
+`onInterceptTouchEvent` on Android, and on iOS because `canCancelContentTouches`
+defaults to letting a scroll view cancel a child's touch. Claiming later than the
+scroll view decides is a race you lose.
+
+**The board must claim the touch at touch-down**, in the capture phase, so there
+is no window in which the gesture can be read as a scroll. Three parts, all
+required:
+
+1. `onStartShouldSetPanResponderCapture` **and** `onStartShouldSetPanResponder`
+   both return true. The capture claim is what pre-empts the ScrollView on
+   native; register the bubble-phase one too, because react-native-web does not
+   reliably honour a capture-phase claim on touch start and taps die without it.
+2. `scrollEnabled={false}` on the ScrollView while a finger is down on the board.
+   This is the part that reliably stops Android. Plus
+   `canCancelContentTouches={false}` on iOS, and
+   `onShouldBlockNativeResponder: () => true` in the responder config.
+3. Because the board owns the touch from the start, **a per-cell `Touchable`
+   never sees a press** — taps have to be recognized by the responder itself
+   (release under the drag threshold = tap) and dispatched from there. Cells
+   become plain `View`s that keep their accessibility labels plus
+   `onAccessibilityTap`.
+
+**Accepted trade-off:** you cannot scroll this screen by dragging on the board.
+Drag anywhere else. The content fits without scrolling on a normal phone even at
+8×8, so the ScrollView is really insurance for small or landscape screens.
+
+**Known regression from part 3:** on web, cells were focusable buttons and are
+now plain views, so keyboard tabbing to a cell is gone. Nobody asked for keyboard
+play and the labels (the accessibility channel that matters here) are intact, but
+it is a real loss — revisit if web keyboard play ever matters.
+
+**None of this is verifiable in a browser.** The web build never reproduced the
+bug: react-native-web uses ordinary overflow scrolling, so even synthetic touch
+drags painted correctly before the fix. What a browser *can* check is that taps,
+strokes, and jittery taps all still behave — do that, then confirm the scroll
+behavior on device.
+
 ## 3. The board
 
 - **Region color = cell background**, filling the whole cell (the reference is a

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -260,7 +260,7 @@ the step's real acceptance test, alongside its automated checks.
 | 3 | ~~**Game shell + hub**~~ ✅ (§6) — screen router, game registry, hub screen, back-to-hub, Fungiku's own screen | **The hub**: app opens on a home screen with **Sudoku and Fungiku side by side as peers**; Fungiku is a real destination, not a button in Sudoku's menu |
 | 4 | ~~**State**~~ ✅ — reducer + context: mark cycling, live conflict validation, win detection, undo/redo, persistence | The Fungiku screen becomes **playable**: tap-to-cycle X/🍄, live conflict highlighting, `🍄 X/N` counter, win banner |
 | 5 | ~~**Board UI**~~ ✅ — the real board component: region-boundary borders, themed styling, win flow, **palette tuning** | The **finished board**, styled to the app's themes, replacing the preview's rough grid |
-| 6 | **Input ergonomics & assists** (§2) — **drag to sweep X's**, then optional auto-X | **Swipe a finger across cells to rule them out**; assist toggle |
+| 6 | ~~**Input ergonomics & assists**~~ ✅ (§2) — **drag to sweep X's**, optional auto-X | **Swipe a finger across cells to rule them out**; assist toggle |
 | 7 | **Ladder & scoring** — training ladder, size progression, scoring | Level progression and a score |
 | 8 | **Art swap** (floating, asset-only — gated on artwork, not on code) | Static mushroom art replaces the icon glyph |
 

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -96,8 +96,14 @@ empty → X (eliminated) → 🍄 (mushroom) → empty
 - **Conflicts show live:** any two mushrooms sharing a row, column, or region,
   or touching each other, are highlighted (the reference glows them). Conflicts
   do not block placement — the player fixes them.
-- **Optional assist (later step):** auto-place X's in a placed mushroom's row,
-  column, region, and neighbors. A setting, off by default.
+- **The rule-out assist is a button, not a mode** (operator decision,
+  2026-07-25): one tap marks every cell the mushrooms already on the board
+  forbid — their rows, columns, regions and neighbors. It is an action the player
+  asks for, never something that fires behind them as they place. It only fills
+  blanks, never disturbs a mushroom (not even a conflicting one), and undoes as a
+  single action. Being explicit is what keeps it an aid rather than a mode that
+  quietly does the deduction for you.
+- **Feedback and hints have their own requirements — see §11.**
 
 No number pad. No 3×3 notes mini-grid. No digit feedback.
 
@@ -303,9 +309,14 @@ the step's real acceptance test, alongside its automated checks.
 | 3 | ~~**Game shell + hub**~~ ✅ (§6) — screen router, game registry, hub screen, back-to-hub, Fungiku's own screen | **The hub**: app opens on a home screen with **Sudoku and Fungiku side by side as peers**; Fungiku is a real destination, not a button in Sudoku's menu |
 | 4 | ~~**State**~~ ✅ — reducer + context: mark cycling, live conflict validation, win detection, undo/redo, persistence | The Fungiku screen becomes **playable**: tap-to-cycle X/🍄, live conflict highlighting, `🍄 X/N` counter, win banner |
 | 5 | ~~**Board UI**~~ ✅ — the real board component: region-boundary borders, themed styling, win flow, **palette tuning** | The **finished board**, styled to the app's themes, replacing the preview's rough grid |
-| 6 | ~~**Input ergonomics & assists**~~ ✅ (§2) — **drag to sweep X's**, optional auto-X | **Swipe a finger across cells to rule them out**; assist toggle |
-| 7 | **Ladder & scoring** — training ladder, size progression, scoring | Level progression and a score |
-| 8 | **Art swap** (floating, asset-only — gated on artwork, not on code) | Static mushroom art replaces the icon glyph |
+| 6 | ~~**Input ergonomics & assists**~~ ✅ (§2) — **drag to sweep X's**, rule-out button | **Swipe a finger across cells to rule them out**; a *Rule out* button |
+| 7 | **Feedback & hints** (§11) — correctness feedback on placements, and a hint ladder | **Optional "show mistakes" for mushrooms**, and a hint you can ask for when stuck |
+| 8 | **Ladder & scoring** — training ladder, size progression, scoring | Level progression and a score |
+| 9 | **Art swap** (floating, asset-only — gated on artwork, not on code) | Static mushroom art replaces the icon glyph |
+
+**Why feedback and hints come before scoring:** scoring has to know what a
+mistake and a hint are *worth*, so the ladder step needs both to already exist.
+Building scoring first would mean guessing at the currency it is denominated in.
 
 **Why drag-to-sweep sits at Step 6, not earlier:** it needs the real board's
 touch and geometry layer, which Step 5 builds. Writing the gesture against the
@@ -340,7 +351,16 @@ Step 5 replaced that rough grid with the themed, responsive board.
    both games stay discoverable. Revisit only if it grates on device.
 4. **Ladder shape** — v1 ships **5×5 → 8×8**. Where should it top out, and
    should size be a free choice or unlocked by progression?
-5. **Assist defaults** — should auto-X be on by default for younger players?
+5. ~~**Assist defaults**~~ — **moot as of 2026-07-25.** The rule-out assist became
+   a button you tap rather than a mode with a setting, so there is no default to
+   choose. (§2)
+6. **How strong should hints go?** (§11) The hint ladder ends at *reveal a correct
+   mushroom*, which solves a cell outright. For a family game that may be exactly
+   right — or it may feel like cheating and want capping at a nudge. Needs a
+   judgement call once hints are playable.
+7. **Should correctness feedback default on for younger players?** (§11) It turns
+   a deduction puzzle into trial-and-error for anyone who leaves it on, which is
+   an argument for off — but "off" for a seven-year-old may just mean stuck.
 
 ## 9. Edge cases to get right
 
@@ -365,3 +385,72 @@ Step 5 replaced that rough grid with the themed, responsive board.
   Sudoku board*. Built on the superseded "display mode" model: Fungiku is a
   separate mode with its own board, so a symbol-set toggle over the 9×9 numeric
   grid has no place. Closed rather than merged.
+
+## 11. Feedback on your moves, and hints (operator request, 2026-07-25)
+
+Two related gaps. Today the board tells you when you have **broken a rule**, and
+nothing else: it never tells you that a legal move was *wrong*, and when you are
+genuinely stuck your only options are guess or walk away. Both need answering
+before scoring exists, because scoring has to know what a mistake and a hint are
+worth.
+
+### 11.1 Feedback
+
+Four kinds, in increasing intrusiveness. The first exists; the rest are this
+requirement.
+
+1. **Rule feedback — shipped, always on.** Any two mushrooms sharing a row,
+   column or region, or touching, are ringed and recoloured. This is *local*
+   consistency: it catches a move that contradicts another move.
+2. **Correctness feedback — opt-in.** Flag a mushroom that is not where the
+   puzzle's single solution has it, even though it breaks no rule yet. The
+   engine already knows the answer (`generate()` returns `solution`, and
+   `findSolutions` recovers it from `regions`), so this is cheap to compute. It
+   must be **opt-in**: left on, it turns a deduction puzzle into trial-and-error.
+   Mirror Sudoku's existing **"Show Mistakes"** switch — same words, same
+   placement in the menu, so the app has one vocabulary for the idea.
+3. **Positive confirmation.** A correct placement should *feel* correct, not
+   merely fail to turn red. A small settle or pulse on the mushroom, in the app's
+   motion language. This is the half of feedback that makes a game feel good and
+   the half most often skipped.
+4. **Progress feedback.** The `🍄 X/N` counter exists. Consider also surfacing
+   *structure* solved — "3 of 5 regions settled" — which is what a player
+   actually reasons about.
+
+Two consequences of the rules worth writing down, because they shape the work:
+
+- **X marks are never wrong.** They are a thinking aid with no bearing on the win
+  (§9), so correctness feedback applies to **mushrooms only**. Flagging a
+  "wrong" X would be telling the player how to think.
+- **There is no such thing as a complete-but-wrong board.** Uniqueness (rule 5)
+  means N mushrooms placed with no conflicts *is* the solution — so correctness
+  feedback is purely a **mid-solve** aid. It can never be the thing that tells
+  you a finished board is wrong, because a finished legal board cannot be.
+
+### 11.2 Hints
+
+A ladder of increasing strength. A hint is **always an explicit request** — never
+automatic, never on a timer — and each rung should cost more than the last once
+scoring exists.
+
+| Rung | Hint | Strength | Cost to build |
+|------|------|----------|---------------|
+| 1 | **Rule out** — mark everything the placed mushrooms forbid | Reveals nothing the player could not derive mechanically | **Shipped** (§2) |
+| 2 | **Nudge** — name a row, column or region where a deduction is available, without saying what it is | Preserves the "aha"; the best hint in a teaching game | Needs a **deductive** solver — constraint propagation, not the backtracking one. `findSolutions` can say *what* the answer is but not that a step is *forced*. This is the real work in the step. |
+| 3 | **Reveal a mushroom** — place one correct mushroom from the solution | Solves a cell outright | Trivial: the solution is known |
+| 4 | **Point out a mistake** — "one of your mushrooms is wrong", optionally which | Undoes a wrong branch without explaining | Trivial: compare against the solution |
+
+Requirements on any hint:
+
+- **Never place a conflicting mushroom.** A hint that creates a conflict is worse
+  than no hint.
+- **A revealing hint is one undoable action**, like the rule-out button.
+- **Count hints used**, per puzzle — the ladder step will want that for scoring,
+  and it is much easier to record from the start than to retrofit.
+- **A hint must never be the only path forward.** If rung 2 cannot find a forced
+  deduction, say so honestly rather than silently falling through to rung 3.
+
+### 11.3 Open questions this raises
+
+Carried into §8 as #6 and #7: how strong hints should go for a family game, and
+whether correctness feedback should default on for younger players.


### PR DESCRIPTION
Step 6 of the Fungiku epic (refs #65, plan §2). Targets `epic/fungiku`.

**This is your request:** *"I want to be able to drag my finger to place Xs in places where mushrooms wouldn't be."* You can now swipe across a row of cells and have them all become ✕ in one motion.

> **Also carries one unrelated CI commit** (`f49479f`), from a side question about stale EAS Update branches — see the last section. It's separable; say the word and I'll pull it into its own PR.

## ⚠️ This one needs a device pass before it merges

Everything below was driven with **real mouse drags** in Chromium and it all works — but a mouse is not a thumb. Whether the gesture fights the `ScrollView`, and whether a shaky tap accidentally paints, are questions only Expo Go can answer. **Please try it on device before I merge this.** The QR is in the Expo preview comment.

---

## How the gesture behaves

Ruling out cells was the most repetitive thing about playing Fungiku — one tap per cell, and you need a lot of them. The rules below exist so the sweep is predictable rather than surprising:

| | |
|---|---|
| **Drag paints ✕, never cycles** | Cycling under a moving finger would scatter mushrooms across the board. |
| **The first cell fixes the mode for the whole stroke** | Starting on an ✕ **erases**; anything else **paints**. So dragging back over your own path can't flip cells twice. |
| **A stroke never overwrites a mushroom** | Losing a deduced placement to a stray swipe is the worst thing this feature could do. |
| **One undo per stroke, not per cell** | `beginStroke` arms the undo entry and the first *effective* paint spends it — so a stroke that begins over cells it can't change still undoes as one action. |
| **Fast and diagonal strokes fill every cell crossed** | A finger at speed skips cells between move events. |

## The two hazards, handled

**1. `locationX`/`locationY` are unusable here.** On the new architecture they're relative to the touched *child* view — a single cell — not the responder. `hooks/useBoardOrigin.js` resolves cells from `pageX`/`pageY` minus the board's measured origin, **re-measured at gesture grant** rather than only on layout, because the win banner mounting shifts the board by its whole height.

**2. The board lives inside a `ScrollView`.** The responder is claimed on **movement**, not touch-down, so the per-cell `Touchable`s keep handling taps — which preserves the full cycle *and* their accessibility labels, which are the only non-visual channel and the seam the browser tests address cells through. Past a 6px threshold the board takes over, and `onPanResponderTerminationRequest` returns false so the ScrollView can't steal a stroke mid-sweep.

## What's new

| | |
|---|---|
| `games/fungiku/geometry.js` | **new, pure** — `cellFromPoint` and `cellsAlongLine` (Bresenham). Gesture bugs are otherwise only findable on a device; this is the half that can be unit-tested, and it is. |
| `hooks/useBoardOrigin.js` | **new** — the measured-origin hook, with the `locationX` hazard written up in it. |
| `games/fungiku/reducer.js` | `BEGIN_STROKE` / `PAINT_CELLS` / `END_STROKE`, plus `SET_AUTO_X`. |
| `games/fungiku/engine.js` | **new export `cellsRuledOutBy`** — every cell a mushroom forbids. It's a restatement of the rules, so it belongs in the engine, not in the assist. |
| `games/fungiku/FungikuBoard.js` | the `PanResponder`. Gesture callbacks read live state through a ref so the responder is built once. |
| `FungikuScreen.js` | the **Auto rule-out** toggle. |

## The auto rule-out assist

Off by default — §8 #5 is still unanswered, and left on it does most of the deduction for you, which is the game. Placing a mushroom fills ✕ into its row, column, region and eight neighbours, **inside the same action as the placement**, so it's one undo. The preference persists and survives starting a new puzzle.

One deliberate decision worth your eye: **assist marks become ordinary ✕ marks the moment they land.** Cycling the mushroom away leaves them behind; *undo* takes the placement and its marks back together. Retracting them on removal would need per-mark provenance, which is ambiguous as soon as two mushrooms rule out the same cell. A test pins this behavior — say the word if it annoys you in play and I'll reconsider.

## Verification

```
npm test                       → 194/194 pass (42 new)
npx expo-doctor                → 18/18
npx expo export --platform all → web + iOS + Android all bundle
```

Chromium pass driving **real mouse drags**, **no page errors**:

| Check | Result |
|---|---|
| A tap still cycles | `ruled out` → `mushroom` → `empty` |
| Drag across row 1 | all five cells `ruled out` |
| **One** undo | whole sweep gone — `empty ×5` |
| Redo, then drag back over it | erased — `empty ×5` |
| Sweep across a placed mushroom | `✕ ✕ 🍄 ✕ ✕` — untouched |
| Deliberately coarse 6-step diagonal | all five diagonal cells filled (interpolation works) |
| Assist on, mushroom at r3c3 | exactly row + column + region + 8 neighbours |
| Undo after an assisted placement | placement *and* its marks retracted together |
| Assist after a new puzzle, and after a reload | still on |
| Whole board swept with ✕ | **not solved** — ✕ still can't win |

## One accessibility fix that pass found

`accessibilityState.checked` **does not reach `aria-checked` on web** — the toggle's state was invisible to both my test and a screen reader. It now names its state in its `accessibilityLabel` ("Auto rule-out, on"), which is the only place that reads reliably. Noted in the handoff for future toggles.

---

## Unrelated: EAS Update branch cleanup (`f49479f`)

From a side question about EAS branches surviving their deleted git branches. **The project had 68 stale EAS Update branches** — mostly May 2025, plus `pr-66`…`pr-71`, and ~13 *duplicate pairs* (`web-support` **and** `feature/web-support`, `scoring` **and** `feature/scoring`, …) left by an earlier workflow that published a branch's last path segment as well as its full ref. All 68 are now deleted; **7 remain**: `main`, `epic/fungiku`, `pr-72`, and the four whose git branches still exist.

Deleting was safe to do because `eas channel:list` returns **empty** — with no channels, no installed build resolves updates through any branch; they're only reachable by direct QR/permalink.

The commit stops the `pr-*` ones coming back:

- `pull_request` now names all four activity types, because **`closed` isn't in the default set** and naming any type replaces the defaults;
- a `cleanup-preview` job deletes `pr-<N>` on close, `continue-on-error` since a PR that closed before publishing has no branch and a missing branch is the goal anyway;
- **`preview-mobile` now excludes `action == 'closed'`** — without that it would fire on close and republish the branch the cleanup job just deleted.

## Remaining after this

**Two steps: 7 (ladder & scoring) and 8 (art swap)** — and 8 waits on artwork rather than code. Step 7 needs an answer to §8 #4: where should the ladder top out, and is board size a free choice or unlocked by progression? I'll default to "ladder plus a free-play escape hatch" if you'd rather not decide up front.