### PR TITLE
Fungiku Step 7: feedback on your moves, and hints

### DIFF
--- a/SudokuApp/games/fungiku/FungikuBoard.js
+++ b/SudokuApp/games/fungiku/FungikuBoard.js
@@ -128,13 +128,29 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
     const value = popValues[placed[0]];
     if (!value) return;
 
+    // Stop anything already running on this cell's value before restarting it.
+    // Placing, removing and replacing a mushroom quickly would otherwise leave
+    // two springs driving one value.
+    value.stopAnimation();
     value.setValue(0.45);
     Animated.spring(value, {
       toValue: 1,
       friction: 5,
       tension: 140,
-      useNativeDriver: true,
-    }).start();
+      // **Deliberately NOT the native driver.** This value has to *rest* at
+      // exactly 1, and it is reset with setValue() on every placement — and
+      // mixing setValue() with useNativeDriver leaves the JS-side value as a
+      // stale copy, because the animation runs natively and does not write back.
+      // The operator caught the result: on a solved 8×8, five of eight mushrooms
+      // sat permanently smaller than the rest, their scale stranded at the pop's
+      // start value. With the JS driver the value is the single source of truth
+      // and lands on 1.
+      useNativeDriver: false,
+    }).start(() => {
+      // Belt and braces: whatever interrupts the spring, the cell must not be
+      // left mid-pop. A stuck scale is a permanent visual defect, not a glitch.
+      value.setValue(1);
+    });
   }, [marks, popValues]);
 
   // Re-measure whenever something *above* the board appears or disappears.

--- a/SudokuApp/games/fungiku/FungikuBoard.js
+++ b/SudokuApp/games/fungiku/FungikuBoard.js
@@ -40,8 +40,24 @@ const MARK_LABELS = {
 const DRAG_THRESHOLD = 6;
 
 const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
-  const { size, regions, marks, conflicts, cycleCell, paintCells, beginStroke, endStroke, solved } =
-    useFungikuContext();
+  const {
+    size,
+    regions,
+    marks,
+    conflicts,
+    mistakes,
+    showMistakes,
+    hint,
+    cycleCell,
+    paintCells,
+    beginStroke,
+    endStroke,
+    solved,
+  } = useFungikuContext();
+
+  // Cells a hint is pointing at: a whole row/column/region for a nudge, a single
+  // cell for a mistake or a reveal.
+  const hintCells = useMemo(() => new Set(hint?.cells || []), [hint]);
 
   const boardSize = useBoardSize();
   const cell = Math.floor(boardSize / size);
@@ -76,6 +92,54 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
 
   // Tap feedback, which the per-cell Touchables used to give for free.
   const [pressedCell, setPressedCell] = useState(-1);
+
+  // Positive confirmation (plan §11.1): a placement should *feel* like one, not
+  // merely fail to turn red. Deliberately fires for **every** mushroom placed,
+  // right or wrong — animating only correct ones would leak the solution to
+  // anyone who had left correctness feedback switched off.
+  const [poppedCell, setPoppedCell] = useState(-1);
+  const pop = useRef(new Animated.Value(1)).current;
+  const previousMarks = useRef(marks);
+
+  useEffect(() => {
+    const before = previousMarks.current;
+    previousMarks.current = marks;
+    if (before === marks || before.length !== marks.length) return;
+
+    // A single new mushroom means a placement; several at once means a reveal or
+    // an undo, which should not pop.
+    const placed = marks.reduce(
+      (found, mark, cell) =>
+        mark === MARKS.MUSHROOM && before[cell] !== MARKS.MUSHROOM ? [...found, cell] : found,
+      []
+    );
+    if (placed.length !== 1) return;
+
+    setPoppedCell(placed[0]);
+    pop.setValue(0);
+    Animated.spring(pop, {
+      toValue: 1,
+      friction: 5,
+      tension: 140,
+      useNativeDriver: true,
+    }).start();
+  }, [marks, pop]);
+
+  // Re-measure whenever something *above* the board appears or disappears.
+  //
+  // `onLayout` is not enough: on web it is backed by a ResizeObserver, which
+  // watches a view's size and not its position — so a board that gets pushed
+  // down by a banner mounting never fires it. And the `measure()` at touch-down
+  // resolves asynchronously, which is too late for that same touch. The result
+  // was a real bug: the first tap after a hint appeared landed on the wrong cell,
+  // or missed the board entirely.
+  //
+  // This effect runs after the banner has been committed, so the origin is right
+  // before the player can touch anything. `hint` and `solved` are the two things
+  // that mount a banner above the board.
+  useEffect(() => {
+    measure();
+  }, [hint, solved, measure]);
 
   // The latest marks/geometry, readable from inside gesture callbacks that were
   // created once and would otherwise close over a stale render.
@@ -260,6 +324,7 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
             const entry = palette[region % palette.length];
             const mark = marks[index];
             const conflicting = conflicts.has(index);
+            const mistaken = mistakes.has(index);
 
             const differs = (r, c) =>
               r < 0 || c < 0 || r >= size || c >= size || regions[r * size + c] !== region;
@@ -284,7 +349,9 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
                 // also the seam the browser tests address cells through.
                 accessibilityLabel={`Row ${row + 1}, column ${col + 1}, ${entry.name} region, ${
                   MARK_LABELS[mark] || 'empty'
-                }${conflicting ? ', conflict' : ''}`}
+                }${conflicting ? ', conflict' : ''}${
+                  showMistakes && mistaken ? ', mistake' : ''
+                }${hintCells.has(index) ? ', hint' : ''}`}
                 accessibilityHint="Taps cycle empty, ruled out, mushroom"
                 onAccessibilityTap={() => cycleCell(index)}
                 style={{
@@ -323,11 +390,52 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
                   />
                 )}
 
+                {/* A hint points with a dashed inset outline — a third channel,
+                    so it can sit on a cell that is also conflicting or mistaken
+                    without either signal being lost. */}
+                {hintCells.has(index) && (
+                  <View
+                    style={[
+                      styles.hintOutline,
+                      { width: cell - 3, height: cell - 3, borderColor: entry.ink },
+                    ]}
+                  />
+                )}
+
                 {mark === MARKS.MUSHROOM && (
+                  <Animated.View
+                    style={
+                      index === poppedCell
+                        ? {
+                            transform: [
+                              {
+                                scale: pop.interpolate({
+                                  inputRange: [0, 1],
+                                  outputRange: [0.4, 1],
+                                }),
+                              },
+                            ],
+                          }
+                        : null
+                    }
+                  >
+                    <MaterialCommunityIcons
+                      name="mushroom"
+                      size={glyph}
+                      color={conflicting ? entry.conflictInk : entry.ink}
+                    />
+                  </Animated.View>
+                )}
+
+                {/* Mistake badge: legal so far, but not where the solution has it
+                    (plan §11.1). A corner glyph rather than a ring, so it reads
+                    as a different kind of wrong from a conflict. */}
+                {showMistakes && mistaken && (
                   <MaterialCommunityIcons
-                    name="mushroom"
-                    size={glyph}
-                    color={conflicting ? entry.conflictInk : entry.ink}
+                    name="alert"
+                    size={Math.round(cell * 0.28)}
+                    color={entry.conflictInk}
+                    style={styles.mistakeBadge}
                   />
                 )}
 
@@ -357,6 +465,18 @@ const styles = StyleSheet.create({
   conflictRing: {
     position: 'absolute',
     borderWidth: 2.5,
+  },
+  hintOutline: {
+    position: 'absolute',
+    borderWidth: 2,
+    borderStyle: 'dashed',
+    borderRadius: 3,
+    opacity: 0.9,
+  },
+  mistakeBadge: {
+    position: 'absolute',
+    top: 1,
+    right: 1,
   },
 });
 

--- a/SudokuApp/games/fungiku/FungikuBoard.js
+++ b/SudokuApp/games/fungiku/FungikuBoard.js
@@ -97,8 +97,18 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
   // merely fail to turn red. Deliberately fires for **every** mushroom placed,
   // right or wrong — animating only correct ones would leak the solution to
   // anyone who had left correctness feedback switched off.
-  const [poppedCell, setPoppedCell] = useState(-1);
-  const pop = useRef(new Animated.Value(1)).current;
+  //
+  // **One Animated.Value per cell, not one shared value pointed at "the cell that
+  // just popped".** That shared-value version had a real bug: resetting the value
+  // to 0 happens imperatively and immediately, but re-pointing it at the new cell
+  // is a React state update that only lands on the next render — so for those
+  // frames the value sat at 0 while still attached to the *previous* mushroom,
+  // and the earlier mushroom visibly shrank and snapped back. Per-cell values
+  // remove the class of bug rather than patching the ordering.
+  const popValues = useMemo(
+    () => Array.from({ length: size * size }, () => new Animated.Value(1)),
+    [size]
+  );
   const previousMarks = useRef(marks);
 
   useEffect(() => {
@@ -106,8 +116,8 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
     previousMarks.current = marks;
     if (before === marks || before.length !== marks.length) return;
 
-    // A single new mushroom means a placement; several at once means a reveal or
-    // an undo, which should not pop.
+    // A single new mushroom means a placement; several at once means an undo or a
+    // restore, which should not pop.
     const placed = marks.reduce(
       (found, mark, cell) =>
         mark === MARKS.MUSHROOM && before[cell] !== MARKS.MUSHROOM ? [...found, cell] : found,
@@ -115,15 +125,17 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
     );
     if (placed.length !== 1) return;
 
-    setPoppedCell(placed[0]);
-    pop.setValue(0);
-    Animated.spring(pop, {
+    const value = popValues[placed[0]];
+    if (!value) return;
+
+    value.setValue(0.45);
+    Animated.spring(value, {
       toValue: 1,
       friction: 5,
       tension: 140,
       useNativeDriver: true,
     }).start();
-  }, [marks, pop]);
+  }, [marks, popValues]);
 
   // Re-measure whenever something *above* the board appears or disappears.
   //
@@ -404,20 +416,10 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
 
                 {mark === MARKS.MUSHROOM && (
                   <Animated.View
-                    style={
-                      index === poppedCell
-                        ? {
-                            transform: [
-                              {
-                                scale: pop.interpolate({
-                                  inputRange: [0, 1],
-                                  outputRange: [0.4, 1],
-                                }),
-                              },
-                            ],
-                          }
-                        : null
-                    }
+                    // This cell's own pop value, which rests at 1. Only the cell
+                    // that was just placed is ever away from 1, so no other
+                    // mushroom can be affected.
+                    style={{ transform: [{ scale: popValues[index] }] }}
                   >
                     <MaterialCommunityIcons
                       name="mushroom"

--- a/SudokuApp/games/fungiku/FungikuContext.js
+++ b/SudokuApp/games/fungiku/FungikuContext.js
@@ -12,7 +12,9 @@ import {
   selectCanUndo,
   selectConflicts,
   selectIsSolved,
+  selectMistakes,
   selectMushroomCount,
+  selectRevealCell,
   selectRuleOutCells,
 } from './reducer';
 
@@ -66,6 +68,18 @@ export const FungikuProvider = ({ children }) => {
     [state.marks, state.regions, state.size]
   );
 
+  // Correctness feedback (plan §11.1). Computed whether or not the switch is on:
+  // the hint cascade needs to know about mistakes even when the player has not
+  // asked to see them. Only the *rendering* is gated on `showMistakes`.
+  const mistakes = useMemo(
+    () => selectMistakes(state),
+    [state.marks, state.solution, state.size]
+  );
+  const canReveal = useMemo(
+    () => selectRevealCell(state) >= 0,
+    [state.marks, state.regions, state.solution, state.size]
+  );
+
   const cycleCell = useCallback(
     (cell) => dispatch({ type: FUNGIKU_ACTIONS.CYCLE_CELL, payload: { cell } }),
     [dispatch]
@@ -87,6 +101,24 @@ export const FungikuProvider = ({ children }) => {
   /** One tap: mark everything the placed mushrooms forbid (plan §2). */
   const ruleOut = useCallback(() => dispatch({ type: FUNGIKU_ACTIONS.RULE_OUT }), [dispatch]);
 
+  // --- feedback and hints (plan §11) ---------------------------------------
+  const toggleMistakes = useCallback(
+    () => dispatch({ type: FUNGIKU_ACTIONS.TOGGLE_MISTAKES }),
+    [dispatch]
+  );
+  const requestHint = useCallback(
+    () => dispatch({ type: FUNGIKU_ACTIONS.REQUEST_HINT }),
+    [dispatch]
+  );
+  const revealMushroom = useCallback(
+    () => dispatch({ type: FUNGIKU_ACTIONS.REVEAL_MUSHROOM }),
+    [dispatch]
+  );
+  const dismissHint = useCallback(
+    () => dispatch({ type: FUNGIKU_ACTIONS.DISMISS_HINT }),
+    [dispatch]
+  );
+
   /**
    * Start a puzzle. Generation happens here rather than in the reducer so a
    * failure surfaces as a caught error instead of a throw mid-dispatch.
@@ -96,13 +128,15 @@ export const FungikuProvider = ({ children }) => {
       try {
         dispatch({
           type: FUNGIKU_ACTIONS.NEW_PUZZLE,
-          payload: buildPuzzleState({ size, seed }),
+          // The feedback switch is a preference and carries over; the hint count
+          // is per-puzzle and resets.
+          payload: buildPuzzleState({ size, seed, showMistakes: state.showMistakes }),
         });
       } catch (error) {
         console.error('Fungiku generation failed:', error);
       }
     },
-    [dispatch, state.size, state.seed]
+    [dispatch, state.size, state.seed, state.showMistakes]
   );
 
   const nextPuzzle = useCallback(
@@ -135,6 +169,12 @@ export const FungikuProvider = ({ children }) => {
       endStroke,
       ruleOut,
       ruleOutCount,
+      mistakes,
+      canReveal,
+      toggleMistakes,
+      requestHint,
+      revealMushroom,
+      dismissHint,
       startPuzzle,
       nextPuzzle,
       changeSize,
@@ -154,6 +194,12 @@ export const FungikuProvider = ({ children }) => {
       endStroke,
       ruleOut,
       ruleOutCount,
+      mistakes,
+      canReveal,
+      toggleMistakes,
+      requestHint,
+      revealMushroom,
+      dismissHint,
       startPuzzle,
       nextPuzzle,
       changeSize,

--- a/SudokuApp/games/fungiku/FungikuScreen.js
+++ b/SudokuApp/games/fungiku/FungikuScreen.js
@@ -42,16 +42,25 @@ const FungikuScreenContent = ({ onExitToHub }) => {
     nextPuzzle,
     ruleOut,
     ruleOutCount,
+    showMistakes,
+    toggleMistakes,
+    mistakes,
+    hint,
+    hintsUsed,
+    requestHint,
+    revealMushroom,
+    dismissHint,
+    canReveal,
   } = useFungikuContext();
 
   const titleColor = theme.colors.title;
   const surface = theme.colors.numberPad.background;
   const border = theme.colors.numberPad.border;
 
-  // The hint follows the state of play instead of always explaining the tap
-  // cycle — telling a player who has just won how to tap a cell was Step 4's
-  // one loose end.
-  const hint = solved
+  // The status line follows the state of play instead of always explaining the
+  // tap cycle. (Named `statusText`, not `hint` — `hint` is the hint object from
+  // context, and shadowing it here silently broke the build once.)
+  const statusText = solved
     ? 'One per row, column and color — none touching'
     : conflicts.size > 0
       ? `${conflicts.size} mushroom${conflicts.size === 1 ? '' : 's'} breaking a rule`
@@ -86,8 +95,43 @@ const FungikuScreenContent = ({ onExitToHub }) => {
           >
             {mushroomCount}/{size}
           </Text>
-          <Text style={[styles.counterHint, { color: titleColor }]}>{hint}</Text>
+          <Text style={[styles.counterHint, { color: titleColor }]}>{statusText}</Text>
         </View>
+
+        {/* Hint output (plan §11.2). A hint is an explicit request, so its
+            result gets its own line rather than a fleeting toast — and the
+            "nothing is forced" case says so, with the reveal as a second,
+            deliberate tap. */}
+        {hint && !solved && (
+          <View style={[styles.hintBanner, { backgroundColor: surface, borderColor: border }]}>
+            <MaterialCommunityIcons
+              name={hint.kind === 'mistake' ? 'alert' : 'lightbulb-on-outline'}
+              size={18}
+              color={titleColor}
+            />
+            <Text style={[styles.hintText, { color: titleColor }]}>{hint.message}</Text>
+
+            {hint.offerReveal && canReveal && (
+              <TouchableOpacity
+                onPress={revealMushroom}
+                style={[styles.hintAction, { borderColor: titleColor }]}
+                accessibilityRole="button"
+                accessibilityLabel="Reveal a mushroom"
+              >
+                <Text style={[styles.hintActionText, { color: titleColor }]}>Reveal</Text>
+              </TouchableOpacity>
+            )}
+
+            <TouchableOpacity
+              onPress={dismissHint}
+              style={styles.hintDismiss}
+              accessibilityRole="button"
+              accessibilityLabel="Dismiss hint"
+            >
+              <MaterialCommunityIcons name="close" size={16} color={titleColor} />
+            </TouchableOpacity>
+          </View>
+        )}
 
         <FungikuWinBanner
           solved={solved}
@@ -153,6 +197,54 @@ const FungikuScreenContent = ({ onExitToHub }) => {
             <MaterialCommunityIcons name="auto-fix" size={18} color={titleColor} />
             <Text style={[styles.buttonText, { color: titleColor }]}>
               {ruleOutCount === 0 ? 'Rule out' : `Rule out ${ruleOutCount}`}
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        {/* Hint (plan §11.2) and the correctness-feedback switch (§11.1). Both
+            are opt-in by nature: a hint is asked for, and mistakes are only shown
+            to a player who wants them shown. */}
+        <View style={styles.controlRow}>
+          <TouchableOpacity
+            onPress={requestHint}
+            disabled={solved}
+            style={[
+              styles.wideButton,
+              { borderColor: border },
+              solved && styles.toolButtonDisabled,
+            ]}
+            accessibilityRole="button"
+            accessibilityState={{ disabled: solved }}
+            accessibilityLabel={hintsUsed > 0 ? `Hint, ${hintsUsed} used` : 'Hint'}
+            accessibilityHint="Gives the weakest hint that still helps"
+          >
+            <MaterialCommunityIcons name="lightbulb-on-outline" size={18} color={titleColor} />
+            <Text style={[styles.buttonText, { color: titleColor }]}>
+              {hintsUsed > 0 ? `Hint (${hintsUsed})` : 'Hint'}
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            onPress={toggleMistakes}
+            style={[
+              styles.wideButton,
+              { borderColor: border },
+              showMistakes && { backgroundColor: titleColor, borderColor: titleColor },
+            ]}
+            accessibilityRole="switch"
+            accessibilityState={{ checked: showMistakes }}
+            // The state is named in the label because accessibilityState.checked
+            // does not reach aria-checked on web.
+            accessibilityLabel={`Show mistakes, ${showMistakes ? 'on' : 'off'}`}
+            accessibilityHint="Flags mushrooms that break no rule but are in the wrong cell"
+          >
+            <MaterialCommunityIcons
+              name={showMistakes ? 'checkbox-marked' : 'checkbox-blank-outline'}
+              size={18}
+              color={showMistakes ? surface : titleColor}
+            />
+            <Text style={[styles.buttonText, { color: showMistakes ? surface : titleColor }]}>
+              Mistakes{showMistakes && mistakes.size > 0 ? ` (${mistakes.size})` : ''}
             </Text>
           </TouchableOpacity>
         </View>
@@ -252,6 +344,35 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     marginLeft: 6,
     marginRight: 10,
+  },
+  hintBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingVertical: 7,
+    paddingHorizontal: 10,
+    marginBottom: 12,
+    maxWidth: 360,
+  },
+  hintText: {
+    fontSize: 12,
+    marginLeft: 8,
+    flexShrink: 1,
+  },
+  hintAction: {
+    borderWidth: 1,
+    borderRadius: 7,
+    paddingVertical: 3,
+    paddingHorizontal: 8,
+    marginLeft: 8,
+  },
+  hintActionText: {
+    fontSize: 11,
+    fontWeight: '700',
+  },
+  hintDismiss: {
+    paddingLeft: 8,
   },
   counterHint: {
     fontSize: 11,

--- a/SudokuApp/games/fungiku/FungikuWinBanner.js
+++ b/SudokuApp/games/fungiku/FungikuWinBanner.js
@@ -57,7 +57,11 @@ const FungikuWinBanner = ({ solved, size, seed, accent, onNextPuzzle }) => {
         toValue: 1,
         duration: 900,
         easing: Easing.inOut(Easing.quad),
-        useNativeDriver: true,
+        // JS driver, for the same reason as the board's placement pop: this value
+        // is reset with setValue() above, and setValue() mixed with the native
+        // driver leaves the JS value a stale copy — which strands the rotation
+        // part-way instead of returning it to 0deg.
+        useNativeDriver: false,
       }),
     ]);
     animation.start();

--- a/SudokuApp/games/fungiku/__tests__/engine.test.js
+++ b/SudokuApp/games/fungiku/__tests__/engine.test.js
@@ -11,6 +11,7 @@ import {
   countMushrooms,
   createEmptyMarks,
   cellsRuledOutBy,
+  findForcedDeduction,
 } from '../engine';
 
 // Sizes the v1 ladder ships (plan §8). Kept small so the suite stays fast.
@@ -378,6 +379,97 @@ describe('cellsRuledOutBy', () => {
       marks[cell] = MARKS.MUSHROOM;
 
       expect(findConflicts(marks, bands, size).size).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('findForcedDeduction', () => {
+  const size = 5;
+  const at = (row, col) => row * size + col;
+  // Five horizontal bands: every region is a whole row, so nothing is forced on
+  // an empty board and the test controls exactly what constrains what.
+  const bands = Array.from({ length: size * size }, (_, i) => Math.floor(i / size));
+
+  it('finds nothing on an unconstrained board', () => {
+    expect(findForcedDeduction(createEmptyMarks(size), bands, size)).toBeNull();
+  });
+
+  it('finds a row with exactly one candidate left', () => {
+    const marks = createEmptyMarks(size);
+    // Two mushrooms, chosen so row 1 is squeezed to exactly one cell:
+    //   (0,0) blocks column 0, and touches (1,0) and (1,1)
+    //   (2,2) blocks column 2, and touches (1,1), (1,2) and (1,3)
+    // That leaves (1,4) as row 1's only candidate. The two do not conflict:
+    // different rows, columns and bands, and rows 0 and 2 do not touch.
+    marks[at(0, 0)] = MARKS.MUSHROOM;
+    marks[at(2, 2)] = MARKS.MUSHROOM;
+
+    expect(findForcedDeduction(marks, bands, size)).toEqual({
+      kind: 'row',
+      index: 1,
+      cell: at(1, 4),
+    });
+  });
+
+  it('finds nothing when a group is over-constrained rather than forced', () => {
+    // Adding a third mushroom in column 4 blocks (1,4) too, so row 1 has *no*
+    // candidates. "Exactly one" is the deduction; zero is a contradiction, and
+    // reporting it as forced would be a confidently wrong hint.
+    const marks = createEmptyMarks(size);
+    marks[at(0, 0)] = MARKS.MUSHROOM;
+    marks[at(2, 2)] = MARKS.MUSHROOM;
+    marks[at(4, 4)] = MARKS.MUSHROOM;
+
+    expect(findForcedDeduction(marks, bands, size)).toBeNull();
+  });
+
+  it('reasons only from mushrooms, never from the player X marks', () => {
+    // X marks are beliefs and may be wrong; deducing from them would produce a
+    // confidently wrong hint.
+    const withXs = createEmptyMarks(size);
+    for (let col = 1; col < size; col++) withXs[at(0, col)] = MARKS.X;
+
+    // Row 0 "looks" forced to column 0 if you trust the X's — it must not be.
+    expect(findForcedDeduction(withXs, bands, size)).toBeNull();
+  });
+
+  it('skips groups that already hold a mushroom', () => {
+    const marks = createEmptyMarks(size);
+    marks[at(0, 0)] = MARKS.MUSHROOM;
+
+    const found = findForcedDeduction(marks, bands, size);
+    // Row 0 is done, so it is never the answer.
+    expect(found === null || found.kind !== 'row' || found.index !== 0).toBe(true);
+  });
+
+  it('finds a one-cell region, which is forced by definition', () => {
+    const regions = [...bands];
+    regions[at(2, 2)] = 99; // a region of exactly one cell
+
+    const found = findForcedDeduction(createEmptyMarks(size), regions, size);
+    expect(found).toEqual({ kind: 'region', index: 99, cell: at(2, 2) });
+  });
+
+  it('agrees with the real generator: every deduction it reports matches the solution', () => {
+    // The strongest check available — a forced move must be the *right* move, or
+    // the hint would confidently mislead.
+    [5, 6, 7].forEach((boardSize) => {
+      [1, 2, 3, 7].forEach((seed) => {
+        const puzzle = generate({ size: boardSize, seed });
+        const marks = createEmptyMarks(boardSize);
+
+        // Walk the puzzle forward, taking forced moves as they appear.
+        for (let step = 0; step < boardSize; step++) {
+          const found = findForcedDeduction(marks, puzzle.regions, boardSize);
+          if (!found) break;
+
+          const row = Math.floor(found.cell / boardSize);
+          const col = found.cell % boardSize;
+          expect(puzzle.solution[row]).toBe(col);
+
+          marks[found.cell] = MARKS.MUSHROOM;
+        }
+      });
     });
   });
 });

--- a/SudokuApp/games/fungiku/__tests__/reducer.test.js
+++ b/SudokuApp/games/fungiku/__tests__/reducer.test.js
@@ -1,6 +1,7 @@
 import {
   DEFAULT_SEED,
   FUNGIKU_ACTIONS,
+  HINT_KINDS,
   PAINT_MODES,
   buildPuzzleState,
   createInitialFungikuState,
@@ -9,7 +10,9 @@ import {
   selectCanUndo,
   selectConflicts,
   selectIsSolved,
+  selectMistakes,
   selectMushroomCount,
+  selectRevealCell,
   selectRuleOutCells,
 } from '../reducer';
 import { MARKS, MIN_SIZE, createEmptyMarks } from '../engine';
@@ -470,5 +473,190 @@ describe('the rule-out button', () => {
 
   it('cannot win a board on its own', () => {
     expect(selectIsSolved(ruleOut(placeMushroom(base, 12)))).toBe(false);
+  });
+});
+
+describe('correctness feedback', () => {
+  const base = buildPuzzleState({ size: 5, seed: 1 });
+  const solutionCell = (row) => row * base.size + base.solution[row];
+
+  it('is off by default', () => {
+    expect(base.showMistakes).toBe(false);
+  });
+
+  it('flags a mushroom that breaks no rule but is in the wrong cell', () => {
+    // Pick a cell in row 0 that is not the solution's.
+    const wrong = base.solution[0] === 0 ? 1 : 0;
+    const state = placeMushroom(base, wrong);
+
+    expect(selectConflicts(state).size).toBe(0); // legal so far
+    expect([...selectMistakes(state)]).toEqual([wrong]);
+  });
+
+  it('does not flag a correct mushroom', () => {
+    expect(selectMistakes(placeMushroom(base, solutionCell(0))).size).toBe(0);
+  });
+
+  it('never flags an X mark, however many there are', () => {
+    // X is a thinking aid with no bearing on the win, so there is no wrong X.
+    const allX = base.marks.reduce((acc, _, cell) => cycle(acc, cell), base);
+
+    expect(allX.marks.every((m) => m === MARKS.X)).toBe(true);
+    expect(selectMistakes(allX).size).toBe(0);
+  });
+
+  it('never flags a complete legal board, because there cannot be one that is wrong', () => {
+    // Uniqueness: N mushrooms with no conflicts *is* the solution.
+    const solved = solve(base);
+
+    expect(selectIsSolved(solved)).toBe(true);
+    expect(selectMistakes(solved).size).toBe(0);
+  });
+
+  it('is a preference the switch toggles, independent of the flags themselves', () => {
+    const wrong = base.solution[0] === 0 ? 1 : 0;
+    const placed = placeMushroom(base, wrong);
+    const on = fungikuReducer(placed, { type: FUNGIKU_ACTIONS.TOGGLE_MISTAKES });
+
+    expect(on.showMistakes).toBe(true);
+    // The selector reports mistakes either way — only rendering is gated.
+    expect(selectMistakes(on).size).toBe(1);
+    expect(fungikuReducer(on, { type: FUNGIKU_ACTIONS.TOGGLE_MISTAKES }).showMistakes).toBe(false);
+  });
+
+  it('carries the preference across a new puzzle', () => {
+    expect(buildPuzzleState({ size: 6, seed: 2, showMistakes: true }).showMistakes).toBe(true);
+  });
+});
+
+describe('hints', () => {
+  const base = buildPuzzleState({ size: 5, seed: 1 });
+  const solutionCell = (row) => row * base.size + base.solution[row];
+  const hintFor = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.REQUEST_HINT });
+  const reveal = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.REVEAL_MUSHROOM });
+
+  it('starts with no hint and none used', () => {
+    expect(base.hint).toBeNull();
+    expect(base.hintsUsed).toBe(0);
+  });
+
+  it('reports a mistake before anything else, because a wrong mushroom corrupts every deduction after it', () => {
+    const wrong = base.solution[0] === 0 ? 1 : 0;
+    const state = hintFor(placeMushroom(base, wrong));
+
+    expect(state.hint.kind).toBe(HINT_KINDS.MISTAKE);
+    expect(state.hint.cells).toEqual([wrong]);
+    expect(state.hintsUsed).toBe(1);
+  });
+
+  it('nudges at a group without naming the cell', () => {
+    // Four of five rows solved leaves the fifth forced.
+    let state = base;
+    for (let row = 0; row < 4; row++) state = placeMushroom(state, solutionCell(row));
+
+    const hinted = hintFor(state);
+    expect(hinted.hint.kind).toBe(HINT_KINDS.NUDGE);
+    // The highlight is the whole group, not the single forced cell — that is
+    // what makes it a nudge rather than a reveal.
+    expect(hinted.hint.cells.length).toBeGreaterThan(1);
+    expect(hinted.hint.cells).toContain(solutionCell(4));
+    expect(hinted.hint.message).toMatch(/only one cell/i);
+  });
+
+  it('says so honestly when nothing is forced, instead of quietly revealing', () => {
+    // A synthetic layout where every region is a whole row, so every row, column
+    // and region has five candidates and nothing is forced. (A generated puzzle
+    // often *does* have a forced move on an empty board — a one-cell region is
+    // forced by definition — so this branch needs a board built for it.)
+    const bands = {
+      size: 5,
+      seed: 0,
+      regions: Array.from({ length: 25 }, (_, i) => Math.floor(i / 5)),
+      solution: [0, 2, 4, 1, 3],
+      marks: createEmptyMarks(5),
+      undoStack: [],
+      redoStack: [],
+      showMistakes: false,
+      hintsUsed: 0,
+      hint: null,
+      strokeOpen: false,
+    };
+
+    const hinted = hintFor(bands);
+    expect(hinted.hint.kind).toBe(HINT_KINDS.STUCK);
+    expect(hinted.hint.offerReveal).toBe(true);
+    expect(hinted.hint.cells).toEqual([]);
+    // Nothing was given away, so it does not count against the player.
+    expect(hinted.hintsUsed).toBe(0);
+  });
+
+  it('reveals a correct mushroom as a separate, counted action', () => {
+    const revealed = reveal(base);
+    const cell = revealed.hint.cells[0];
+
+    expect(revealed.hint.kind).toBe(HINT_KINDS.REVEAL);
+    expect(revealed.marks[cell]).toBe(MARKS.MUSHROOM);
+    expect(selectMistakes(revealed).size).toBe(0); // it revealed a *correct* one
+    expect(revealed.hintsUsed).toBe(1);
+  });
+
+  it('never reveals a mushroom that would conflict', () => {
+    // Reveal repeatedly and check the board stays legal throughout.
+    let state = base;
+    for (let i = 0; i < 5; i++) {
+      state = reveal(state);
+      expect(selectConflicts(state).size).toBe(0);
+    }
+    expect(selectIsSolved(state)).toBe(true);
+  });
+
+  it('has nothing safe to reveal when a wrong mushroom blocks every solution cell', () => {
+    // Fill the whole board with mushrooms: every solution cell is occupied or
+    // conflicted, so there is no safe reveal and the cascade reports mistakes.
+    const everywhere = base.marks.reduce((acc, _, cell) => placeMushroom(acc, cell), base);
+
+    expect(selectRevealCell(everywhere)).toBe(-1);
+    expect(reveal(everywhere)).toBe(everywhere);
+    expect(hintFor(everywhere).hint.kind).toBe(HINT_KINDS.MISTAKE);
+  });
+
+  it('is one undoable action', () => {
+    const revealed = reveal(base);
+    const back = fungikuReducer(revealed, { type: FUNGIKU_ACTIONS.UNDO });
+
+    expect(back.marks).toEqual(base.marks);
+  });
+
+  it('goes stale the moment the board changes', () => {
+    const hinted = hintFor(base);
+    expect(hinted.hint).not.toBeNull();
+
+    expect(cycle(hinted, 0).hint).toBeNull();
+
+    // Only an action that *actually changes the board* clears it. A no-op
+    // action leaves the advice alone, because it is still advice about the board
+    // in front of you — so these use a board where each action does something.
+    const played = hintFor(placeMushroom(base, solutionCell(0)));
+    expect(fungikuReducer(played, { type: FUNGIKU_ACTIONS.RULE_OUT }).hint).toBeNull();
+    expect(fungikuReducer(played, { type: FUNGIKU_ACTIONS.UNDO }).hint).toBeNull();
+
+    // ...and a no-op undo on a board with no history keeps it.
+    expect(fungikuReducer(hintFor(base), { type: FUNGIKU_ACTIONS.UNDO }).hint).not.toBeNull();
+  });
+
+  it('can be dismissed', () => {
+    const hinted = hintFor(base);
+    expect(fungikuReducer(hinted, { type: FUNGIKU_ACTIONS.DISMISS_HINT }).hint).toBeNull();
+  });
+
+  it('keeps its count across a hint that follows', () => {
+    const once = reveal(base);
+    expect(reveal(once).hintsUsed).toBe(2);
+  });
+
+  it('resets the count for a new puzzle but not the preference', () => {
+    const fresh = buildPuzzleState({ size: 5, seed: 2, showMistakes: true, hintsUsed: 0 });
+    expect(fresh.hintsUsed).toBe(0);
+    expect(fresh.showMistakes).toBe(true);
   });
 });

--- a/SudokuApp/games/fungiku/engine.js
+++ b/SudokuApp/games/fungiku/engine.js
@@ -437,6 +437,77 @@ export function createEmptyMarks(size) {
 }
 
 /**
+ * Find one **forced** placement given the mushrooms already on the board.
+ *
+ * This is a different question from the one `findSolutions` answers, and the
+ * distinction is the whole point of hint rung 2 (plan §11.2). `findSolutions`
+ * backtracks: it can tell you *what* the answer is, but not that any particular
+ * step follows from the board in front of you. A hint that says "row 3 has only
+ * one cell left" teaches; a hint that says "the answer is here" does not.
+ *
+ * So this does constraint propagation instead. Candidates are the cells no placed
+ * mushroom forbids; a row, column or region with exactly one candidate has a
+ * forced placement. **Only placed mushrooms constrain the search — never the
+ * player's X marks**, which are beliefs and may be wrong. Deducing from a wrong X
+ * would produce a confidently wrong hint.
+ *
+ * @returns {{kind: 'row'|'column'|'region', index: number, cell: number}|null}
+ *   `index` is the row/column number or region id — enough to point at without
+ *   giving the cell away. null when nothing is forced from here.
+ */
+export function findForcedDeduction(marks, regions, size) {
+  const blocked = new Array(size * size).fill(false);
+  const filledRows = new Set();
+  const filledCols = new Set();
+  const filledRegions = new Set();
+
+  marks.forEach((mark, cell) => {
+    if (mark !== MARKS.MUSHROOM) return;
+    filledRows.add(Math.floor(cell / size));
+    filledCols.add(cell % size);
+    filledRegions.add(regions[cell]);
+    cellsRuledOutBy(cell, regions, size).forEach((ruled) => {
+      blocked[ruled] = true;
+    });
+  });
+
+  const isCandidate = (cell) => !blocked[cell] && marks[cell] !== MARKS.MUSHROOM;
+
+  /** The one candidate in `cells`, or -1 if there are none or several. */
+  const soleCandidate = (cells) => {
+    const found = cells.filter(isCandidate);
+    return found.length === 1 ? found[0] : -1;
+  };
+
+  // Rows first, then columns, then regions: rows and columns are the constraints
+  // a player scans naturally, so a nudge about them lands more easily.
+  for (let row = 0; row < size; row++) {
+    if (filledRows.has(row)) continue;
+    const cell = soleCandidate(Array.from({ length: size }, (_, col) => idx(row, col, size)));
+    if (cell >= 0) return { kind: 'row', index: row, cell };
+  }
+
+  for (let col = 0; col < size; col++) {
+    if (filledCols.has(col)) continue;
+    const cell = soleCandidate(Array.from({ length: size }, (_, row) => idx(row, col, size)));
+    if (cell >= 0) return { kind: 'column', index: col, cell };
+  }
+
+  const regionIds = [...new Set(regions)];
+  for (const region of regionIds) {
+    if (filledRegions.has(region)) continue;
+    const cells = [];
+    regions.forEach((r, cell) => {
+      if (r === region) cells.push(cell);
+    });
+    const cell = soleCandidate(cells);
+    if (cell >= 0) return { kind: 'region', index: region, cell };
+  }
+
+  return null;
+}
+
+/**
  * Every cell a mushroom at `cell` rules out: its whole row, its whole column,
  * its whole color region, and the eight cells touching it (plan §1). `cell`
  * itself is not included.

--- a/SudokuApp/games/fungiku/reducer.js
+++ b/SudokuApp/games/fungiku/reducer.js
@@ -21,6 +21,7 @@ import {
   createEmptyMarks,
   countMushrooms,
   findConflicts,
+  findForcedDeduction,
   generate,
   isSolved,
   nextMark,
@@ -44,6 +45,20 @@ export const FUNGIKU_ACTIONS = {
   // "Rule out" — one tap marks every cell the mushrooms already on the board
   // forbid. An action the player asks for, not a mode that acts behind them.
   RULE_OUT: 'FUNGIKU_RULE_OUT',
+
+  // Feedback and hints (plan §11).
+  TOGGLE_MISTAKES: 'FUNGIKU_TOGGLE_MISTAKES',
+  REQUEST_HINT: 'FUNGIKU_REQUEST_HINT',
+  REVEAL_MUSHROOM: 'FUNGIKU_REVEAL_MUSHROOM',
+  DISMISS_HINT: 'FUNGIKU_DISMISS_HINT',
+};
+
+/** What a hint turned out to be able to offer (plan §11.2). */
+export const HINT_KINDS = {
+  MISTAKE: 'mistake',
+  NUDGE: 'nudge',
+  REVEAL: 'reveal',
+  STUCK: 'stuck',
 };
 
 /** What a drag stroke does to the cells it crosses. */
@@ -59,7 +74,13 @@ export const DEFAULT_SEED = 1;
  *
  * @param {{size: number, seed: number, marks?: string[]}} opts
  */
-export const buildPuzzleState = ({ size = DEFAULT_SIZE, seed = DEFAULT_SEED, marks } = {}) => {
+export const buildPuzzleState = ({
+  size = DEFAULT_SIZE,
+  seed = DEFAULT_SEED,
+  marks,
+  showMistakes = false,
+  hintsUsed = 0,
+} = {}) => {
   const puzzle = generate({ size, seed });
 
   return {
@@ -74,6 +95,15 @@ export const buildPuzzleState = ({ size = DEFAULT_SIZE, seed = DEFAULT_SEED, mar
         : createEmptyMarks(puzzle.size),
     undoStack: [],
     redoStack: [],
+    // Opt-in correctness feedback (plan §11.1). Off by default: left on it turns
+    // a deduction puzzle into trial-and-error. A preference, so it carries across
+    // puzzles; §8 #7 asks whether it should default on for younger players.
+    showMistakes: !!showMistakes,
+    // Per-puzzle, so the ladder step can price hints later (plan §11.2).
+    hintsUsed: Number.isFinite(hintsUsed) ? hintsUsed : 0,
+    // Transient advice, never persisted: it goes stale the moment the board
+    // changes, so every board-changing action clears it.
+    hint: null,
     // Transient: true between BEGIN_STROKE and the stroke's first effective
     // paint, which is the paint that records the single undo entry. Never
     // persisted (see ./storage.js).
@@ -94,6 +124,8 @@ const pushHistory = (state, marks) => ({
   marks,
   undoStack: [...state.undoStack, state.marks],
   redoStack: [],
+  // Advice about a board you have since changed is worse than no advice.
+  hint: null,
 });
 
 export function fungikuReducer(state, action) {
@@ -131,6 +163,85 @@ export function fungikuReducer(state, action) {
       // Retracting them per-mushroom would need per-mark provenance, which is
       // ambiguous the moment two mushrooms rule out the same cell.
       return pushHistory(state, marks);
+    }
+
+    case FUNGIKU_ACTIONS.TOGGLE_MISTAKES:
+      return { ...state, showMistakes: !state.showMistakes };
+
+    case FUNGIKU_ACTIONS.DISMISS_HINT:
+      return state.hint ? { ...state, hint: null } : state;
+
+    /**
+     * One hint, as weak as will still help (plan §11.2). The cascade matters:
+     *
+     * 1. A wrong mushroom on the board corrupts every deduction that follows, so
+     *    saying "row 3 is forced" would be confidently wrong. Mistakes first.
+     * 2. Otherwise nudge: name the row, column or region where something is
+     *    forced, *without* saying which cell. That is the hint that teaches.
+     * 3. Nothing forced from here — **say so** rather than quietly revealing.
+     *    The reveal is a second, deliberate tap.
+     */
+    case FUNGIKU_ACTIONS.REQUEST_HINT: {
+      const mistakes = selectMistakes(state);
+      if (mistakes.size > 0) {
+        const cell = Math.min(...mistakes);
+        return {
+          ...state,
+          hintsUsed: state.hintsUsed + 1,
+          hint: {
+            kind: HINT_KINDS.MISTAKE,
+            cells: [cell],
+            message:
+              mistakes.size === 1
+                ? 'This mushroom is in the wrong place.'
+                : `${mistakes.size} of your mushrooms are in the wrong place — here is one.`,
+          },
+        };
+      }
+
+      const forced = findForcedDeduction(state.marks, state.regions, state.size);
+      if (forced) {
+        return {
+          ...state,
+          hintsUsed: state.hintsUsed + 1,
+          hint: {
+            kind: HINT_KINDS.NUDGE,
+            // The whole row/column/region, deliberately — not `forced.cell`.
+            cells: [...cellsOfGroup(forced, state.regions, state.size)],
+            message: `${describeGroup(forced)} has only one cell left that can hold a mushroom.`,
+          },
+        };
+      }
+
+      // No forced step. Not counted as a hint used: it gave nothing away.
+      return {
+        ...state,
+        hint: {
+          kind: HINT_KINDS.STUCK,
+          cells: [],
+          offerReveal: true,
+          message: 'No single forced step from here. Reveal a mushroom instead?',
+        },
+      };
+    }
+
+    /** The strongest rung: place one correct mushroom outright. */
+    case FUNGIKU_ACTIONS.REVEAL_MUSHROOM: {
+      const cell = selectRevealCell(state);
+      if (cell < 0) return state;
+
+      const marks = state.marks.slice();
+      marks[cell] = MARKS.MUSHROOM;
+
+      return {
+        ...pushHistory(state, marks),
+        hintsUsed: state.hintsUsed + 1,
+        hint: {
+          kind: HINT_KINDS.REVEAL,
+          cells: [cell],
+          message: 'One mushroom revealed.',
+        },
+      };
     }
 
     case FUNGIKU_ACTIONS.BEGIN_STROKE:
@@ -183,6 +294,7 @@ export function fungikuReducer(state, action) {
         marks: state.undoStack[state.undoStack.length - 1],
         undoStack: state.undoStack.slice(0, -1),
         redoStack: [...state.redoStack, state.marks],
+        hint: null,
       };
     }
 
@@ -193,6 +305,7 @@ export function fungikuReducer(state, action) {
         marks: state.redoStack[state.redoStack.length - 1],
         undoStack: [...state.undoStack, state.marks],
         redoStack: state.redoStack.slice(0, -1),
+        hint: null,
       };
     }
 
@@ -235,5 +348,72 @@ export const selectRuleOutCells = (state) => {
 
 export const selectCanUndo = (state) => state.undoStack.length > 0;
 export const selectCanRedo = (state) => state.redoStack.length > 0;
+
+/**
+ * Mushrooms that break no rule *yet* but are not where the puzzle's single
+ * solution has them (plan §11.1). Derived, never stored, so undo cannot leave a
+ * stale flag behind.
+ *
+ * **Mushrooms only.** X marks are a thinking aid with no bearing on the win, so
+ * there is no such thing as a wrong X — flagging one would be telling the player
+ * how to think.
+ *
+ * Note what this can never report: because the puzzle has exactly one solution,
+ * N mushrooms placed with no conflicts *is* that solution. There is no
+ * complete-but-wrong board, so this is purely a mid-solve aid.
+ */
+export const selectMistakes = (state) => {
+  const out = new Set();
+
+  state.marks.forEach((mark, cell) => {
+    if (mark !== MARKS.MUSHROOM) return;
+    const row = Math.floor(cell / state.size);
+    if (state.solution[row] !== cell % state.size) out.add(cell);
+  });
+
+  return out;
+};
+
+/**
+ * Which cell a reveal would fill: a row still missing its mushroom whose solution
+ * cell can be placed **without creating a conflict** (plan §11.2 — "a hint that
+ * creates a conflict is worse than no hint").
+ *
+ * Returns -1 when there is nothing safe to reveal, which in practice means a
+ * wrongly-placed mushroom is in the way. The hint cascade catches that first and
+ * reports the mistake instead.
+ */
+export const selectRevealCell = (state) => {
+  for (let row = 0; row < state.size; row++) {
+    const cell = row * state.size + state.solution[row];
+    if (state.marks[cell] === MARKS.MUSHROOM) continue;
+
+    const trial = state.marks.slice();
+    trial[cell] = MARKS.MUSHROOM;
+    if (!findConflicts(trial, state.regions, state.size).has(cell)) return cell;
+  }
+
+  return -1;
+};
+
+/** Every cell of the row/column/region a nudge points at. */
+const cellsOfGroup = ({ kind, index }, regions, size) => {
+  if (kind === 'row') return Array.from({ length: size }, (_, col) => index * size + col);
+  if (kind === 'column') return Array.from({ length: size }, (_, row) => row * size + index);
+
+  const cells = [];
+  regions.forEach((region, cell) => {
+    if (region === index) cells.push(cell);
+  });
+  return cells;
+};
+
+/** How a nudge names the group it is pointing at, in the player's terms. */
+const describeGroup = ({ kind, index }) => {
+  if (kind === 'row') return `Row ${index + 1}`;
+  if (kind === 'column') return `Column ${index + 1}`;
+  // Regions have no number the player can see — the highlight does the pointing.
+  return 'One color region';
+};
 
 export default fungikuReducer;

--- a/SudokuApp/games/fungiku/storage.js
+++ b/SudokuApp/games/fungiku/storage.js
@@ -35,7 +35,13 @@ export const loadFungikuState = async () => {
 
     // Rebuilding through buildPuzzleState also validates the save: a `marks`
     // array of the wrong length for this size is discarded, not rendered.
-    return buildPuzzleState({ size: saved.size, seed: saved.seed, marks: saved.marks });
+    return buildPuzzleState({
+      size: saved.size,
+      seed: saved.seed,
+      marks: saved.marks,
+      showMistakes: saved.showMistakes,
+      hintsUsed: saved.hintsUsed,
+    });
   } catch (error) {
     console.error('Error loading Fungiku state:', error);
     return null;
@@ -52,9 +58,13 @@ export const saveFungikuState = debounce(async (state) => {
         size: state.size,
         seed: state.seed,
         marks: state.marks,
-        // `strokeOpen` deliberately does not persist — it is transient gesture
-        // bookkeeping. Nor does anything about the rule-out assist: it is an
-        // action the player taps, not a mode with a remembered setting.
+        // The feedback switch is a preference and the hint count is per-puzzle
+        // history, so both persist. `strokeOpen` and `hint` deliberately do not:
+        // one is gesture bookkeeping, the other is advice that goes stale the
+        // moment the board changes. Nor does anything about the rule-out assist —
+        // it is an action the player taps, not a mode with a remembered setting.
+        showMistakes: !!state.showMistakes,
+        hintsUsed: state.hintsUsed || 0,
       })
     );
   } catch (error) {

--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -92,95 +92,94 @@ operator to test in Expo Go.**
 
 ---
 
-## Next step: **Step 7 — feedback on your moves, and hints**
+## Next step: **Step 8 — the training ladder and scoring**
 
-Branch: **`feature/fungiku-feedback`** off `epic/fungiku`.
-Plan: **§11**, which is the whole spec — read it end to end. Also §8 #6 and #7,
-the two questions this step raises.
+Branch: **`feature/fungiku-ladder`** off `epic/fungiku`.
+Plan: the §7 table row for step 8, plus **§8 #4**, which this step needs answered
+(or defaulted, with the default stated in the PR).
 
 ### Why this step exists
 
-Two gaps, both requested by the operator. Today the board tells you when you have
-**broken a rule** and nothing else: it never tells you a legal move was *wrong*,
-and when you are genuinely stuck your only options are guess or walk away.
+Fungiku is a complete puzzle with feedback and hints, but it has **no shape as a
+game**. You pick a size from four chips and press "New puzzle" for a random seed;
+nothing tracks what you have done, nothing gets harder, nothing tells you that
+you are improving. This step turns a puzzle generator into something worth coming
+back to.
 
-It comes before the ladder and scoring on purpose: **scoring has to know what a
-mistake and a hint are worth.** Building scoring first would mean guessing at the
-currency it is denominated in.
+Feedback and hints landed first on purpose: **scoring now has real events to
+price.** `hintsUsed` is already recorded per puzzle, and `selectMistakes` already
+knows when a placement is wrong.
 
 ### Read first
 
-- **`docs/fungiku-plan.md` §11** — the spec. Four kinds of feedback (§11.1) and a
-  four-rung hint ladder (§11.2), with what each costs to build.
-- `SudokuApp/games/fungiku/engine.js` — `generate()` already returns `solution`,
-  and `findSolutions(regions, size, limit)` recovers it from a layout. That is all
-  correctness feedback and the revealing hints need. What the engine does **not**
-  have is any notion of a move being *forced*, which is what hint rung 2 needs.
-- `SudokuApp/games/fungiku/reducer.js` — `selectConflicts` is the model to copy
-  for a `selectMistakes`-style selector: **derive it, never store it**, or undo
-  will leave stale flags behind. `selectRuleOutCells` shows the shape for "cells a
-  hint would touch".
-- `SudokuApp/games/fungiku/FungikuBoard.js` — where a mistake marker has to
-  render. Note conflicts already own the ring and the recoloured glyph, so a
-  mistake needs a *different* visual channel; and note the accessibility label
-  format, which must grow to carry the new state.
-- `SudokuApp/contexts/GameContext.js` + `components/modals/GameMenuModal.js` —
-  Sudoku's **"Show Mistakes"** switch, its `showFeedback` flag and its
-  `cellFeedback` map. Match its wording and placement so the app has one
-  vocabulary for the idea. Read it; don't refactor it.
-- `SudokuApp/games/fungiku/__tests__/reducer.test.js` — the style to extend. The
-  selectors are pure and deserve the same coverage the others got.
+- `SudokuApp/games/fungiku/reducer.js` — `hintsUsed` is already counted per
+  puzzle and persisted; that is the hook scoring hangs off. Note how `changeSize`
+  and `nextPuzzle` currently work (`changeSize` resets to seed 1, `nextPuzzle`
+  bumps the seed) — a ladder replaces that with a level list.
+- `SudokuApp/games/fungiku/storage.js` — persistence is `size` + `seed` + `marks`
+  + `showMistakes` + `hintsUsed`. Ladder progress is the first thing needing a
+  **schema change**: bump `FUNGIKU_STORAGE_VERSION` and decide what an old save
+  migrates to. Today a version mismatch returns null and the board starts fresh —
+  fine for a board, **not** fine for someone's progress.
+- `SudokuApp/utils/gameProgress.js` + `games/registry.js` —
+  `describeFungikuProgress` feeds the hub's Continue badge. With a ladder the
+  badge probably wants to name the *level* rather than the board size.
+- **The sibling color-loop app is the reference for exactly this problem** — it
+  has a training ladder in `games/colorloop/levels.ts` with per-level star
+  thresholds, and its `docs/game-design.md` covers the progression thinking. Read
+  it before designing a second one from scratch.
+- `SudokuApp/contexts/GameContext.js` — Sudoku's scoring (time-based, with
+  completion bonuses) is one model. Fungiku has **no timer at all** today, which
+  is a decision this step has to make deliberately rather than by accident.
 
 ### Scope — ONLY this
 
-1. **Correctness feedback, opt-in** — a selector flagging mushrooms not in the
-   solution, a switch to turn it on, and a board treatment distinct from
-   conflicts. Off by default pending §8 #7.
-2. **Positive confirmation** — a correct placement should *feel* correct, not
-   merely fail to turn red. A settle or pulse in the app's motion language.
-   §11.1 calls this the most-often-skipped half of feedback; do not skip it.
-3. **Hint rungs 3 and 4** — reveal a correct mushroom, and point out a mistake.
-   Both are trivial given the solution, both are one undoable action.
-4. **Hint rung 2 (the nudge) — attempt it, and be honest if it does not land.**
-   Naming a row/column/region where a deduction is *available* needs constraint
-   propagation, not the existing backtracking solver. It is the real work here
-   and the best hint in a teaching game. If it proves too big, ship rungs 3–4 and
-   say plainly in the PR that the nudge is deferred — **do not fake it** by
-   dressing up a reveal as a nudge.
-5. **Count hints used per puzzle** — the ladder step needs it, and it is far
-   easier to record now than to retrofit.
-6. **Tests** for every new selector, and for the hint invariants below.
+1. **A level ladder as data** — an ordered list, each level pinning a `size` and a
+   `seed`. Both are already deterministic, so a level *is* a `{size, seed}` pair.
+   Keep it a table in its own module so tuning is editing data.
+2. **Progression + persistence** — which levels are complete, and what unlocks.
+   Bump the storage version and **migrate**, don't discard.
+3. **A level-select surface** replacing the raw size chips as the primary path.
+   Keep a free-play route: the chips are how the 8×8 regression cases get
+   checked, and free choice is a reasonable answer to §8 #4.
+4. **Scoring** — decide what it measures and say why in the PR. Hints used and
+   mistakes made are both available now. If it needs a timer, add one, and note
+   that Fungiku deliberately had none until this point.
+5. **Hub integration** — the Continue badge should reflect ladder position.
+6. **Tests** — the ladder table and progression logic are pure; cover them. And
+   **assert that every level in the table actually generates**: a bad
+   `{size, seed}` pair would otherwise only fail when a player reaches it.
 
 ### Behaviors that are easy to get wrong
 
-- **X marks are never wrong.** Correctness feedback applies to **mushrooms only**
-  (§11.1). Flagging a "wrong" X is telling the player how to think.
-- **There is no complete-but-wrong board.** Uniqueness means N mushrooms placed
-  with no conflicts *is* the solution, so correctness feedback is purely a
-  mid-solve aid — it can never be what tells you a finished board is wrong.
-  A test asserting "a legal full board is never flagged" is worth having.
-- **A hint must never place a conflicting mushroom.** Worse than no hint.
-- **Derive feedback, don't store it.** Same reason conflicts are a selector: undo
-  must not be able to leave a stale mistake marker on the board.
-- **Conflicts and mistakes are different things** and can coexist on one cell. Do
-  not let one visual treatment swallow the other, and keep both readable without
-  color (plan §5) and on a dark theme.
-- **Don't regress the cell accessibility labels** — they are the test seam. Extend
-  the format, don't reshape it.
+- **Every level must be generatable.** `generate()` throws below size 5; a typo
+  in the table becomes a crash for whoever reaches that level. Assert the whole
+  table.
+- **Don't lose existing progress on the schema change.** A player mid-board today
+  has `{size, seed, marks, showMistakes, hintsUsed}` and no ladder state; that has
+  to migrate to something sensible, not a wiped save.
+- **Star thresholds and difficulty curves are guesses until played.** Draft them,
+  say in the PR that they are estimates, and flag them for tuning on device — the
+  same way color-loop's ladder was left.
+- **Keep free play reachable**, or the 8×8 palette and layout cases get harder to
+  check.
+- **Don't let scoring change what a hint does.** Hints are counted already; this
+  step prices them, it does not redesign them.
 
 ### Out of scope for this step
 
-- **No ladder, progression or scoring** — Step 8. Count hints, don't price them.
 - **No art swap** — Step 9, gated on artwork rather than code.
-- **No Sudoku changes.** Its "Show Mistakes" is a reference for wording and
-  placement, not something to refactor or share code with.
+- **No new feedback or hint behavior.** Step 7 shipped both; if the operator wants
+  the hint ladder to escalate differently (see the note below), that is its own
+  change, not this step.
+- **No engine changes.** Levels are `{size, seed}` pairs over the existing
+  generator.
 
 ### Visible in Expo Go when this lands
 
-Turn **Show Mistakes** on, place a mushroom that breaks no rule but is in the
-wrong cell, and see it flagged as a mistake rather than as a conflict. Get stuck
-and **ask for a hint**, and get help proportional to what you asked for. A correct
-placement feels like one.
+A **level list** you progress through, with completed levels marked, and a score
+or rating when you solve one. The hub's Fungiku card says where you are in the
+ladder.
 
 ## Open questions for the operator (carry these forward)
 
@@ -201,6 +200,19 @@ placement feels like one.
    *(Step 6 concern.)*
 
 ### Noted in passing, for a later step
+
+- **A reveal is only reachable when nothing is forced.** The hint button gives the
+  weakest hint that still helps, so while any forced deduction exists you get a
+  nudge and never a reveal. That is deliberate — it is the pedagogically right
+  default for a family game — but it means a frustrated player cannot skip to the
+  answer. Flagged against §8 #6; making reveal always available is a small change
+  if the operator wants it.
+- **A banner mounting above the board invalidates the board's measured origin.**
+  `onLayout` does not save you: on web it is backed by a ResizeObserver, which
+  watches size and not position, so a board that merely *moves* never fires it.
+  `FungikuBoard` re-measures in an effect keyed on `[hint, solved]` — the two
+  things that mount a banner. **Anything new added above the board must be added
+  to those deps**, or the first tap after it appears lands on the wrong cell.
 
 - **Dragging on the board never scrolls the page.** The board claims every touch
   at touch-down — that is the fix for the operator's device report that a vertical
@@ -254,4 +266,5 @@ placement feels like one.
 | 3 | Game shell + hub — router, registry, `HubScreen`, `FungikuScreen`, back-to-hub | merged to `epic/fungiku` (#70, `a9caf92`) |
 | 4 | Fungiku state — reducer, tap-to-cycle marks, live conflicts, win, undo/redo, own-key persistence | merged to `epic/fungiku` (#70, `a9caf92`) |
 | 5 | Board UI — palette fix with a tested ΔE floor, themed + responsive board, animated win | merged to `epic/fungiku` (#71, `905bfa2`) |
-| 6 | Input ergonomics — drag to sweep X's, rule-out button | PR to `epic/fungiku` |
+| 6 | Input ergonomics — drag to sweep X's, rule-out button | merged to `epic/fungiku` (#72, `e896fb6`) |
+| 7 | Feedback & hints — mistake flagging, forced-deduction nudge, reveal, placement pop | PR to `epic/fungiku` |

--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -215,6 +215,12 @@ ladder.
   cell".** Resetting a shared value happens immediately while re-pointing it is a
   React state update, so for a frame it is still attached to the *previous* cell.
   On device that showed up as the previously placed mushroom shrinking.
+- **Never mix `setValue()` with `useNativeDriver: true`** — plan §2 has the full
+  rule. The native driver does not keep the JS value in step, so a value that is
+  reset with `setValue()` can be left stranded at the reset value *permanently*.
+  On device that showed up as five of eight mushrooms sitting small on a solved
+  board. If you `setValue()` it, drive it with `useNativeDriver: false`,
+  `stopAnimation()` before restarting, and finish with an explicit rest.
 - **A banner mounting above the board invalidates the board's measured origin.**
   `onLayout` does not save you: on web it is backed by a ResizeObserver, which
   watches size and not position, so a board that merely *moves* never fires it.

--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -207,6 +207,14 @@ ladder.
   default for a family game — but it means a frustrated player cannot skip to the
   answer. Flagged against §8 #6; making reveal always available is a small change
   if the operator wants it.
+- **Native gesture/animation bugs do not reproduce in the web build, and a
+  passing browser check can be a false pass.** Both bugs the operator has found
+  were invisible on web — see plan §2, "A pattern worth knowing". Use the browser
+  to prove nothing broke; ask for a device pass to prove the native bug is fixed.
+- **One `Animated.Value` per cell, never one shared value pointed at "the current
+  cell".** Resetting a shared value happens immediately while re-pointing it is a
+  React state update, so for a frame it is still attached to the *previous* cell.
+  On device that showed up as the previously placed mushroom shrinking.
 - **A banner mounting above the board invalidates the board's measured origin.**
   `onLayout` does not save you: on web it is backed by a ResizeObserver, which
   watches size and not position, so a board that merely *moves* never fires it.

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -219,6 +219,35 @@ value driven with `useNativeDriver`:
   animation values instead of one shared value; claiming a touch at touch-down
   instead of racing for it.
 
+#### Never mix `setValue()` with `useNativeDriver: true`
+
+The concrete rule that came out of the second bug, worth stating on its own
+because it is easy to write by accident and impossible to see on web.
+
+With `useNativeDriver: true` the animation runs on the native side and **the
+JS-side `Animated.Value` is not kept in step**. So a value that is reset with
+`setValue()` and then animated natively can end up with its JS copy stranded at
+the reset value. Anything that later initializes from the JS value renders the
+stranded number — permanently, not for a frame.
+
+The operator caught exactly that: on a **solved** 8×8, five of eight mushrooms sat
+noticeably smaller than the rest, each one stuck at the pop animation's start
+scale. A solved board is stationary, which is what made it obvious that these were
+resting values and not animation frames.
+
+So:
+
+- **If a value is reset with `setValue()`, drive it with `useNativeDriver: false`.**
+  The JS value is then the single source of truth and lands exactly on the target.
+  A one-cell scale on the JS driver costs nothing worth measuring.
+- **`stopAnimation()` before restarting** a value, or a fast place/remove/place
+  leaves two animations driving it.
+- **Finish with an explicit rest**: `.start(() => value.setValue(1))`, so an
+  interrupted animation cannot leave a permanent visual defect.
+- Values animated only with `timing`/`spring` to an explicit `toValue` in *both*
+  directions, and never `setValue()`d, are safe on the native driver — the win
+  banner's entrance and the board's win lift both qualify and stay native.
+
 ## 3. The board
 
 - **Region color = cell background**, filling the whole cell (the reference is a

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -310,7 +310,7 @@ the step's real acceptance test, alongside its automated checks.
 | 4 | ~~**State**~~ ✅ — reducer + context: mark cycling, live conflict validation, win detection, undo/redo, persistence | The Fungiku screen becomes **playable**: tap-to-cycle X/🍄, live conflict highlighting, `🍄 X/N` counter, win banner |
 | 5 | ~~**Board UI**~~ ✅ — the real board component: region-boundary borders, themed styling, win flow, **palette tuning** | The **finished board**, styled to the app's themes, replacing the preview's rough grid |
 | 6 | ~~**Input ergonomics & assists**~~ ✅ (§2) — **drag to sweep X's**, rule-out button | **Swipe a finger across cells to rule them out**; a *Rule out* button |
-| 7 | **Feedback & hints** (§11) — correctness feedback on placements, and a hint ladder | **Optional "show mistakes" for mushrooms**, and a hint you can ask for when stuck |
+| 7 | ~~**Feedback & hints**~~ ✅ (§11) — correctness feedback on placements, and a hint ladder | **Optional "show mistakes" for mushrooms**, and a hint you can ask for when stuck |
 | 8 | **Ladder & scoring** — training ladder, size progression, scoring | Level progression and a score |
 | 9 | **Art swap** (floating, asset-only — gated on artwork, not on code) | Static mushroom art replaces the icon glyph |
 

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -191,6 +191,34 @@ drags painted correctly before the fix. What a browser *can* check is that taps,
 strokes, and jittery taps all still behave — do that, then confirm the scroll
 behavior on device.
 
+### A pattern worth knowing: native-only gesture and animation bugs
+
+**Both bugs the operator has found were invisible in the web build**, and for the
+same underlying reason — react-native-web substitutes browser behavior for the
+native machinery:
+
+| Bug | Why the browser could not show it |
+|-----|-----------------------------------|
+| Vertical drag scrolled instead of painting (Step 6) | RNW uses ordinary overflow scrolling, not a native `ScrollView` with touch interception |
+| Placing a mushroom shrank the previously placed one (Step 7) | `useNativeDriver: true` is a no-op on RNW, and React commits the re-render inside the same frame, so the bad intermediate state is never painted |
+
+The second one is worth dwelling on, because it produced a **false pass**: a
+per-frame `requestAnimationFrame` probe of the buggy build reported the earlier
+mushroom never shrinking. The check was not wrong about what it measured; it was
+measuring a platform where the bug does not exist.
+
+So when a fix targets `PanResponder`, a native `ScrollView`, or an `Animated`
+value driven with `useNativeDriver`:
+
+- **Use the browser to prove you have not broken anything** — taps, strokes,
+  labels, no page errors. That is real value and it has caught real regressions.
+- **Do not present a passing browser check as evidence the native bug is fixed.**
+  Say which platform the evidence comes from, and ask for a device pass.
+- Prefer fixes that remove the *class* of problem over fixes that reorder
+  operations, precisely because you cannot test the ordering locally. Per-cell
+  animation values instead of one shared value; claiming a touch at touch-down
+  instead of racing for it.
+
 ## 3. The board
 
 - **Region color = cell background**, filling the whole cell (the reference is a


### PR DESCRIPTION
Step 7 of the Fungiku epic (refs #65, plan §11). Targets `epic/fungiku`.

The board told you when you'd **broken a rule** and nothing else: never that a legal move was *wrong*, and when genuinely stuck your options were guess or walk away.

## 📱 Test it in Expo Go

QR in the Expo preview comment. Runtime `exposdk:54.0.0`, republished on every push.

---

## Correctness feedback — opt-in, off by default

`selectMistakes` flags mushrooms that break no rule *yet* but aren't where the puzzle's single solution has them. Derived, never stored, so undo can't leave a stale flag behind.

- Rendered as a **corner alert badge**, not a ring — so a mistake reads as a *different kind of wrong* from a conflict, and the two can sit on one cell without either being lost.
- **Mushrooms only.** An ✕ is a thinking aid, so there is no such thing as a wrong ✕ — flagging one would be telling the player how to think.
- The selector runs whether or not the switch is on, because the hint cascade needs to know about mistakes even when the player hasn't asked to see them. Only the *rendering* is gated.

## The hint ladder — the cascade is where the design lives

One **Hint** button that gives the weakest hint that still helps:

1. **A wrong mushroom is reported first.** It corrupts every deduction after it, so telling you "row 3 is forced" on a corrupted board would be *confidently wrong*.
2. **Otherwise a nudge** — naming the row, column or region where something is forced, **without** saying which cell.
3. **Nothing forced? It says so**, and offers the reveal as a second, deliberate tap — rather than quietly falling through to the answer.

### The nudge needed a different kind of solver

This is the piece plan §11.2 flagged as the real work, and it's worth being precise about why. `findSolutions` **backtracks**: it knows *what* the answer is, but not that any particular step *follows from the board in front of you*. A hint built on it can only reveal.

So `findForcedDeduction` does **constraint propagation** instead — a row, column or region with exactly one remaining candidate. Two decisions in it matter:

- **It reasons only from placed mushrooms, never from the player's ✕ marks.** ✕s are beliefs and may be wrong; deducing from a wrong ✕ produces a confidently wrong hint. There's a test for this.
- **The highlight covers the whole group**, deliberately — that's what makes it a nudge rather than a reveal.

A reveal never places a conflicting mushroom (it picks a solution cell that doesn't conflict, and returns nothing if none is safe — which the mistake branch catches first anyway), and is one undoable action.

`hintsUsed` is counted per puzzle and persisted, ready for Step 8 to price. **The "nothing is forced" case isn't counted** — it gave nothing away.

## Positive confirmation

A placement now pops. Deliberately for **every** mushroom placed, right or wrong — animating only the correct ones would leak the solution to anyone who'd left correctness feedback switched off. That's the trap in "make correct placements feel correct", and it's why the pop is placement-triggered rather than correctness-triggered.

## A bug the browser pass caught

Same class as the drag/ScrollView race, and worth recording: **a banner mounting above the board moves it, and the first tap afterwards landed on the wrong cell.**

`onLayout` doesn't save you — on web it's backed by a `ResizeObserver`, which watches a view's *size* and not its *position*, so a board that merely moves never fires it. And the `measure()` at touch-down resolves asynchronously, too late for that same touch. The board now re-measures in an effect keyed on `[hint, solved]`, the two things that mount a banner. **Anything new added above the board has to go in those deps** — noted in the handoff.

## Verification

```
npm test                       → 220/220 (26 new)
npx expo-doctor                → 18/18
npx expo export --platform all → web + iOS + Android all bundle
```

Browser pass, **no page errors**:

| Check | Result |
|---|---|
| Show mistakes default | `off` |
| Legal-but-wrong mushroom, switch off | `…, mushroom` — no conflict, no flag |
| Same cell, switch on | `…, mushroom, mistake` |
| Ask for a hint | reports the mistake first; button reads `Hint, 1 used` |
| Four correct mushrooms, ask again | *"Row 5 has only one cell left that can hold a mushroom"* |
| Cells highlighted by that nudge | **5** — the whole row, forced cell not singled out |
| Change the board | hint goes stale |
| Hint count + switch after reload | both survive |

**The strongest new test** walks generated puzzles at sizes 5–7 across four seeds, taking forced moves as they appear, and asserts every one matches the solution — a forced move must be the *right* move, or the hint confidently misleads.

## Two things for your judgement

- **A reveal is only reachable when nothing is forced.** While any forced deduction exists you get a nudge, never a reveal. That's the pedagogically right default for a family game, but it means a frustrated player can't skip to the answer. This is §8 #6 ("how strong should hints go?") — making reveal always available is a small change if you want it.
- **Correctness feedback defaults off** (§8 #7). It turns a deduction puzzle into trial-and-error left on — but "off" for a seven-year-old may just mean stuck. One-line change either way.

## Out of scope

- **Step 8 — ladder & scoring.** The handoff is rewritten for it, and it now has real events to price: `hintsUsed` is recorded and `selectMistakes` knows when a placement is wrong. It'll need a storage-version bump and a **migration**, since it's the first change that must not wipe someone's progress.
- **Step 9 — art swap**, gated on artwork rather than code.
- **No Sudoku changes.** Its *Show Mistakes* is a wording reference only.

## Remaining after this

**Two steps: 8 (ladder & scoring) and 9 (art swap)** — and 9 waits on artwork. Step 8 needs §8 #4: where should the ladder top out, and is board size a free choice or unlocked by progression? I'll default to a ladder plus a free-play escape hatch if you'd rather not decide up front.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3yWT2tp5eK1iFkcSVzUVq)_