### PR TITLE
Fungiku: cap the ladder at 10×10 (plan §12, handoff for Step 8)

### DIFF
--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -92,94 +92,126 @@ operator to test in Expo Go.**
 
 ---
 
-## Next step: **Step 8 — the training ladder and scoring**
+## Next step: **Step 8 — bigger boards, up to 12×12**
 
-Branch: **`feature/fungiku-ladder`** off `epic/fungiku`.
-Plan: the §7 table row for step 8, plus **§8 #4**, which this step needs answered
-(or defaulted, with the default stated in the PR).
+Branch: **`feature/fungiku-big-boards`** off `epic/fungiku`.
+Plan: **§12** end to end (it is all new, written 2026-07-25), plus the §7 note
+"Why bigger boards come before the ladder".
 
 ### Why this step exists
 
-Fungiku is a complete puzzle with feedback and hints, but it has **no shape as a
-game**. You pick a size from four chips and press "New puzzle" for a random seed;
-nothing tracks what you have done, nothing gets harder, nothing tells you that
-you are improving. This step turns a puzzle generator into something worth coming
-back to.
+The operator asked for the ladder to reach **12×12**. That answers half of §8 #4,
+and it is not a table entry — it is an engineering problem. Two things built for
+boards of 5–8 do not survive the jump, and one of them is measured to be
+catastrophic:
 
-Feedback and hints landed first on purpose: **scoring now has real events to
-price.** `hintsUsed` is already recorded per puzzle, and `selectMistakes` already
-knows when a placement is wrong.
+- **Generation is synchronous and superlinear.** Twelve seeds per size on this
+  machine: 8×8 median **6 ms**, 10×10 **284 ms**, 11×11 **2.5 s**, 12×12
+  **7.3 s median and 41.8 s worst case**. Nothing *failed* at any size — the
+  boards are correct — but tapping "New puzzle" on a 12×12 freezes the app for
+  seven seconds typically. That reads as a crash. Full table in §12.1.
+- **The palette has nine colours and wraps.** `getRegionColor` does
+  `regionId % palette.length`, so at 10, 11 and 12 regions **two different
+  regions render identically**. Region colour is the only way the player sees
+  region boundaries, so that is a correctness bug at those sizes, not a cosmetic
+  one. §12.2 has the measurement showing 12 well-chosen fills would actually be
+  *better* separated (ΔE 21.80) than the 9 that ship today (17.11).
+
+The ladder (now Step 9) has to know its own ceiling, and one candidate fix here —
+baking level layouts as data — is itself a ladder design decision. Doing sizes
+first avoids building a 5–8 ladder and then reworking it.
 
 ### Read first
 
-- `SudokuApp/games/fungiku/reducer.js` — `hintsUsed` is already counted per
-  puzzle and persisted; that is the hook scoring hangs off. Note how `changeSize`
-  and `nextPuzzle` currently work (`changeSize` resets to seed 1, `nextPuzzle`
-  bumps the seed) — a ladder replaces that with a level list.
-- `SudokuApp/games/fungiku/storage.js` — persistence is `size` + `seed` + `marks`
-  + `showMistakes` + `hintsUsed`. Ladder progress is the first thing needing a
-  **schema change**: bump `FUNGIKU_STORAGE_VERSION` and decide what an old save
-  migrates to. Today a version mismatch returns null and the board starts fresh —
-  fine for a board, **not** fine for someone's progress.
-- `SudokuApp/utils/gameProgress.js` + `games/registry.js` —
-  `describeFungikuProgress` feeds the hub's Continue badge. With a ladder the
-  badge probably wants to name the *level* rather than the board size.
-- **The sibling color-loop app is the reference for exactly this problem** — it
-  has a training ladder in `games/colorloop/levels.ts` with per-level star
-  thresholds, and its `docs/game-design.md` covers the progression thinking. Read
-  it before designing a second one from scratch.
-- `SudokuApp/contexts/GameContext.js` — Sudoku's scoring (time-based, with
-  completion bonuses) is one model. Fungiku has **no timer at all** today, which
-  is a decision this step has to make deliberately rather than by accident.
+- **§12 of the plan.** It has the generation timings, the palette measurement, the
+  27-pixel legibility list, and four candidate approaches to the cost ranked
+  cheapest-first. Do not re-derive any of it.
+- `SudokuApp/games/fungiku/engine.js` — `generate()` grows regions randomly and
+  then perturbs toward uniqueness (`findSolutions` → `breakSolution`, up to
+  `PERTURB_BUDGET` rounds). **The cost is in that loop, and §12.1 candidate #1 is
+  to profile it before optimizing**: whether it is the number of rounds or the
+  cost of each search changes the fix completely. `MIN_SIZE = 5` exists; there is
+  no upper bound, so size 20 is accepted and never returns.
+- `SudokuApp/utils/symbolSets.js` — `HUE_ORDER` + `LIGHT_TINTS`/`DARK_TINTS`
+  build both theme palettes; `getRegionColor` wraps. The `corners` shape cue in
+  this module is **defined but unused by the Fungiku board** — twelve regions is
+  where colour alone starts carrying too much, so this is the moment to add a
+  second channel.
+- `SudokuApp/utils/__tests__/symbolSets.test.js` — holds the ΔE 15 worst-pair
+  floor that the current palette clears at 17.11. Extending to 12 must keep it
+  green; §12.2 says that is achievable.
+- `SudokuApp/hooks/useBoardSize.js` — returns a fixed **324** on native, so a
+  12×12 cell is **27 px** (web's 450 gives 37 px). §12.3 lists what breaks at
+  that size — notably the mistake badge at `cell * 0.28` ≈ 7 px.
+- `SudokuApp/games/fungiku/FungikuScreen.js` — where the size chips live. Four
+  chips become up to eight; that is a layout question, not just a data one.
 
 ### Scope — ONLY this
 
-1. **A level ladder as data** — an ordered list, each level pinning a `size` and a
-   `seed`. Both are already deterministic, so a level *is* a `{size, seed}` pair.
-   Keep it a table in its own module so tuning is editing data.
-2. **Progression + persistence** — which levels are complete, and what unlocks.
-   Bump the storage version and **migrate**, don't discard.
-3. **A level-select surface** replacing the raw size chips as the primary path.
-   Keep a free-play route: the chips are how the 8×8 regression cases get
-   checked, and free choice is a reasonable answer to §8 #4.
-4. **Scoring** — decide what it measures and say why in the PR. Hints used and
-   mistakes made are both available now. If it needs a timer, add one, and note
-   that Fungiku deliberately had none until this point.
-5. **Hub integration** — the Continue badge should reflect ladder position.
-6. **Tests** — the ladder table and progression logic are pure; cover them. And
-   **assert that every level in the table actually generates**: a bad
-   `{size, seed}` pair would otherwise only fail when a player reaches it.
+1. **Make 12×12 generate promptly, or cap honestly.** Profile the perturbation
+   loop first (§12.1 #1), then pick from #2–#4. Whatever the outcome, the app must
+   never block the main thread for seconds: a loading state around generation
+   (§12.1 #3) is a safety net worth having regardless of how fast it gets.
+   **If 12×12 cannot be made interactive, cap the ladder where it can be and say
+   so in the PR** — an honest 10×10 ceiling beats a 12×12 that freezes.
+2. **Add `MAX_SIZE = 12`** and reject above it, the same way sizes below 5 are
+   rejected today. Right now there is no upper bound at all.
+3. **Extend the palette to 12 distinguishable fills per theme**, derived the same
+   way §5's was — maximize the worst pairwise CIEDE2000 distance under the
+   lightness band. **Do not eyeball it, and do not stop at ΔE:** check the three
+   new hues under colourblind simulation (§12.2), because Okabe–Ito was chosen for
+   CVD safety and a hue picked purely to maximize ΔE for normal vision can collide
+   under deutan or protan.
+4. **Make `getRegionColor` stop wrapping silently.** Repeating a colour across two
+   regions must be impossible-by-construction or loud, not quiet.
+5. **A legibility pass at 27 px** (§12.3): mistake badge, conflict ring, region
+   borders, glyph size. Sizes tuned for 5×5 do not scale down by themselves.
+6. **Sizes reachable from the UI**, so the operator can actually play a 12×12 in
+   Expo Go.
+7. **Tests** — the palette floor extended to 12 entries, `MAX_SIZE` rejection, and
+   a generation test at the top size that would catch a regression to
+   multi-second cost. Keep it a bound with headroom, not a tight timing assert:
+   CI machines vary.
 
 ### Behaviors that are easy to get wrong
 
-- **Every level must be generatable.** `generate()` throws below size 5; a typo
-  in the table becomes a crash for whoever reaches that level. Assert the whole
-  table.
-- **Don't lose existing progress on the schema change.** A player mid-board today
-  has `{size, seed, marks, showMistakes, hintsUsed}` and no ladder state; that has
-  to migrate to something sensible, not a wiped save.
-- **Star thresholds and difficulty curves are guesses until played.** Draft them,
-  say in the PR that they are estimates, and flag them for tuning on device — the
-  same way color-loop's ladder was left.
-- **Keep free play reachable**, or the 8×8 palette and layout cases get harder to
-  check.
-- **Don't let scoring change what a hint does.** Hints are counted already; this
-  step prices them, it does not redesign them.
+- **Don't ship a size the app cannot generate promptly.** This is the one
+  requirement that outranks "support 12×12".
+- **A timing test on CI is a flake factory.** Assert a generous ceiling (or count
+  perturbation rounds instead of milliseconds) rather than a tight duration.
+- **Re-tune the palette with the same objective, never by hand.** The test floor
+  exists precisely so a well-meaning hand-picked swatch can't quietly regress
+  separation.
+- **ΔE is not colourblind safety.** They are different properties; twelve hues is
+  where that gap starts to matter.
+- **The board's measured origin.** If this step adds anything above the board (a
+  generation spinner, for instance), it must go into the deps of `FungikuBoard`'s
+  re-measure effect — currently `[hint, solved, measure]` — or the first tap after
+  it appears lands on the wrong cell. `onLayout` does not save you; see the note
+  below.
+- **Bigger boards mean smaller cells mean fatter fingers.** The existing tap
+  threshold (6 px before a tap becomes a stroke) was tuned against ~40 px cells.
+  At 27 px it may need revisiting — and that is a device question, not a browser
+  one.
 
 ### Out of scope for this step
 
-- **No art swap** — Step 9, gated on artwork rather than code.
-- **No new feedback or hint behavior.** Step 7 shipped both; if the operator wants
-  the hint ladder to escalate differently (see the note below), that is its own
-  change, not this step.
-- **No engine changes.** Levels are `{size, seed}` pairs over the existing
-  generator.
+- **No ladder, no scoring** — Step 9. This step decides the ceiling the ladder
+  will use; it does not build progression. Research already gathered for that step
+  is parked in plan **§13** so it isn't lost.
+- **No art swap** — Step 10, gated on artwork rather than code.
+- **No hint-strength work.** §12.4 found the forced-move nudge is shallow (it
+  averages 1–2 deductions from an empty board at any size), which will be more
+  obvious on a 12×12. Real, and worth doing — but strengthening the propagator
+  with pigeonhole reasoning is its own change. Note it in the PR; don't smuggle it
+  in.
 
 ### Visible in Expo Go when this lands
 
-A **level list** you progress through, with completed levels marked, and a score
-or rating when you solve one. The hub's Fungiku card says where you are in the
-ladder.
+**A playable 12×12** — twelve visibly different region colours, legible marks at
+27-pixel cells, and a "New puzzle" tap that either returns quickly or shows an
+honest loading state instead of freezing. If the ceiling ends up below 12, the
+largest size that *is* playable, with the reason in the PR.
 
 ## Open questions for the operator (carry these forward)
 
@@ -194,10 +226,19 @@ ladder.
 3. ~~**Hub vs. resume on launch**~~ — built hub-first in Step 3: the app opens on
    the hub and the Sudoku card carries a *Continue* badge. Revisit only if the
    operator dislikes it on device.
-4. **Ladder shape** — v1 targets 5×5 → 8×8. Where should it top out, and is size
-   a free choice or unlocked by progression? *(Step 6 concern.)*
-5. **Assist defaults** — should auto-X be on by default for younger players?
-   *(Step 6 concern.)*
+4. **Ladder shape** — **top end decided: 12×12** (operator, 2026-07-25; plan
+   §12). Still open: **is size a free choice or unlocked by progression?**
+5. ~~**Assist defaults**~~ — moot: the rule-out assist became a button you tap
+   rather than a mode with a setting, so there is no default to choose. (§2)
+6. **How strong should hints go?** (§11) The ladder ends at *reveal a correct
+   mushroom*, which solves a cell outright. Right for a family game, or does it
+   want capping at a nudge? Related: a reveal is currently only reachable when
+   nothing is forced, so a frustrated player cannot skip to the answer — see the
+   first note below.
+7. **Should "Show mistakes" default on for younger players?** (§11) It turns a
+   deduction puzzle into trial-and-error for anyone who leaves it on, which argues
+   for off — but "off" for a seven-year-old may just mean stuck. Ships **off**
+   today.
 
 ### Noted in passing, for a later step
 
@@ -281,4 +322,4 @@ ladder.
 | 4 | Fungiku state — reducer, tap-to-cycle marks, live conflicts, win, undo/redo, own-key persistence | merged to `epic/fungiku` (#70, `a9caf92`) |
 | 5 | Board UI — palette fix with a tested ΔE floor, themed + responsive board, animated win | merged to `epic/fungiku` (#71, `905bfa2`) |
 | 6 | Input ergonomics — drag to sweep X's, rule-out button | merged to `epic/fungiku` (#72, `e896fb6`) |
-| 7 | Feedback & hints — mistake flagging, forced-deduction nudge, reveal, placement pop | PR to `epic/fungiku` |
+| 7 | Feedback & hints — mistake flagging, forced-deduction nudge, reveal, placement pop | merged to `epic/fungiku` (#73, `12f72c3`) |

--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -92,126 +92,130 @@ operator to test in Expo Go.**
 
 ---
 
-## Next step: **Step 8 — bigger boards, up to 12×12**
+## Next step: **Step 8 — bigger boards, up to 10×10**
 
 Branch: **`feature/fungiku-big-boards`** off `epic/fungiku`.
-Plan: **§12** end to end (it is all new, written 2026-07-25), plus the §7 note
-"Why bigger boards come before the ladder".
+Plan: **§12** end to end (all new, 2026-07-25), plus the §7 note "Why bigger
+boards come before the ladder".
 
 ### Why this step exists
 
-The operator asked for the ladder to reach **12×12**. That answers half of §8 #4,
-and it is not a table entry — it is an engineering problem. Two things built for
-boards of 5–8 do not survive the jump, and one of them is measured to be
-catastrophic:
+The ladder needs a ceiling, and it is now decided: **10×10**. The operator asked
+for 12×12 first; measuring the generator showed a 12×12 takes **7.3 seconds
+median and 41.8 seconds worst case**, synchronously on the main thread, so the
+target moved down to the last affordable size. Cost per size goes off a cliff:
 
-- **Generation is synchronous and superlinear.** Twelve seeds per size on this
-  machine: 8×8 median **6 ms**, 10×10 **284 ms**, 11×11 **2.5 s**, 12×12
-  **7.3 s median and 41.8 s worst case**. Nothing *failed* at any size — the
-  boards are correct — but tapping "New puzzle" on a 12×12 freezes the app for
-  seven seconds typically. That reads as a crash. Full table in §12.1.
-- **The palette has nine colours and wraps.** `getRegionColor` does
-  `regionId % palette.length`, so at 10, 11 and 12 regions **two different
-  regions render identically**. Region colour is the only way the player sees
-  region boundaries, so that is a correctness bug at those sizes, not a cosmetic
-  one. §12.2 has the measurement showing 12 well-chosen fills would actually be
-  *better* separated (ΔE 21.80) than the 9 that ship today (17.11).
+| Size | median | worst |
+|------|--------|-------|
+| 8×8 | 6 ms | 25 ms |
+| 10×10 | **284 ms** | **584 ms** |
+| 11×11 | 2,536 ms | 5,096 ms |
+| 12×12 | 7,286 ms | 41,830 ms |
 
-The ladder (now Step 9) has to know its own ceiling, and one candidate fix here —
-baking level layouts as data — is itself a ladder design decision. Doing sizes
-first avoids building a 5–8 ladder and then reworking it.
+**Read that as good news for this step.** The hard engineering problem — making
+the uniqueness loop cheap enough for 12×12 — is off the table. What remains is
+small and concrete:
+
+- **The palette wraps at 9.** `getRegionColor` does `regionId % palette.length`
+  over nine entries, so **at 10 regions, region 9 renders identically to region
+  0**. Region colour is the only way the player sees region boundaries, so that is
+  a correctness bug at the new top size. §12.2 measured that 10 well-chosen fills
+  reach worst-pair ΔE 23.78 — *better* separated than the 9 shipping today at
+  17.11 — so this is a one-colour problem with headroom.
+- **There is no upper bound at all.** `MIN_SIZE = 5` exists; `generate()` accepts
+  size 20 and never returns.
+- **Cells get to 32 px** at 10×10 inside the fixed 324pt native board, and several
+  constants were tuned against 5×5.
 
 ### Read first
 
-- **§12 of the plan.** It has the generation timings, the palette measurement, the
-  27-pixel legibility list, and four candidate approaches to the cost ranked
-  cheapest-first. Do not re-derive any of it.
-- `SudokuApp/games/fungiku/engine.js` — `generate()` grows regions randomly and
-  then perturbs toward uniqueness (`findSolutions` → `breakSolution`, up to
-  `PERTURB_BUDGET` rounds). **The cost is in that loop, and §12.1 candidate #1 is
-  to profile it before optimizing**: whether it is the number of rounds or the
-  cost of each search changes the fix completely. `MIN_SIZE = 5` exists; there is
-  no upper bound, so size 20 is accepted and never returns.
-- `SudokuApp/utils/symbolSets.js` — `HUE_ORDER` + `LIGHT_TINTS`/`DARK_TINTS`
-  build both theme palettes; `getRegionColor` wraps. The `corners` shape cue in
-  this module is **defined but unused by the Fungiku board** — twelve regions is
-  where colour alone starts carrying too much, so this is the moment to add a
-  second channel.
+- **§12 of the plan.** Generation timings, the palette measurement, the
+  32-pixel legibility list, and (in §12.1) the four ranked approaches to
+  generation cost — kept for the day the ceiling might rise, **not work for this
+  step**. Do not re-derive any of it.
+- `SudokuApp/games/fungiku/engine.js` — `MIN_SIZE` and the perturbation loop
+  (`generate` → `findSolutions` → `breakSolution`, up to `PERTURB_BUDGET` rounds).
+  You are adding a bound here, not rewriting the loop.
+- `SudokuApp/utils/symbolSets.js` — `HUE_ORDER` + `LIGHT_TINTS`/`DARK_TINTS` build
+  both theme palettes; `getRegionColor` wraps. The `corners` shape cue in this
+  module is **defined but unused by the Fungiku board** — worth knowing the second
+  channel exists if the tenth colour proves hard to place.
 - `SudokuApp/utils/__tests__/symbolSets.test.js` — holds the ΔE 15 worst-pair
-  floor that the current palette clears at 17.11. Extending to 12 must keep it
-  green; §12.2 says that is achievable.
-- `SudokuApp/hooks/useBoardSize.js` — returns a fixed **324** on native, so a
-  12×12 cell is **27 px** (web's 450 gives 37 px). §12.3 lists what breaks at
-  that size — notably the mistake badge at `cell * 0.28` ≈ 7 px.
+  floor that today's palette clears at 17.11. Extending to 10 must keep it green;
+  §12.2 says that is comfortable.
+- `SudokuApp/hooks/useBoardSize.js` — fixed **324** on native, so a 10×10 cell is
+  **32 px** (web's 450 gives 45 px, which is why the browser will not show you the
+  problem).
 - `SudokuApp/games/fungiku/FungikuScreen.js` — where the size chips live. Four
-  chips become up to eight; that is a layout question, not just a data one.
+  chips become six; that is a layout question, not just a data one.
 
 ### Scope — ONLY this
 
-1. **Make 12×12 generate promptly, or cap honestly.** Profile the perturbation
-   loop first (§12.1 #1), then pick from #2–#4. Whatever the outcome, the app must
-   never block the main thread for seconds: a loading state around generation
-   (§12.1 #3) is a safety net worth having regardless of how fast it gets.
-   **If 12×12 cannot be made interactive, cap the ladder where it can be and say
-   so in the PR** — an honest 10×10 ceiling beats a 12×12 that freezes.
-2. **Add `MAX_SIZE = 12`** and reject above it, the same way sizes below 5 are
-   rejected today. Right now there is no upper bound at all.
-3. **Extend the palette to 12 distinguishable fills per theme**, derived the same
-   way §5's was — maximize the worst pairwise CIEDE2000 distance under the
-   lightness band. **Do not eyeball it, and do not stop at ΔE:** check the three
-   new hues under colourblind simulation (§12.2), because Okabe–Ito was chosen for
-   CVD safety and a hue picked purely to maximize ΔE for normal vision can collide
-   under deutan or protan.
-4. **Make `getRegionColor` stop wrapping silently.** Repeating a colour across two
-   regions must be impossible-by-construction or loud, not quiet.
-5. **A legibility pass at 27 px** (§12.3): mistake badge, conflict ring, region
-   borders, glyph size. Sizes tuned for 5×5 do not scale down by themselves.
-6. **Sizes reachable from the UI**, so the operator can actually play a 12×12 in
-   Expo Go.
-7. **Tests** — the palette floor extended to 12 entries, `MAX_SIZE` rejection, and
-   a generation test at the top size that would catch a regression to
-   multi-second cost. Keep it a bound with headroom, not a tight timing assert:
-   CI machines vary.
+1. **Add `MAX_SIZE = 10`** to the engine and reject above it, the same way sizes
+   below 5 are rejected today.
+2. **Add a 10th region colour per theme**, derived the same way §5's palette was —
+   maximize the worst pairwise CIEDE2000 distance under the lightness band. **Do
+   not eyeball it, and do not stop at ΔE:** check the new hue under colourblind
+   simulation (§12.2). Okabe–Ito was chosen for CVD survival, and one hue picked
+   purely to maximize ΔE for normal vision can still collide under deutan or
+   protan.
+3. **Make `getRegionColor` stop wrapping silently.** Two regions sharing a colour
+   must be impossible-by-construction or loud, not quiet — that is the bug class
+   this step is closing, and leaving the modulo in place just moves the boundary
+   to 11.
+4. **Sizes 9 and 10 reachable from the UI**, so the operator can actually play a
+   10×10 in Expo Go. Six chips need a layout that survives a narrow phone.
+5. **Confirm the generation hitch is acceptable at the top size** — 284 ms median,
+   584 ms worst, on the main thread. Either show a brief loading state or verify on
+   device that it is imperceptible. **Don't assume; a visible freeze on "New
+   puzzle" reads as a bug.**
+6. **A legibility pass at 32 px** (§12.3): mistake badge (`cell * 0.28` ≈ 9 px),
+   conflict ring, region borders, glyph size.
+7. **Tests** — the palette floor extended to 10 entries, `MAX_SIZE` rejection, and
+   a **generation-cost bound at the top size**. 10×10 sits one size below a
+   ten-times cliff, so a change that makes generation modestly slower would turn
+   the top size from *hitch* into *freeze* with no other symptom.
 
 ### Behaviors that are easy to get wrong
 
-- **Don't ship a size the app cannot generate promptly.** This is the one
-  requirement that outranks "support 12×12".
-- **A timing test on CI is a flake factory.** Assert a generous ceiling (or count
-  perturbation rounds instead of milliseconds) rather than a tight duration.
+- **A timing test on CI is a flake factory.** Assert a generous ceiling, or count
+  perturbation rounds instead of milliseconds — rounds are machine-independent,
+  which is what you actually want from a regression bound.
 - **Re-tune the palette with the same objective, never by hand.** The test floor
   exists precisely so a well-meaning hand-picked swatch can't quietly regress
   separation.
-- **ΔE is not colourblind safety.** They are different properties; twelve hues is
-  where that gap starts to matter.
-- **The board's measured origin.** If this step adds anything above the board (a
-  generation spinner, for instance), it must go into the deps of `FungikuBoard`'s
-  re-measure effect — currently `[hint, solved, measure]` — or the first tap after
-  it appears lands on the wrong cell. `onLayout` does not save you; see the note
+- **ΔE is not colourblind safety.** Different properties; one new hue is a small
+  risk, not no risk.
+- **The board's measured origin.** If this step adds anything above the board — a
+  generation spinner, for instance — it must go into the deps of `FungikuBoard`'s
+  re-measure effect, currently `[hint, solved, measure]`, or the first tap after it
+  appears lands on the wrong cell. `onLayout` will not save you; see the note
   below.
-- **Bigger boards mean smaller cells mean fatter fingers.** The existing tap
-  threshold (6 px before a tap becomes a stroke) was tuned against ~40 px cells.
-  At 27 px it may need revisiting — and that is a device question, not a browser
-  one.
+- **Smaller cells, same fingers.** The 6-pixel tap-vs-drag threshold was tuned
+  against roughly 40 px cells. At 32 px there is less room to press without
+  registering a stroke, and **that is a device question the browser cannot answer**
+  — web renders at 45 px, larger than native, so the browser is the wrong place to
+  judge any of §12.3.
 
 ### Out of scope for this step
 
-- **No ladder, no scoring** — Step 9. This step decides the ceiling the ladder
-  will use; it does not build progression. Research already gathered for that step
-  is parked in plan **§13** so it isn't lost.
+- **No generator re-engineering.** §12.1's four approaches exist for the day the
+  ceiling might rise past 10. At 10 the generator is fast enough; leave it alone
+  and spend the step on the palette, the bound, and legibility.
+- **No ladder, no scoring** — Step 9. This step fixes the ceiling the ladder will
+  use; it does not build progression. Research already gathered for that step is
+  parked in plan **§13** so it isn't lost.
 - **No art swap** — Step 10, gated on artwork rather than code.
-- **No hint-strength work.** §12.4 found the forced-move nudge is shallow (it
-  averages 1–2 deductions from an empty board at any size), which will be more
-  obvious on a 12×12. Real, and worth doing — but strengthening the propagator
-  with pigeonhole reasoning is its own change. Note it in the PR; don't smuggle it
-  in.
+- **No hint-strength work.** §12.4 found the forced-move nudge is shallow (2 of 10
+  deductions from an empty 10×10 board). Real, and worth doing — but strengthening
+  the propagator with pigeonhole reasoning is its own change. Note it in the PR;
+  don't smuggle it in.
 
 ### Visible in Expo Go when this lands
 
-**A playable 12×12** — twelve visibly different region colours, legible marks at
-27-pixel cells, and a "New puzzle" tap that either returns quickly or shows an
-honest loading state instead of freezing. If the ceiling ends up below 12, the
-largest size that *is* playable, with the reason in the PR.
+**A playable 10×10** — ten visibly different region colours with no repeat,
+legible marks at 32-pixel cells, and a "New puzzle" tap at the top size that
+doesn't read as a freeze.
 
 ## Open questions for the operator (carry these forward)
 
@@ -226,8 +230,9 @@ largest size that *is* playable, with the reason in the PR.
 3. ~~**Hub vs. resume on launch**~~ — built hub-first in Step 3: the app opens on
    the hub and the Sudoku card carries a *Continue* badge. Revisit only if the
    operator dislikes it on device.
-4. **Ladder shape** — **top end decided: 12×12** (operator, 2026-07-25; plan
-   §12). Still open: **is size a free choice or unlocked by progression?**
+4. **Ladder shape** — **top end decided: 10×10** (operator, 2026-07-25; plan
+   §12). 12×12 was asked for first and withdrawn once measured at 7.3 s to
+   generate. Still open: **is size a free choice or unlocked by progression?**
 5. ~~**Assist defaults**~~ — moot: the rule-out assist became a button you tap
    rather than a mode with a setting, so there is no default to choose. (§2)
 6. **How strong should hints go?** (§11) The ladder ends at *reveal a correct

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -368,8 +368,15 @@ the step's real acceptance test, alongside its automated checks.
 | 5 | ~~**Board UI**~~ ✅ — the real board component: region-boundary borders, themed styling, win flow, **palette tuning** | The **finished board**, styled to the app's themes, replacing the preview's rough grid |
 | 6 | ~~**Input ergonomics & assists**~~ ✅ (§2) — **drag to sweep X's**, rule-out button | **Swipe a finger across cells to rule them out**; a *Rule out* button |
 | 7 | ~~**Feedback & hints**~~ ✅ (§11) — correctness feedback on placements, and a hint ladder | **Optional "show mistakes" for mushrooms**, and a hint you can ask for when stuck |
-| 8 | **Ladder & scoring** — training ladder, size progression, scoring | Level progression and a score |
-| 9 | **Art swap** (floating, asset-only — gated on artwork, not on code) | Static mushroom art replaces the icon glyph |
+| 8 | **Bigger boards, up to 12×12** (§12) — generation cost, a 12-colour palette, legibility at 27px cells | **A playable 12×12** that generates without freezing |
+| 9 | **Ladder & scoring** — training ladder, size progression, scoring | Level progression and a score |
+| 10 | **Art swap** (floating, asset-only — gated on artwork, not on code) | Static mushroom art replaces the icon glyph |
+
+**Why bigger boards come before the ladder:** the ladder has to know its own top
+end, and §12.1 says whether 12×12 is even affordable is an open engineering
+question. Building the ladder first would bake in a 5–8 range and then need
+reworking — and one of the candidate fixes for generation cost (baking level
+layouts as data) is itself a ladder design decision.
 
 **Why feedback and hints come before scoring:** scoring has to know what a
 mistake and a hint are *worth*, so the ladder step needs both to already exist.
@@ -406,8 +413,10 @@ Step 5 replaced that rough grid with the themed, responsive board.
 3. ~~**Hub vs. resume on launch**~~ — **decided in Step 3: hub-first.** The app
    opens on the hub and a game with saved progress carries a *Continue* badge, so
    both games stay discoverable. Revisit only if it grates on device.
-4. **Ladder shape** — v1 ships **5×5 → 8×8**. Where should it top out, and
-   should size be a free choice or unlocked by progression?
+4. **Ladder shape** — **top end decided 2026-07-25: 12×12** (§12), which makes it
+   a real engineering problem rather than a table entry — a 12×12 currently takes
+   seven seconds to generate. Still open: **is size a free choice or unlocked by
+   progression?**
 5. ~~**Assist defaults**~~ — **moot as of 2026-07-25.** The rule-out assist became
    a button you tap rather than a mode with a setting, so there is no default to
    choose. (§2)
@@ -511,3 +520,157 @@ Requirements on any hint:
 
 Carried into §8 as #6 and #7: how strong hints should go for a family game, and
 whether correctness feedback should default on for younger players.
+
+## 12. Board sizes up to 12×12 (operator request, 2026-07-25)
+
+The ladder should reach **12×12**. That answers §8 #4's "where should it top out",
+and it is a bigger change than it looks: the engine and the palette were both
+built around boards of 5–8, and one of them does not survive the jump.
+
+**`MIN_SIZE = 5` exists; there is no upper bound.** `generate()` will happily
+accept size 20 and never return. Add a `MAX_SIZE = 12` and reject above it, the
+same way 4×4 is rejected below.
+
+### 12.1 Generation time is the blocker — measured, not guessed
+
+Twelve seeds per size, on this machine:
+
+| Size | ok | median | p90 | max |
+|------|----|--------|-----|-----|
+| 8×8 | 12/12 | **6 ms** | 21 ms | 25 ms |
+| 9×9 | 12/12 | 30 ms | 82 ms | 103 ms |
+| 10×10 | 12/12 | 284 ms | 519 ms | 584 ms |
+| 11×11 | 12/12 | 2,536 ms | 4,124 ms | 5,096 ms |
+| 12×12 | 12/12 | **7,286 ms** | 30,618 ms | **41,830 ms** |
+
+**Correctness is fine — nothing failed at any size.** The problem is purely cost,
+and it is catastrophic: generation is synchronous JS on the main thread, so a
+12×12 freezes the app for seven seconds typically and **forty seconds** at worst.
+Tapping "New puzzle" on a big board today would look like a crash.
+
+The cost is in the uniqueness loop (`generate` → `findSolutions` → `breakSolution`,
+up to `PERTURB_BUDGET` times). Each `findSolutions` call is a backtracking search,
+and it is re-run after every perturbation. Four directions worth trying, cheapest
+first:
+
+1. **Profile before optimizing.** Is it the number of perturbation rounds, or the
+   cost of each `findSolutions`? The fix differs completely. Instrument the loop
+   and count.
+2. **Bake the ladder's puzzles as data.** A level is a deterministic
+   `{size, seed}` pair, so its `regions` array can be generated once at build
+   time and shipped as JSON. That removes runtime cost for every ladder level —
+   but not for free-play reseeding, so it is a partial answer.
+3. **Generate off the main thread, with a loading state.** Honest and simple, and
+   it will still feel bad at 40 seconds. Needed as a safety net regardless.
+4. **Construct for uniqueness instead of perturbing toward it.** The current
+   approach grows regions randomly and then hammers them until only one solution
+   survives. Biasing region growth to produce tight constraints, or building
+   region-by-region while tracking solution count, would attack the exponent
+   rather than the constant. The most work and the most upside.
+
+**Do not ship a size the app cannot generate promptly.** If 12×12 cannot be made
+interactive, cap the ladder where it can and say so — an honest 10×10 ceiling
+beats a 12×12 that freezes.
+
+### 12.2 The palette needs 12 colours and only has 9
+
+`REGION_COLORS` holds nine entries — the eight Okabe–Ito swatches plus the
+mushroom red — and `getRegionColor` wraps with `regionId % palette.length`. **At
+10, 11 and 12 regions, colours silently repeat**, so two different regions render
+identically. Region colour is how the player sees region boundaries at all, so
+this is a correctness bug at those sizes, not a cosmetic one.
+
+The good news, measured the same way §5's palette work was: **12 distinguishable
+pastel fills are comfortably achievable.** Sampling sRGB inside the light theme's
+L* 65–97 band and picking the farthest-apart set:
+
+| Fills | Best achievable worst-pair ΔE |
+|-------|-------------------------------|
+| 9 | 24.50 |
+| 10 | 23.78 |
+| 11 | 21.90 |
+| **12** | **21.80** |
+
+For comparison the **shipped 9-colour palette manages ΔE 17.11**, so twelve
+well-chosen fills would be *better separated* than what ships today. The ΔE 15
+floor in `utils/__tests__/symbolSets.test.js` is safe.
+
+Two constraints that the ΔE number does **not** capture, and which the work must
+respect:
+
+- **Colourblind safety is a separate property.** Okabe–Ito was chosen precisely
+  because its hues survive the common CVD types. Three new hues chosen only to
+  maximize ΔE for normal vision may collide under deutan or protan. **Check the
+  extended palette under CVD simulation, not just ΔE.**
+- **The `corners` shape cue in `symbolSets.js` is still unused by the Fungiku
+  board.** Twelve regions is where colour alone starts carrying too much, so this
+  is the point to add a second channel rather than lean harder on hue.
+
+### 12.3 Legibility at 27-pixel cells
+
+`useBoardSize()` returns a fixed 324 on native, so a 12×12 cell is **27 px** (450
+on web gives 37 px). At that size:
+
+- the mushroom glyph is 16 px — probably fine, needs looking at;
+- the **mistake badge is `cell * 0.28` ≈ 7 px, which is too small to read**;
+- the conflict ring at `cell - 6` leaves a 21 px ring — tight;
+- region-boundary borders at 2 px against 27 px cells will dominate visually.
+
+None of this is hard, but a 12×12 needs a deliberate pass rather than inheriting
+constants tuned for 5×5.
+
+### 12.4 A finding about hints on big boards
+
+Measured while timing generation: the length of a pure forced-move chain from an
+empty board, using the Step 7 propagator.
+
+| Size | Average forced moves found |
+|------|----------------------------|
+| 8×8 | 1.2 of 8 |
+| 10×10 | 2.0 of 10 |
+| 12×12 | 1.1 of 12 |
+
+**The nudge is shallow, and bigger boards make that more obvious.** It finds an
+opening move and then runs dry, because `findForcedDeduction` only knows one rule:
+a row, column or region with exactly one candidate. Human solvers also use
+pigeonhole arguments — "every candidate for this region lies in one row, so that
+row's mushroom is in this region" — which eliminate far more.
+
+That is not a 12×12 blocker, but on a 12×12 a hint that helps once out of twelve
+placements will feel broken. Worth strengthening the propagator in the same step,
+or accepting that the reveal rung carries more of the load on large boards (§8 #6).
+
+## 13. Ladder & scoring — notes parked for Step 9
+
+The ladder was briefed as Step 8 until 12×12 displaced it (§7, "Why bigger boards
+come before the ladder"). The research done for that brief is kept here so the
+Step 9 session does not repeat it.
+
+- **A level is a `{size, seed}` pair.** Both are already deterministic, so the
+  ladder is a data table in its own module and tuning it is editing data. Assert
+  in a test that **every row actually generates** — `generate()` rejects sizes
+  below 5, so a typo in the table becomes a crash for whoever reaches that level
+  rather than a failing build.
+- **`hintsUsed` is already counted and persisted per puzzle**, and
+  `selectMistakes` already knows when a placement is wrong. That is the currency
+  scoring is denominated in, and the reason feedback and hints shipped first.
+- **Ladder progress forces the first storage schema change.** Today a version
+  mismatch in `games/fungiku/storage.js` returns null and the board starts fresh.
+  That is fine for a board and **not** fine for someone's progress: bump
+  `FUNGIKU_STORAGE_VERSION` and write a migration for the existing
+  `{size, seed, marks, showMistakes, hintsUsed}` shape.
+- **Fungiku has no timer at all.** Sudoku scores on time with completion bonuses
+  (`contexts/GameContext.js`). Whether Fungiku gets a clock is a decision to make
+  deliberately, not to inherit — a family puzzle that times you plays differently.
+- **The sibling color-loop app already solved this problem**: a training ladder
+  with per-level star thresholds in `games/colorloop/levels.ts`, and the
+  progression thinking in its `docs/game-design.md`. Read it before designing a
+  second one.
+- **Thresholds and difficulty curves are guesses until played.** Draft them, say
+  so in the PR, and flag them for on-device tuning — color-loop's were left the
+  same way and are still on its backlog.
+- **Keep a free-play route** whatever the ladder does. The size chips are how
+  regression cases at a given size get checked by hand.
+- **The hub's Continue badge** (`utils/gameProgress.js` → `describeFungikuProgress`)
+  probably wants to name the *level* rather than the board size once a ladder
+  exists.

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -368,15 +368,14 @@ the step's real acceptance test, alongside its automated checks.
 | 5 | ~~**Board UI**~~ ✅ — the real board component: region-boundary borders, themed styling, win flow, **palette tuning** | The **finished board**, styled to the app's themes, replacing the preview's rough grid |
 | 6 | ~~**Input ergonomics & assists**~~ ✅ (§2) — **drag to sweep X's**, rule-out button | **Swipe a finger across cells to rule them out**; a *Rule out* button |
 | 7 | ~~**Feedback & hints**~~ ✅ (§11) — correctness feedback on placements, and a hint ladder | **Optional "show mistakes" for mushrooms**, and a hint you can ask for when stuck |
-| 8 | **Bigger boards, up to 12×12** (§12) — generation cost, a 12-colour palette, legibility at 27px cells | **A playable 12×12** that generates without freezing |
+| 8 | **Bigger boards, up to 10×10** (§12) — a 10th region colour, legibility at 32px cells, a generation-cost bound | **A playable 10×10** that generates without a visible freeze |
 | 9 | **Ladder & scoring** — training ladder, size progression, scoring | Level progression and a score |
 | 10 | **Art swap** (floating, asset-only — gated on artwork, not on code) | Static mushroom art replaces the icon glyph |
 
 **Why bigger boards come before the ladder:** the ladder has to know its own top
-end, and §12.1 says whether 12×12 is even affordable is an open engineering
-question. Building the ladder first would bake in a 5–8 range and then need
-reworking — and one of the candidate fixes for generation cost (baking level
-layouts as data) is itself a ladder design decision.
+end. §12.1 measured it — generation cost goes off a cliff between 10×10 and 11×11,
+which is what set the ceiling at 10 — and the ladder's whole table is denominated
+in sizes. Building it against a 5–8 range first would mean reworking it.
 
 **Why feedback and hints come before scoring:** scoring has to know what a
 mistake and a hint are *worth*, so the ladder step needs both to already exist.
@@ -413,10 +412,10 @@ Step 5 replaced that rough grid with the themed, responsive board.
 3. ~~**Hub vs. resume on launch**~~ — **decided in Step 3: hub-first.** The app
    opens on the hub and a game with saved progress carries a *Continue* badge, so
    both games stay discoverable. Revisit only if it grates on device.
-4. **Ladder shape** — **top end decided 2026-07-25: 12×12** (§12), which makes it
-   a real engineering problem rather than a table entry — a 12×12 currently takes
-   seven seconds to generate. Still open: **is size a free choice or unlocked by
-   progression?**
+4. **Ladder shape** — **top end decided 2026-07-25: 10×10** (§12). The operator
+   asked for 12×12 first; measuring showed it takes seven seconds to generate, and
+   10×10 (284 ms) is the last affordable size, so the ceiling moved there. Still
+   open: **is size a free choice or unlocked by progression?**
 5. ~~**Assist defaults**~~ — **moot as of 2026-07-25.** The rule-out assist became
    a button you tap rather than a mode with a setting, so there is no default to
    choose. (§2)
@@ -521,17 +520,22 @@ Requirements on any hint:
 Carried into §8 as #6 and #7: how strong hints should go for a family game, and
 whether correctness feedback should default on for younger players.
 
-## 12. Board sizes up to 12×12 (operator request, 2026-07-25)
+## 12. Board sizes up to 10×10 (operator request, 2026-07-25)
 
-The ladder should reach **12×12**. That answers §8 #4's "where should it top out",
-and it is a bigger change than it looks: the engine and the palette were both
-built around boards of 5–8, and one of them does not survive the jump.
+The operator first asked for the ladder to reach **12×12**. Measuring the cost
+(§12.1) showed a 12×12 takes **7.3 seconds to generate, synchronously on the main
+thread** — so the operator revised the target to **10×10** the same day. That is
+the requirement: **the ladder tops out at 10×10.**
+
+The measurements are kept below rather than deleted, because they are the reason
+for the ceiling. If generation is ever made substantially cheaper, they are also
+the evidence for raising it.
 
 **`MIN_SIZE = 5` exists; there is no upper bound.** `generate()` will happily
-accept size 20 and never return. Add a `MAX_SIZE = 12` and reject above it, the
-same way 4×4 is rejected below.
+accept size 20 and never return. Add a **`MAX_SIZE = 10`** and reject above it,
+the same way 4×4 is rejected below.
 
-### 12.1 Generation time is the blocker — measured, not guessed
+### 12.1 Generation time — measured, not guessed
 
 Twelve seeds per size, on this machine:
 
@@ -539,19 +543,34 @@ Twelve seeds per size, on this machine:
 |------|----|--------|-----|-----|
 | 8×8 | 12/12 | **6 ms** | 21 ms | 25 ms |
 | 9×9 | 12/12 | 30 ms | 82 ms | 103 ms |
-| 10×10 | 12/12 | 284 ms | 519 ms | 584 ms |
+| 10×10 | 12/12 | **284 ms** | 519 ms | **584 ms** |
 | 11×11 | 12/12 | 2,536 ms | 4,124 ms | 5,096 ms |
-| 12×12 | 12/12 | **7,286 ms** | 30,618 ms | **41,830 ms** |
+| 12×12 | 12/12 | 7,286 ms | 30,618 ms | 41,830 ms |
 
 **Correctness is fine — nothing failed at any size.** The problem is purely cost,
-and it is catastrophic: generation is synchronous JS on the main thread, so a
-12×12 freezes the app for seven seconds typically and **forty seconds** at worst.
-Tapping "New puzzle" on a big board today would look like a crash.
+and it goes off a cliff between 10 and 11: an order of magnitude per size, from
+284 ms to 2.5 s to 7.3 s. **10×10 is the last size that is affordable without
+re-engineering the generator**, which is exactly why the ceiling sits there.
 
 The cost is in the uniqueness loop (`generate` → `findSolutions` → `breakSolution`,
 up to `PERTURB_BUDGET` times). Each `findSolutions` call is a backtracking search,
-and it is re-run after every perturbation. Four directions worth trying, cheapest
-first:
+re-run after every perturbation.
+
+**At a 10×10 ceiling, none of that needs fixing** — 284 ms median is a hitch, not a
+freeze. Two things it does need:
+
+1. **A generation hitch you can see is worse than one you are told about.** Half a
+   second of frozen UI on "New puzzle" at the top size reads as a bug. Either show
+   a brief loading state, or confirm on device that it is imperceptible — don't
+   assume.
+2. **A regression bound in the test suite.** 10×10 sits one size below a
+   ten-times cliff, so a change that makes generation modestly slower would push
+   the top size from *hitch* to *freeze* with no other symptom. Assert a generous
+   ceiling (or count perturbation rounds, which is machine-independent) so that
+   regression is visible.
+
+If the ceiling is ever to rise past 10, the generator has to get cheaper first,
+and there are four directions worth trying, cheapest first:
 
 1. **Profile before optimizing.** Is it the number of perturbation rounds, or the
    cost of each `findSolutions`? The fix differs completely. Instrument the loop
@@ -561,65 +580,69 @@ first:
    time and shipped as JSON. That removes runtime cost for every ladder level —
    but not for free-play reseeding, so it is a partial answer.
 3. **Generate off the main thread, with a loading state.** Honest and simple, and
-   it will still feel bad at 40 seconds. Needed as a safety net regardless.
+   at 12×12 it would still feel bad at 40 seconds.
 4. **Construct for uniqueness instead of perturbing toward it.** The current
    approach grows regions randomly and then hammers them until only one solution
    survives. Biasing region growth to produce tight constraints, or building
    region-by-region while tracking solution count, would attack the exponent
    rather than the constant. The most work and the most upside.
 
-**Do not ship a size the app cannot generate promptly.** If 12×12 cannot be made
-interactive, cap the ladder where it can and say so — an honest 10×10 ceiling
-beats a 12×12 that freezes.
-
-### 12.2 The palette needs 12 colours and only has 9
+### 12.2 The palette needs 10 colours and has 9
 
 `REGION_COLORS` holds nine entries — the eight Okabe–Ito swatches plus the
 mushroom red — and `getRegionColor` wraps with `regionId % palette.length`. **At
-10, 11 and 12 regions, colours silently repeat**, so two different regions render
-identically. Region colour is how the player sees region boundaries at all, so
-this is a correctness bug at those sizes, not a cosmetic one.
+10 regions, region 9 renders identically to region 0.** Region colour is how the
+player sees region boundaries at all, so this is a correctness bug at the new top
+size, not a cosmetic one.
 
-The good news, measured the same way §5's palette work was: **12 distinguishable
-pastel fills are comfortably achievable.** Sampling sRGB inside the light theme's
-L* 65–97 band and picking the farthest-apart set:
+The 10×10 ceiling makes this a **one-colour problem**, which is the cheapest
+version of it. Sampling sRGB inside the light theme's L\* 65–97 band and picking
+the farthest-apart set:
 
 | Fills | Best achievable worst-pair ΔE |
 |-------|-------------------------------|
 | 9 | 24.50 |
-| 10 | 23.78 |
+| **10** | **23.78** |
 | 11 | 21.90 |
-| **12** | **21.80** |
+| 12 | 21.80 |
 
-For comparison the **shipped 9-colour palette manages ΔE 17.11**, so twelve
+For comparison the **shipped 9-colour palette manages ΔE 17.11**, so ten
 well-chosen fills would be *better separated* than what ships today. The ΔE 15
-floor in `utils/__tests__/symbolSets.test.js` is safe.
+floor in `utils/__tests__/symbolSets.test.js` is safe with room to spare.
 
 Two constraints that the ΔE number does **not** capture, and which the work must
 respect:
 
 - **Colourblind safety is a separate property.** Okabe–Ito was chosen precisely
-  because its hues survive the common CVD types. Three new hues chosen only to
+  because its hues survive the common CVD types. A tenth hue chosen only to
   maximize ΔE for normal vision may collide under deutan or protan. **Check the
-  extended palette under CVD simulation, not just ΔE.**
+  extended palette under CVD simulation, not just ΔE.** One new hue is a much
+  smaller risk than three, but it is still a check, not an assumption.
 - **The `corners` shape cue in `symbolSets.js` is still unused by the Fungiku
-  board.** Twelve regions is where colour alone starts carrying too much, so this
-  is the point to add a second channel rather than lean harder on hue.
+  board.** Ten regions is close to where colour alone starts carrying too much, so
+  it is worth knowing the second channel already exists if the tenth colour proves
+  hard to place.
 
-### 12.3 Legibility at 27-pixel cells
+### 12.3 Legibility at 32-pixel cells
 
-`useBoardSize()` returns a fixed 324 on native, so a 12×12 cell is **27 px** (450
-on web gives 37 px). At that size:
+`useBoardSize()` returns a fixed 324 on native, so a 10×10 cell is **32 px** (450
+on web gives 45 px). At that size:
 
-- the mushroom glyph is 16 px — probably fine, needs looking at;
-- the **mistake badge is `cell * 0.28` ≈ 7 px, which is too small to read**;
-- the conflict ring at `cell - 6` leaves a 21 px ring — tight;
-- region-boundary borders at 2 px against 27 px cells will dominate visually.
+- the mushroom glyph lands around 19 px — probably fine, needs looking at;
+- the **mistake badge is `cell * 0.28` ≈ 9 px, which is small enough to need
+  checking on a real screen** rather than in a browser at 45 px;
+- the conflict ring at `cell - 6` leaves a 26 px ring — tighter than at 5×5 but
+  not tight;
+- region-boundary borders at 2 px against 32 px cells are heavier than intended,
+  though nothing like the 27 px case.
 
-None of this is hard, but a 12×12 needs a deliberate pass rather than inheriting
-constants tuned for 5×5.
+None of this is hard, but the top size needs a deliberate pass rather than
+inheriting constants tuned for 5×5. The 6-pixel tap-vs-drag threshold deserves the
+same scrutiny: it was tuned against roughly 40 px cells, and a 32 px cell means
+less room to press without registering a stroke. **That is a device question, not
+a browser one.**
 
-### 12.4 A finding about hints on big boards
+### 12.4 A finding about hints on bigger boards
 
 Measured while timing generation: the length of a pure forced-move chain from an
 empty board, using the Step 7 propagator.
@@ -636,14 +659,14 @@ a row, column or region with exactly one candidate. Human solvers also use
 pigeonhole arguments — "every candidate for this region lies in one row, so that
 row's mushroom is in this region" — which eliminate far more.
 
-That is not a 12×12 blocker, but on a 12×12 a hint that helps once out of twelve
-placements will feel broken. Worth strengthening the propagator in the same step,
-or accepting that the reveal rung carries more of the load on large boards (§8 #6).
+That is not a blocker for 10×10, but a hint that helps twice out of ten placements
+will feel thin. Worth strengthening the propagator, or accepting that the reveal
+rung carries more of the load on large boards (§8 #6).
 
 ## 13. Ladder & scoring — notes parked for Step 9
 
-The ladder was briefed as Step 8 until 12×12 displaced it (§7, "Why bigger boards
-come before the ladder"). The research done for that brief is kept here so the
+The ladder was briefed as Step 8 until the board-size work displaced it (§7, "Why
+bigger boards come before the ladder"). The research done for that brief is kept here so the
 Step 9 session does not repeat it.
 
 - **A level is a `{size, seed}` pair.** Both are already deterministic, so the


### PR DESCRIPTION
Docs only — no app code changes. Refs #65.

The ask was "the ladder should reach 12×12". I measured what that costs before writing it down, and the measurement changed the answer: **the ceiling is 10×10** (operator decision, same day).

## Why 12×12 didn't survive contact

Twelve seeds per size, on this machine:

| Size | ok | median | p90 | max |
|------|----|--------|-----|-----|
| 8×8 | 12/12 | **6 ms** | 21 ms | 25 ms |
| 9×9 | 12/12 | 30 ms | 82 ms | 103 ms |
| 10×10 | 12/12 | **284 ms** | 519 ms | **584 ms** |
| 11×11 | 12/12 | 2,536 ms | 4,124 ms | 5,096 ms |
| 12×12 | 12/12 | 7,286 ms | 30,618 ms | 41,830 ms |

**Correctness is fine — nothing failed at any size.** The cost is the problem, and it goes off a cliff between 10 and 11: roughly an order of magnitude per size. Generation is synchronous JS on the main thread, so a 12×12 freezes the app for seven seconds typically and forty at worst — that reads as a crash, not as loading. **10×10 is the last size affordable without re-engineering the uniqueness loop.**

The timings stay in the plan rather than getting deleted with the 12×12 target: they're the justification for the ceiling, and the evidence for raising it if generation ever gets cheaper. §12.1's four optimization approaches (profile first · bake ladder layouts as data · off-main-thread · construct for uniqueness instead of perturbing) are explicitly parked as future work, **not** Step 8 work — at 10×10 the generator is fast enough and the step should spend itself elsewhere.

## What the lower ceiling leaves to do

**The palette is still a correctness bug, but a one-colour one.** `getRegionColor` does `regionId % palette.length` over nine entries, so at 10 regions **region 9 renders identically to region 0** — and region colour is the only way region boundaries are visible.

| Fills | Best achievable worst-pair ΔE |
|-------|-------------------------------|
| 9 | 24.50 |
| **10** | **23.78** |
| 12 | 21.80 |

The shipped 9-colour palette manages **17.11**, so ten well-chosen fills would be *better* separated than what ships today, with comfortable room over the ΔE 15 test floor. One new hue instead of three also shrinks the colourblind-safety risk — but it's still a check, not an assumption: Okabe–Ito was picked for CVD survival, and ΔE for normal vision doesn't measure that.

**`MAX_SIZE = 10`.** Today `MIN_SIZE = 5` exists and there is no upper bound at all — `generate()` accepts size 20 and never returns.

**Legibility is milder than the 12×12 case but not free.** A 10×10 cell is 32 px inside the fixed 324pt native board, so the mistake badge (`cell * 0.28`) lands at ~9 px rather than ~7. Worth checking on device, and *only* on device — web renders 45 px cells, so the browser is the wrong place to judge it. Same for the 6-pixel tap-vs-drag threshold, which was tuned against roughly 40 px cells and has less room at 32.

**One requirement the 12×12 framing didn't need:** a generation-cost bound in the test suite. 10×10 sits one size below a ten-times cliff, so a change that makes generation modestly slower would turn the top size from a hitch into a freeze with no other symptom. The plan suggests counting perturbation rounds over asserting milliseconds, since rounds don't vary with the CI machine.

**Also found while measuring:** the forced-move nudge is shallow at every size (2.0 of 10 deductions on a 10×10) because `findForcedDeduction` only knows sole-candidate, not pigeonhole. Real, flagged in §12.4, explicitly out of scope for Step 8.

## Step renumbering

Bigger boards become **Step 8**, the ladder moves to **9**, art swap to **10**. The ladder's whole table is denominated in sizes, so building it against a 5–8 range and then raising the ceiling would mean reworking it.

- §8 #4's "where should it top out" is answered; the free-choice-vs-unlocked half stays open.
- Ladder research already gathered is parked in new **§13** so Step 9 doesn't repeat it (storage-version migration hazard, `hintsUsed` as scoring currency, the deliberate absence of a timer, color-loop's `levels.ts` as prior art).
- `docs/fungiku-handoff.md` rewritten for Step 8, with Step 7's two open questions (hint strength, mistakes-on-by-default) carried forward.

## Verification

`npm test` → 220 passed, 6 suites. No app code touched, so there's nothing new to see in Expo Go — the Step 7 build (#73) is still current.