### PR TITLE
Fungiku Step 8: bigger boards, up to 10×10

### DIFF
--- a/SudokuApp/games/fungiku/FungikuBoard.js
+++ b/SudokuApp/games/fungiku/FungikuBoard.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, StyleSheet, Animated, Easing, PanResponder } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { MARKS } from './engine';
@@ -7,6 +7,7 @@ import useBoardSize from '../../hooks/useBoardSize';
 import useBoardOrigin from '../../hooks/useBoardOrigin';
 import { cellFromPoint, cellsAlongLine } from './geometry';
 import { PAINT_MODES } from './reducer';
+import FungikuGridLines from './FungikuGridLines';
 import { useFungikuContext } from './FungikuContext';
 
 /**
@@ -67,20 +68,25 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
   // --- legibility at the top size (plan §12.3) ------------------------------
   //
   // The board is a fixed 324pt on native however many cells it holds, so a cell
-  // is 64px at 5×5 and **32px at 10×10**. Several constants below were tuned
-  // against the large end and stop working at the small one, so they step down —
-  // at a threshold that leaves every size that has already shipped (5×5 through
-  // 8×8, cells 64 down to 40) drawn exactly as it is today, and changes only the
-  // two sizes this step adds.
+  // is 64px at 5×5 and **32px at 10×10**. The conflict ring and the mistake badge
+  // were tuned against the large end and stop working at the small one, so they
+  // step down at a threshold that leaves 5×5 through 8×8 (cells 64 down to 40)
+  // exactly as they were, and changes only the two sizes this step adds.
+  //
+  // The board's *lines* are a different story: they changed at every size, because
+  // the way they were drawn was wrong at every size and only obvious at small
+  // ones. See FungikuGridLines.
   //
   // Note what the browser cannot tell you here: web boards are up to 450px, so a
   // 10×10 cell is 45px there — *larger* than a 5×5 native cell. None of this is
   // judgeable outside Expo Go.
   const tightCells = cell < 40;
 
-  // 2px of region border against a 32px cell is a heavy line; against 64px it is
-  // the intended hairline-vs-boundary contrast.
-  const regionBorder = tightCells ? 1.5 : 2;
+  // Region-boundary stroke. Drawn once per edge by FungikuGridLines — when this
+  // was a per-cell border every interior boundary was drawn by *both* cells and
+  // came out at double this, which is why 2 looked heavy and the frame around
+  // the board looked thin by comparison.
+  const regionBorder = tightCells ? 2 : 2.5;
 
   // The conflict ring is inset from the cell edge. A fixed 6px inset leaves only
   // 20px of clear ring at 32px cells, which crowds the 20px mushroom glyph
@@ -341,10 +347,14 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
     [beginStroke, endStroke, paintCells, measure]
   );
 
-  // Region outlines come from the theme's grid colors so the board reads as part
-  // of the app; they need to hold up over both light and dark region fills.
+  // Region boundaries come from the theme's grid colors so the board reads as
+  // part of the app; they need to hold up over both light and dark region fills.
+  //
+  // Grid lines *within* a region do not come from the theme — see the note in
+  // FungikuGridLines. `inkAt` gives that overlay the contrast-picked ink for a
+  // region's fill, which is the one color guaranteed legible on it.
   const outline = theme?.colors?.grid?.boxBorder || (isDark ? '#e8e8e8' : '#333333');
-  const hairline = theme?.colors?.grid?.cellBorder || (isDark ? '#ffffff44' : '#33333344');
+  const inkAt = useCallback((region) => getRegionColor(region, isDark).ink, [isDark]);
 
   // The board itself celebrates a win first (a gentle lift), before the banner
   // above it arrives — same "board celebrates first" idea the sibling color-loop
@@ -391,9 +401,6 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
             const conflicting = conflicts.has(index);
             const mistaken = mistakes.has(index);
 
-            const differs = (r, c) =>
-              r < 0 || c < 0 || r >= size || c >= size || regions[r * size + c] !== region;
-
             // X is a thinking aid, so it sits quieter than a mushroom — but it
             // still has to be visible on its own fill, so it is the same
             // contrast-checked ink at reduced strength rather than a fixed gray.
@@ -419,6 +426,9 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
                 }${hintCells.has(index) ? ', hint' : ''}`}
                 accessibilityHint="Taps cycle empty, ruled out, mushroom"
                 onAccessibilityTap={() => cycleCell(index)}
+                // No borders here: every line on this board is drawn once, by
+                // the FungikuGridLines overlay below. Per-cell borders drew each
+                // interior boundary twice and mitered at every corner.
                 style={{
                   width: cell,
                   height: cell,
@@ -427,16 +437,6 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
                   opacity: pressedCell === index ? 0.6 : 1,
                   alignItems: 'center',
                   justifyContent: 'center',
-                  borderTopColor: differs(row - 1, col) ? outline : hairline,
-                  borderBottomColor: differs(row + 1, col) ? outline : hairline,
-                  borderLeftColor: differs(row, col - 1) ? outline : hairline,
-                  borderRightColor: differs(row, col + 1) ? outline : hairline,
-                  borderTopWidth: differs(row - 1, col) ? regionBorder : StyleSheet.hairlineWidth,
-                  borderBottomWidth: differs(row + 1, col)
-                    ? regionBorder
-                    : StyleSheet.hairlineWidth,
-                  borderLeftWidth: differs(row, col - 1) ? regionBorder : StyleSheet.hairlineWidth,
-                  borderRightWidth: differs(row, col + 1) ? regionBorder : StyleSheet.hairlineWidth,
                 }}
               >
                 {/* Conflict is signalled by a ring *and* a color change, so it
@@ -509,6 +509,17 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
           })}
         </View>
       ))}
+
+      {/* Drawn last so the lines sit on top of the fills rather than being eaten
+          by them. Memoized on the puzzle, so a tap does not rebuild it. */}
+      <FungikuGridLines
+        size={size}
+        cell={cell}
+        regions={regions}
+        width={regionBorder}
+        color={outline}
+        inkAt={inkAt}
+      />
     </Animated.View>
   );
 };

--- a/SudokuApp/games/fungiku/FungikuBoard.js
+++ b/SudokuApp/games/fungiku/FungikuBoard.js
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { View, StyleSheet, Animated, Easing, PanResponder } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { MARKS } from './engine';
-import { getRegionPalette } from '../../utils/symbolSets';
+import { getRegionColor } from '../../utils/symbolSets';
 import useBoardSize from '../../hooks/useBoardSize';
 import useBoardOrigin from '../../hooks/useBoardOrigin';
 import { cellFromPoint, cellsAlongLine } from './geometry';
@@ -53,6 +53,7 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
     beginStroke,
     endStroke,
     solved,
+    generating,
   } = useFungikuContext();
 
   // Cells a hint is pointing at: a whole row/column/region for a nudge, a single
@@ -62,6 +63,34 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
   const boardSize = useBoardSize();
   const cell = Math.floor(boardSize / size);
   const glyph = Math.round(cell * 0.62);
+
+  // --- legibility at the top size (plan §12.3) ------------------------------
+  //
+  // The board is a fixed 324pt on native however many cells it holds, so a cell
+  // is 64px at 5×5 and **32px at 10×10**. Several constants below were tuned
+  // against the large end and stop working at the small one, so they step down —
+  // at a threshold that leaves every size that has already shipped (5×5 through
+  // 8×8, cells 64 down to 40) drawn exactly as it is today, and changes only the
+  // two sizes this step adds.
+  //
+  // Note what the browser cannot tell you here: web boards are up to 450px, so a
+  // 10×10 cell is 45px there — *larger* than a 5×5 native cell. None of this is
+  // judgeable outside Expo Go.
+  const tightCells = cell < 40;
+
+  // 2px of region border against a 32px cell is a heavy line; against 64px it is
+  // the intended hairline-vs-boundary contrast.
+  const regionBorder = tightCells ? 1.5 : 2;
+
+  // The conflict ring is inset from the cell edge. A fixed 6px inset leaves only
+  // 20px of clear ring at 32px cells, which crowds the 20px mushroom glyph
+  // inside it, so tight cells give the ring more room and a thinner stroke.
+  const ringInset = tightCells ? 4 : 6;
+  const ringWidth = tightCells ? 2 : 2.5;
+
+  // The mistake badge is a corner glyph at 28% of the cell — 18px at 5×5 but
+  // 9px at 10×10, which is below the size an alert triangle still reads as one.
+  const badge = Math.max(11, Math.round(cell * 0.28));
 
   // --- drag to sweep X's (plan §2) -----------------------------------------
   //
@@ -165,9 +194,13 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
   // This effect runs after the banner has been committed, so the origin is right
   // before the player can touch anything. `hint` and `solved` are the two things
   // that mount a banner above the board.
+  // `generating` is in here for the same reason `hint` and `solved` are: it
+  // changes what the row above the board renders. That row keeps its height by
+  // design, so the board should not actually move — this is the cheap insurance
+  // that says so, and the place the next thing added above the board belongs.
   useEffect(() => {
     measure();
-  }, [hint, solved, measure]);
+  }, [hint, solved, generating, measure]);
 
   // The latest marks/geometry, readable from inside gesture callbacks that were
   // created once and would otherwise close over a stale render.
@@ -308,8 +341,6 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
     [beginStroke, endStroke, paintCells, measure]
   );
 
-  const palette = useMemo(() => getRegionPalette(isDark), [isDark]);
-
   // Region outlines come from the theme's grid colors so the board reads as part
   // of the app; they need to hold up over both light and dark region fills.
   const outline = theme?.colors?.grid?.boxBorder || (isDark ? '#e8e8e8' : '#333333');
@@ -332,6 +363,9 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
     <Animated.View
       ref={boardRef}
       onLayout={onLayout}
+      // While a big board generates, the board on screen is the *previous*
+      // puzzle and is about to be replaced. Marks made on it would vanish.
+      pointerEvents={generating ? 'none' : 'auto'}
       {...responder.panHandlers}
       style={[
         styles.board,
@@ -349,7 +383,10 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
           {Array.from({ length: size }, (_, col) => {
             const index = row * size + col;
             const region = regions[index];
-            const entry = palette[region % palette.length];
+            // Looked up through the engine's guarded accessor rather than a
+            // modulo into the palette. The modulo silently gave region 9 the
+            // same fill as region 0 the moment boards reached 10 regions.
+            const entry = getRegionColor(region, isDark);
             const mark = marks[index];
             const conflicting = conflicts.has(index);
             const mistaken = mistakes.has(index);
@@ -394,10 +431,12 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
                   borderBottomColor: differs(row + 1, col) ? outline : hairline,
                   borderLeftColor: differs(row, col - 1) ? outline : hairline,
                   borderRightColor: differs(row, col + 1) ? outline : hairline,
-                  borderTopWidth: differs(row - 1, col) ? 2 : StyleSheet.hairlineWidth,
-                  borderBottomWidth: differs(row + 1, col) ? 2 : StyleSheet.hairlineWidth,
-                  borderLeftWidth: differs(row, col - 1) ? 2 : StyleSheet.hairlineWidth,
-                  borderRightWidth: differs(row, col + 1) ? 2 : StyleSheet.hairlineWidth,
+                  borderTopWidth: differs(row - 1, col) ? regionBorder : StyleSheet.hairlineWidth,
+                  borderBottomWidth: differs(row + 1, col)
+                    ? regionBorder
+                    : StyleSheet.hairlineWidth,
+                  borderLeftWidth: differs(row, col - 1) ? regionBorder : StyleSheet.hairlineWidth,
+                  borderRightWidth: differs(row, col + 1) ? regionBorder : StyleSheet.hairlineWidth,
                 }}
               >
                 {/* Conflict is signalled by a ring *and* a color change, so it
@@ -409,9 +448,10 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
                     style={[
                       styles.conflictRing,
                       {
-                        width: cell - 6,
-                        height: cell - 6,
-                        borderRadius: (cell - 6) / 2,
+                        width: cell - ringInset,
+                        height: cell - ringInset,
+                        borderRadius: (cell - ringInset) / 2,
+                        borderWidth: ringWidth,
                         borderColor: entry.conflictInk,
                       },
                     ]}
@@ -451,7 +491,7 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
                 {showMistakes && mistaken && (
                   <MaterialCommunityIcons
                     name="alert"
-                    size={Math.round(cell * 0.28)}
+                    size={badge}
                     color={entry.conflictInk}
                     style={styles.mistakeBadge}
                   />
@@ -482,7 +522,7 @@ const styles = StyleSheet.create({
   },
   conflictRing: {
     position: 'absolute',
-    borderWidth: 2.5,
+    // borderWidth is set per board size — see `ringWidth`.
   },
   hintOutline: {
     position: 'absolute',

--- a/SudokuApp/games/fungiku/FungikuContext.js
+++ b/SudokuApp/games/fungiku/FungikuContext.js
@@ -1,6 +1,6 @@
-import React, { createContext, useCallback, useContext, useMemo } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import usePersistentReducer from '../../hooks/usePersistentReducer';
-import { MARKS, MIN_SIZE } from './engine';
+import { MARKS, MAX_SIZE, MIN_SIZE } from './engine';
 import { loadFungikuState, saveFungikuState } from './storage';
 import {
   DEFAULT_SEED,
@@ -29,11 +29,29 @@ import {
  */
 const FungikuContext = createContext();
 
-/** Board sizes offered today. The real ladder arrives in a later step. */
-export const SIZES = [5, 6, 7, 8];
+/**
+ * Board sizes offered today — every size the engine supports, derived there from
+ * MIN_SIZE/MAX_SIZE rather than listed here, so a chip the UI offers and a size
+ * `generate()` accepts cannot drift apart. The real ladder arrives in a later
+ * step and will pick its rungs from this same range.
+ */
+export { SIZES } from './engine';
 
 // Stable object identity, so the persistence hook never sees a "new" adapter.
 const FUNGIKU_PERSISTENCE = { load: loadFungikuState, save: saveFungikuState };
+
+/**
+ * At and above this size, generation is deferred by a frame so the "Generating…"
+ * state can paint before the main thread is blocked (plan §12.1).
+ *
+ * Generation is synchronous and its cost is a cliff: on the machine that
+ * measured it, 8×8 takes 5 ms, 9×9 51 ms and 10×10 **414 ms median, 789 ms
+ * worst**. A phone's JS engine is slower again. Below the threshold the work is
+ * over before a frame could have been drawn, and deferring would only add
+ * latency; at and above it, a "New puzzle" tap that freezes for half a second
+ * reads as a bug, so the player is told what is happening instead.
+ */
+const DEFER_GENERATION_AT_SIZE = 9;
 
 export const FungikuProvider = ({ children }) => {
   // Generated once. `useReducer` ignores this argument after mount, but
@@ -119,22 +137,70 @@ export const FungikuProvider = ({ children }) => {
     [dispatch]
   );
 
+  // --- starting a puzzle, and the hitch at the top size ---------------------
+  //
+  // True while a big board is being generated. It exists so the half-second the
+  // main thread spends inside `generate()` at 10×10 is *announced* rather than
+  // experienced as a frozen app (plan §12.1).
+  const [generating, setGenerating] = useState(false);
+
+  // Identifies the most recent request. A tap that arrives while an earlier
+  // deferred generation is still pending invalidates it, so rapid taps on
+  // "New puzzle" resolve to the last one asked for rather than racing.
+  const requestId = useRef(0);
+  useEffect(
+    () => () => {
+      // Unmounted (left for the hub): make any pending callback a no-op rather
+      // than let it dispatch into a dead provider.
+      requestId.current += 1;
+    },
+    []
+  );
+
   /**
    * Start a puzzle. Generation happens here rather than in the reducer so a
    * failure surfaces as a caught error instead of a throw mid-dispatch.
    */
   const startPuzzle = useCallback(
     ({ size = state.size, seed = state.seed }) => {
-      try {
-        dispatch({
-          type: FUNGIKU_ACTIONS.NEW_PUZZLE,
-          // The feedback switch is a preference and carries over; the hint count
-          // is per-puzzle and resets.
-          payload: buildPuzzleState({ size, seed, showMistakes: state.showMistakes }),
-        });
-      } catch (error) {
-        console.error('Fungiku generation failed:', error);
+      const run = () => {
+        try {
+          dispatch({
+            type: FUNGIKU_ACTIONS.NEW_PUZZLE,
+            // The feedback switch is a preference and carries over; the hint
+            // count is per-puzzle and resets.
+            payload: buildPuzzleState({ size, seed, showMistakes: state.showMistakes }),
+          });
+        } catch (error) {
+          console.error('Fungiku generation failed:', error);
+        }
+      };
+
+      // Small boards: generate inline. The work finishes inside the same frame,
+      // so deferring would add a frame of latency and buy nothing.
+      if (size < DEFER_GENERATION_AT_SIZE) {
+        run();
+        return;
       }
+
+      const id = (requestId.current += 1);
+      setGenerating(true);
+
+      // Two hops on purpose. The state update above only *schedules* a render;
+      // requestAnimationFrame runs after that render is committed, and the
+      // timeout after the frame it belongs to has been handed off — so
+      // "Generating…" is on screen before the main thread disappears into the
+      // generator. A bare setTimeout(0) can run before the frame is drawn.
+      requestAnimationFrame(() => {
+        setTimeout(() => {
+          if (requestId.current !== id) return; // superseded, or unmounted
+          try {
+            run();
+          } finally {
+            setGenerating(false);
+          }
+        }, 0);
+      });
     },
     [dispatch, state.size, state.seed, state.showMistakes]
   );
@@ -163,6 +229,8 @@ export const FungikuProvider = ({ children }) => {
       canUndo: selectCanUndo(state),
       canRedo: selectCanRedo(state),
       minSize: MIN_SIZE,
+      maxSize: MAX_SIZE,
+      generating,
       cycleCell,
       beginStroke,
       paintCells,
@@ -188,6 +256,7 @@ export const FungikuProvider = ({ children }) => {
       mushroomCount,
       solved,
       hasMarks,
+      generating,
       cycleCell,
       beginStroke,
       paintCells,

--- a/SudokuApp/games/fungiku/FungikuGridLines.js
+++ b/SudokuApp/games/fungiku/FungikuGridLines.js
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, PixelRatio } from 'react-native';
 
 /**
  * The board's lines — every grid line and every region boundary — drawn as one
@@ -53,6 +53,30 @@ const gridInkFor = (ink) => (ink === '#ffffff' ? '#ffffff66' : '#1a1a1a5e');
 const GRID_LINE_WIDTH = 1;
 
 /**
+ * Round a length to a whole number of **device** pixels.
+ *
+ * This is the difference between a line and a smear, and it is why the grid
+ * still looked patchy after the overlay fixed everything else. A line centered on
+ * a cell edge lands at a half logical pixel — `y = 35.5, height = 1` — and on a
+ * 3× screen that is device rows 106.5 to 109.5. The renderer cannot draw half a
+ * pixel, so it antialiases: 50% coverage, 100%, 100%, 50%. Multiply that by the
+ * line's own 37% alpha and the edges all but vanish, unevenly, depending on the
+ * fill behind them.
+ *
+ * Region boundaries never showed the problem because their width happened to put
+ * them on integers at the sizes that shipped — which is exactly the kind of
+ * accident that makes this look like "some lines are missing" rather than "every
+ * thin line is half a pixel off".
+ *
+ * Snapping both the position *and* the thickness means every line covers whole
+ * device pixels at full strength.
+ */
+const snap = (value) => PixelRatio.roundToNearestPixel(value);
+
+/** A line's thickness, never rounded away to nothing. */
+const snapWidth = (value) => Math.max(StyleSheet.hairlineWidth, snap(value));
+
+/**
  * @param {number}   size   - N
  * @param {number}   cell   - cell size in px
  * @param {number[]} regions- flat region ids
@@ -64,8 +88,13 @@ const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
   const { gridSegments, regionSegments } = useMemo(() => {
     const grid = [];
     const region = [];
-    const half = width / 2;
-    const gridHalf = GRID_LINE_WIDTH / 2;
+    // Snapped once: every position below is derived from these, so the whole
+    // overlay sits on the device pixel grid.
+    const regionWidth = snapWidth(width);
+    const gridWidth = snapWidth(GRID_LINE_WIDTH);
+    const half = regionWidth / 2;
+    /** A line of `thickness` centered on edge position `p`, snapped. */
+    const lineAt = (p, thickness) => snap(p - thickness / 2);
     const at = (row, col) => regions[row * size + col];
 
     /**
@@ -91,10 +120,11 @@ const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
      * device as small ticks poking past the frame. Clamped, the run still runs
      * right into the frame band and joins it solidly.
      */
-    const span = (index, last) => ({
-      from: index === 0 ? 0 : index * cell - half,
-      to: last === size ? size * cell : last * cell + half,
-    });
+    const span = (index, last) => {
+      const from = index === 0 ? 0 : snap(index * cell - half);
+      const to = last === size ? size * cell : snap(last * cell + half);
+      return { from, to };
+    };
 
     /** Walk one line of edges, emitting a rectangle per run of identical ones. */
     const walk = (count, edgeAtIndex, emit) => {
@@ -120,16 +150,16 @@ const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
             const { from, to } = span(c0, c1);
             region.push({
               key: `h${r}-${c0}`,
-              style: { top: r * cell - half, left: from, width: to - from, height: width },
+              style: { top: lineAt(r * cell, regionWidth), left: from, width: to - from, height: regionWidth },
             });
           } else {
             grid.push({
               key: `h${r}-${c0}`,
               style: {
-                top: r * cell - gridHalf,
+                top: lineAt(r * cell, gridWidth),
                 left: c0 * cell,
                 width: (c1 - c0) * cell,
-                height: GRID_LINE_WIDTH,
+                height: gridWidth,
                 backgroundColor: run.ink,
               },
             });
@@ -148,16 +178,16 @@ const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
             const { from, to } = span(r0, r1);
             region.push({
               key: `v${c}-${r0}`,
-              style: { left: c * cell - half, top: from, height: to - from, width },
+              style: { left: lineAt(c * cell, regionWidth), top: from, height: to - from, width: regionWidth },
             });
           } else {
             grid.push({
               key: `v${c}-${r0}`,
               style: {
-                left: c * cell - gridHalf,
+                left: lineAt(c * cell, gridWidth),
                 top: r0 * cell,
                 height: (r1 - r0) * cell,
-                width: GRID_LINE_WIDTH,
+                width: gridWidth,
                 backgroundColor: run.ink,
               },
             });
@@ -172,10 +202,10 @@ const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
     // touch geometry: `cellFromPoint` resolves taps against this origin, so
     // nothing here may change where the board's top-left corner sits.
     const frame = [
-      { key: 'top', style: { top: 0, left: 0, right: 0, height: width } },
-      { key: 'bottom', style: { bottom: 0, left: 0, right: 0, height: width } },
-      { key: 'left', style: { top: 0, bottom: 0, left: 0, width } },
-      { key: 'right', style: { top: 0, bottom: 0, right: 0, width } },
+      { key: 'top', style: { top: 0, left: 0, right: 0, height: regionWidth } },
+      { key: 'bottom', style: { bottom: 0, left: 0, right: 0, height: regionWidth } },
+      { key: 'left', style: { top: 0, bottom: 0, left: 0, width: regionWidth } },
+      { key: 'right', style: { top: 0, bottom: 0, right: 0, width: regionWidth } },
     ];
 
     return { gridSegments: grid, regionSegments: [...region, ...frame] };

--- a/SudokuApp/games/fungiku/FungikuGridLines.js
+++ b/SudokuApp/games/fungiku/FungikuGridLines.js
@@ -81,6 +81,21 @@ const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
       return { key: `grid:${ink}`, boundary: false, ink };
     };
 
+    /**
+     * Where a run of region boundary starts and ends along its line.
+     *
+     * Interior ends are extended half a stroke so a corner or T-junction is
+     * filled by overlap rather than left as a notch — but an end that reaches
+     * the edge of the board is **clamped instead**. Extending there put the
+     * half-stroke *outside* the board, where nothing clips it, and it showed on
+     * device as small ticks poking past the frame. Clamped, the run still runs
+     * right into the frame band and joins it solidly.
+     */
+    const span = (index, last) => ({
+      from: index === 0 ? 0 : index * cell - half,
+      to: last === size ? size * cell : last * cell + half,
+    });
+
     /** Walk one line of edges, emitting a rectangle per run of identical ones. */
     const walk = (count, edgeAtIndex, emit) => {
       let start = 0;
@@ -101,13 +116,11 @@ const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
         size,
         (col) => edge(r - 1, col, r, col),
         (c0, c1, run) => {
-          const span = (c1 - c0) * cell;
           if (run.boundary) {
+            const { from, to } = span(c0, c1);
             region.push({
               key: `h${r}-${c0}`,
-              // Extended half a stroke at each end so a corner or T-junction is
-              // filled by overlap rather than left as a notch.
-              style: { top: r * cell - half, left: c0 * cell - half, width: span + width, height: width },
+              style: { top: r * cell - half, left: from, width: to - from, height: width },
             });
           } else {
             grid.push({
@@ -115,7 +128,7 @@ const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
               style: {
                 top: r * cell - gridHalf,
                 left: c0 * cell,
-                width: span,
+                width: (c1 - c0) * cell,
                 height: GRID_LINE_WIDTH,
                 backgroundColor: run.ink,
               },
@@ -131,11 +144,11 @@ const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
         size,
         (row) => edge(row, c - 1, row, c),
         (r0, r1, run) => {
-          const span = (r1 - r0) * cell;
           if (run.boundary) {
+            const { from, to } = span(r0, r1);
             region.push({
               key: `v${c}-${r0}`,
-              style: { left: c * cell - half, top: r0 * cell - half, height: span + width, width },
+              style: { left: c * cell - half, top: from, height: to - from, width },
             });
           } else {
             grid.push({
@@ -143,7 +156,7 @@ const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
               style: {
                 left: c * cell - gridHalf,
                 top: r0 * cell,
-                height: span,
+                height: (r1 - r0) * cell,
                 width: GRID_LINE_WIDTH,
                 backgroundColor: run.ink,
               },

--- a/SudokuApp/games/fungiku/FungikuGridLines.js
+++ b/SudokuApp/games/fungiku/FungikuGridLines.js
@@ -1,0 +1,195 @@
+import React, { useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
+
+/**
+ * The board's lines — every grid line and every region boundary — drawn as one
+ * overlay on top of the cells.
+ *
+ * ### Why this is not per-cell borders
+ *
+ * It used to be: each cell set its own four border widths and colors, thick
+ * where the neighboring cell belonged to a different region. That is the obvious
+ * way to do it and it produces three artifacts, all of which the operator saw on
+ * device (2026-07-26) and none of which are visible in a browser at desktop
+ * scale:
+ *
+ * 1. **Every interior region boundary was drawn twice** — once by the cell on
+ *    each side — so it rendered at double width, while the board's outer edge
+ *    was drawn once. Interior boundaries were literally twice the weight of the
+ *    frame around them.
+ * 2. **Corners notched.** React Native miters adjacent borders, so a cell with a
+ *    thick top edge and a hairline left edge gets a diagonal seam between the
+ *    two where they meet. Where four cells meet at a region corner there are
+ *    four independent miters, and they do not line up.
+ * 3. **Borders are drawn *inside* the cell box**, so a boundary ate 2px off both
+ *    neighbors' fills. At 32px cells that is an eighth of the cell.
+ *
+ * Drawing the lines as absolutely-positioned rectangles fixes all three by
+ * construction: each edge is drawn exactly **once**, at a width that does not
+ * depend on how many cells touch it, **centered on the edge** rather than inside
+ * one cell, and with region segments extended by half a stroke at each end so
+ * corners and T-junctions fill in solid instead of mitering.
+ *
+ * Collinear runs are merged, so a boundary that follows a whole row is one View
+ * and not ten. The whole overlay depends only on the puzzle, never on the
+ * player's marks, so it is memoized and does not re-render on taps.
+ */
+
+/**
+ * Grid lines *within* a region take their color from the fill they sit on, the
+ * same way glyph ink does, rather than from the theme.
+ *
+ * The theme's `grid.cellBorder` is tuned for Sudoku's white cells — in the
+ * Pastel theme it is `#d0d8e6`, which simply disappears on a saturated orange or
+ * green region fill. That is what "the grid lines could use some darker lines"
+ * was about. A contrast-picked ink at low alpha is legible on every fill in the
+ * palette by construction.
+ */
+const gridInkFor = (ink) => (ink === '#ffffff' ? '#ffffff66' : '#1a1a1a5e');
+
+// One physical-ish line rather than StyleSheet.hairlineWidth: a third of a pixel
+// at low alpha is what made these vanish. Region boundaries stay clearly the
+// heavier of the two — that contrast is the board's structure (plan §3).
+const GRID_LINE_WIDTH = 1;
+
+/**
+ * @param {number}   size   - N
+ * @param {number}   cell   - cell size in px
+ * @param {number[]} regions- flat region ids
+ * @param {number}   width  - region-boundary stroke width
+ * @param {string}   color  - region-boundary color
+ * @param {function} inkAt  - (regionId) => the glyph ink for that region's fill
+ */
+const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
+  const { gridSegments, regionSegments } = useMemo(() => {
+    const grid = [];
+    const region = [];
+    const half = width / 2;
+    const gridHalf = GRID_LINE_WIDTH / 2;
+    const at = (row, col) => regions[row * size + col];
+
+    /**
+     * What sits on one interior edge: a region boundary, or a grid line in the
+     * color of the region both sides share. The string is what run-merging
+     * compares, so two runs only merge when they would draw identically.
+     */
+    const edge = (aRow, aCol, bRow, bCol) => {
+      const a = at(aRow, aCol);
+      const b = at(bRow, bCol);
+      if (a !== b) return { key: 'region', boundary: true };
+      const ink = gridInkFor(inkAt(a));
+      return { key: `grid:${ink}`, boundary: false, ink };
+    };
+
+    /** Walk one line of edges, emitting a rectangle per run of identical ones. */
+    const walk = (count, edgeAtIndex, emit) => {
+      let start = 0;
+      let run = edgeAtIndex(0);
+      for (let i = 1; i <= count; i++) {
+        const next = i < count ? edgeAtIndex(i) : null;
+        if (!next || next.key !== run.key) {
+          emit(start, i, run);
+          start = i;
+          run = next;
+        }
+      }
+    };
+
+    // Interior horizontal edges: the line between row r-1 and row r.
+    for (let r = 1; r < size; r++) {
+      walk(
+        size,
+        (col) => edge(r - 1, col, r, col),
+        (c0, c1, run) => {
+          const span = (c1 - c0) * cell;
+          if (run.boundary) {
+            region.push({
+              key: `h${r}-${c0}`,
+              // Extended half a stroke at each end so a corner or T-junction is
+              // filled by overlap rather than left as a notch.
+              style: { top: r * cell - half, left: c0 * cell - half, width: span + width, height: width },
+            });
+          } else {
+            grid.push({
+              key: `h${r}-${c0}`,
+              style: {
+                top: r * cell - gridHalf,
+                left: c0 * cell,
+                width: span,
+                height: GRID_LINE_WIDTH,
+                backgroundColor: run.ink,
+              },
+            });
+          }
+        }
+      );
+    }
+
+    // Interior vertical edges: the line between column c-1 and column c.
+    for (let c = 1; c < size; c++) {
+      walk(
+        size,
+        (row) => edge(row, c - 1, row, c),
+        (r0, r1, run) => {
+          const span = (r1 - r0) * cell;
+          if (run.boundary) {
+            region.push({
+              key: `v${c}-${r0}`,
+              style: { left: c * cell - half, top: r0 * cell - half, height: span + width, width },
+            });
+          } else {
+            grid.push({
+              key: `v${c}-${r0}`,
+              style: {
+                left: c * cell - gridHalf,
+                top: r0 * cell,
+                height: span,
+                width: GRID_LINE_WIDTH,
+                backgroundColor: run.ink,
+              },
+            });
+          }
+        }
+      );
+    }
+
+    // The frame, at the same weight as an interior boundary — which it was not
+    // before, when interior boundaries were double-drawn. Inset fully inside the
+    // board rather than centered on its edge, because the board's box *is* the
+    // touch geometry: `cellFromPoint` resolves taps against this origin, so
+    // nothing here may change where the board's top-left corner sits.
+    const frame = [
+      { key: 'top', style: { top: 0, left: 0, right: 0, height: width } },
+      { key: 'bottom', style: { bottom: 0, left: 0, right: 0, height: width } },
+      { key: 'left', style: { top: 0, bottom: 0, left: 0, width } },
+      { key: 'right', style: { top: 0, bottom: 0, right: 0, width } },
+    ];
+
+    return { gridSegments: grid, regionSegments: [...region, ...frame] };
+  }, [regions, size, cell, width, inkAt]);
+
+  return (
+    // Purely decorative, and the board owns every touch — the overlay must never
+    // intercept one.
+    <View style={StyleSheet.absoluteFill} pointerEvents="none">
+      {gridSegments.map((seg) => (
+        <View key={`g-${seg.key}`} style={[styles.segment, seg.style]} />
+      ))}
+      {/* Region boundaries last, so they cover the grid lines they cross rather
+          than being interrupted by them. */}
+      {regionSegments.map((seg) => (
+        <View key={`r-${seg.key}`} style={[styles.segment, { backgroundColor: color }, seg.style]} />
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  segment: {
+    position: 'absolute',
+  },
+});
+
+// The lines depend on the puzzle, never on the player's marks, and the board
+// re-renders on every tap.
+export default React.memo(FungikuGridLines);

--- a/SudokuApp/games/fungiku/FungikuGridLines.js
+++ b/SudokuApp/games/fungiku/FungikuGridLines.js
@@ -2,71 +2,87 @@ import React, { useMemo } from 'react';
 import { View, StyleSheet, PixelRatio } from 'react-native';
 
 /**
- * The board's lines — every grid line and every region boundary — drawn as one
- * overlay on top of the cells.
+ * The board's grid, drawn as one overlay on top of the cells.
+ *
+ * ### What is drawn, and what deliberately is not
+ *
+ * A line is drawn between two cells **of the same region**, and nowhere else.
+ * Where two regions meet there is no line at all: the fills change colour, and
+ * that colour edge *is* the boundary. Drawing a stroke there as well was drawing
+ * the same information twice — see "the boundary stroke" below.
+ *
+ * So the overlay is: a thin line wherever a region continues into the next cell,
+ * and a frame around the board.
  *
  * ### Why this is not per-cell borders
  *
- * It used to be: each cell set its own four border widths and colors, thick
- * where the neighboring cell belonged to a different region. That is the obvious
- * way to do it and it produces three artifacts, all of which the operator saw on
- * device (2026-07-26) and none of which are visible in a browser at desktop
- * scale:
+ * It used to be: each cell set its own four border widths and colours. That is
+ * the obvious way to do it and it produces three artifacts, all of which the
+ * operator saw on device (2026-07-26) and none of which show in a desktop
+ * browser:
  *
- * 1. **Every interior region boundary was drawn twice** — once by the cell on
- *    each side — so it rendered at double width, while the board's outer edge
- *    was drawn once. Interior boundaries were literally twice the weight of the
- *    frame around them.
+ * 1. **Every interior line was drawn twice**, once by the cell on each side, so
+ *    it rendered at double width while the board's frame was drawn once.
  * 2. **Corners notched.** React Native miters adjacent borders, so a cell with a
- *    thick top edge and a hairline left edge gets a diagonal seam between the
- *    two where they meet. Where four cells meet at a region corner there are
- *    four independent miters, and they do not line up.
- * 3. **Borders are drawn *inside* the cell box**, so a boundary ate 2px off both
- *    neighbors' fills. At 32px cells that is an eighth of the cell.
+ *    thick edge meeting a thin one gets a diagonal seam; where four cells meet,
+ *    four independent miters fail to line up.
+ * 3. **Borders draw *inside* the cell box**, so a line ate width off both
+ *    neighbours' fills — an eighth of the cell at 32px.
  *
- * Drawing the lines as absolutely-positioned rectangles fixes all three by
- * construction: each edge is drawn exactly **once**, at a width that does not
- * depend on how many cells touch it, **centered on the edge** rather than inside
- * one cell, and with region segments extended by half a stroke at each end so
- * corners and T-junctions fill in solid instead of mitering.
+ * Rectangles fix all three by construction: each edge is drawn exactly once, at
+ * a width that does not depend on how many cells touch it, centred on the edge
+ * rather than inside one cell.
  *
- * Collinear runs are merged, so a boundary that follows a whole row is one View
- * and not ten. The whole overlay depends only on the puzzle, never on the
- * player's marks, so it is memoized and does not re-render on taps.
+ * ### The boundary stroke, and why it went away
+ *
+ * Region boundaries used to be drawn as a heavy stroke, on the reasoning that
+ * region outlines are the board's structure the way box lines are in Sudoku
+ * (plan §3). They are not the same case. Sudoku's boxes are invisible without
+ * their lines; a Fungiku region is a **colour**, and ten of them are tuned to be
+ * distinguishable by a measured margin (plan §12.2). The stroke was a second
+ * rendering of information the fill already carried, and it cost the geometry
+ * that produced every artifact above — the double-drawing, the mitering, the
+ * half-stroke extensions needed to close corners, and the ticks where those
+ * extensions ran past the frame.
+ *
+ * Removing it makes colour the **only** channel for region identity. That is a
+ * real trade for a colourblind player, and the reason `corners` in
+ * `utils/symbolSets.js` still exists unused: if the boundary is ever wanted back
+ * as an accessibility channel, a shape cue is the cheaper way to pay for it than
+ * a stroke on every edge.
+ *
+ * Collinear runs are merged, so a row of same-region cells is one View and not
+ * ten. The overlay depends only on the puzzle, never on the player's marks, so
+ * it is memoized and does not re-render on taps.
  */
 
 /**
- * Grid lines *within* a region take their color from the fill they sit on, the
- * same way glyph ink does, rather than from the theme.
+ * Grid lines take their colour from the fill they sit on, the same way glyph ink
+ * does, rather than from the theme.
  *
  * The theme's `grid.cellBorder` is tuned for Sudoku's white cells — in the
  * Pastel theme it is `#d0d8e6`, which simply disappears on a saturated orange or
  * green region fill. That is what "the grid lines could use some darker lines"
  * was about. A contrast-picked ink at low alpha is legible on every fill in the
- * palette by construction.
+ * palette by construction. A line only ever sits between two cells of the *same*
+ * region, so there is exactly one fill to be legible against.
  */
 const gridInkFor = (ink) => (ink === '#ffffff' ? '#ffffff66' : '#1a1a1a5e');
 
 // One physical-ish line rather than StyleSheet.hairlineWidth: a third of a pixel
-// at low alpha is what made these vanish. Region boundaries stay clearly the
-// heavier of the two — that contrast is the board's structure (plan §3).
+// at low alpha is what made these vanish.
 const GRID_LINE_WIDTH = 1;
 
 /**
  * Round a length to a whole number of **device** pixels.
  *
- * This is the difference between a line and a smear, and it is why the grid
- * still looked patchy after the overlay fixed everything else. A line centered on
- * a cell edge lands at a half logical pixel — `y = 35.5, height = 1` — and on a
- * 3× screen that is device rows 106.5 to 109.5. The renderer cannot draw half a
+ * This is the difference between a line and a smear. A line centred on a cell
+ * edge lands at a half logical pixel — `y = 35.5, height = 1` — and on a 3×
+ * screen that is device rows 106.5 to 109.5. The renderer cannot draw half a
  * pixel, so it antialiases: 50% coverage, 100%, 100%, 50%. Multiply that by the
  * line's own 37% alpha and the edges all but vanish, unevenly, depending on the
- * fill behind them.
- *
- * Region boundaries never showed the problem because their width happened to put
- * them on integers at the sizes that shipped — which is exactly the kind of
- * accident that makes this look like "some lines are missing" rather than "every
- * thin line is half a pixel off".
+ * fill behind them. On device that read as "the grid has misses" when in fact
+ * every edge was drawn (plan §12.5).
  *
  * Snapping both the position *and* the thickness means every line covers whole
  * device pixels at full strength.
@@ -77,53 +93,32 @@ const snap = (value) => PixelRatio.roundToNearestPixel(value);
 const snapWidth = (value) => Math.max(StyleSheet.hairlineWidth, snap(value));
 
 /**
- * @param {number}   size   - N
- * @param {number}   cell   - cell size in px
- * @param {number[]} regions- flat region ids
- * @param {number}   width  - region-boundary stroke width
- * @param {string}   color  - region-boundary color
- * @param {function} inkAt  - (regionId) => the glyph ink for that region's fill
+ * @param {number}   size    - N
+ * @param {number}   cell    - cell size in px
+ * @param {number[]} regions - flat region ids
+ * @param {number}   width   - the board frame's stroke width
+ * @param {string}   color   - the board frame's colour
+ * @param {function} inkAt   - (regionId) => the glyph ink for that region's fill
  */
 const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
-  const { gridSegments, regionSegments } = useMemo(() => {
-    const grid = [];
-    const region = [];
-    // Snapped once: every position below is derived from these, so the whole
-    // overlay sits on the device pixel grid.
-    const regionWidth = snapWidth(width);
-    const gridWidth = snapWidth(GRID_LINE_WIDTH);
-    const half = regionWidth / 2;
-    /** A line of `thickness` centered on edge position `p`, snapped. */
-    const lineAt = (p, thickness) => snap(p - thickness / 2);
+  const { lines, frame } = useMemo(() => {
+    const drawn = [];
+    const frameWidth = snapWidth(width);
+    const lineWidth = snapWidth(GRID_LINE_WIDTH);
+    /** A line of `lineWidth` centred on edge position `p`, snapped. */
+    const lineAt = (p) => snap(p - lineWidth / 2);
     const at = (row, col) => regions[row * size + col];
 
     /**
-     * What sits on one interior edge: a region boundary, or a grid line in the
-     * color of the region both sides share. The string is what run-merging
-     * compares, so two runs only merge when they would draw identically.
+     * The line on one interior edge, or null where the two cells belong to
+     * different regions — there the change of fill is the edge. The key is what
+     * run-merging compares, so two runs only merge when they draw identically.
      */
     const edge = (aRow, aCol, bRow, bCol) => {
-      const a = at(aRow, aCol);
-      const b = at(bRow, bCol);
-      if (a !== b) return { key: 'region', boundary: true };
-      const ink = gridInkFor(inkAt(a));
-      return { key: `grid:${ink}`, boundary: false, ink };
-    };
-
-    /**
-     * Where a run of region boundary starts and ends along its line.
-     *
-     * Interior ends are extended half a stroke so a corner or T-junction is
-     * filled by overlap rather than left as a notch — but an end that reaches
-     * the edge of the board is **clamped instead**. Extending there put the
-     * half-stroke *outside* the board, where nothing clips it, and it showed on
-     * device as small ticks poking past the frame. Clamped, the run still runs
-     * right into the frame band and joins it solidly.
-     */
-    const span = (index, last) => {
-      const from = index === 0 ? 0 : snap(index * cell - half);
-      const to = last === size ? size * cell : snap(last * cell + half);
-      return { from, to };
+      const region = at(aRow, aCol);
+      if (region !== at(bRow, bCol)) return null;
+      const ink = gridInkFor(inkAt(region));
+      return { key: ink, ink };
     };
 
     /** Walk one line of edges, emitting a rectangle per run of identical ones. */
@@ -132,8 +127,8 @@ const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
       let run = edgeAtIndex(0);
       for (let i = 1; i <= count; i++) {
         const next = i < count ? edgeAtIndex(i) : null;
-        if (!next || next.key !== run.key) {
-          emit(start, i, run);
+        if (next?.key !== run?.key) {
+          if (run) emit(start, i, run);
           start = i;
           run = next;
         }
@@ -145,26 +140,17 @@ const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
       walk(
         size,
         (col) => edge(r - 1, col, r, col),
-        (c0, c1, run) => {
-          if (run.boundary) {
-            const { from, to } = span(c0, c1);
-            region.push({
-              key: `h${r}-${c0}`,
-              style: { top: lineAt(r * cell, regionWidth), left: from, width: to - from, height: regionWidth },
-            });
-          } else {
-            grid.push({
-              key: `h${r}-${c0}`,
-              style: {
-                top: lineAt(r * cell, gridWidth),
-                left: c0 * cell,
-                width: (c1 - c0) * cell,
-                height: gridWidth,
-                backgroundColor: run.ink,
-              },
-            });
-          }
-        }
+        (c0, c1, run) =>
+          drawn.push({
+            key: `h${r}-${c0}`,
+            style: {
+              top: lineAt(r * cell),
+              left: c0 * cell,
+              width: (c1 - c0) * cell,
+              height: lineWidth,
+              backgroundColor: run.ink,
+            },
+          })
       );
     }
 
@@ -173,55 +159,43 @@ const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
       walk(
         size,
         (row) => edge(row, c - 1, row, c),
-        (r0, r1, run) => {
-          if (run.boundary) {
-            const { from, to } = span(r0, r1);
-            region.push({
-              key: `v${c}-${r0}`,
-              style: { left: lineAt(c * cell, regionWidth), top: from, height: to - from, width: regionWidth },
-            });
-          } else {
-            grid.push({
-              key: `v${c}-${r0}`,
-              style: {
-                left: lineAt(c * cell, gridWidth),
-                top: r0 * cell,
-                height: (r1 - r0) * cell,
-                width: gridWidth,
-                backgroundColor: run.ink,
-              },
-            });
-          }
-        }
+        (r0, r1, run) =>
+          drawn.push({
+            key: `v${c}-${r0}`,
+            style: {
+              left: lineAt(c * cell),
+              top: r0 * cell,
+              height: (r1 - r0) * cell,
+              width: lineWidth,
+              backgroundColor: run.ink,
+            },
+          })
       );
     }
 
-    // The frame, at the same weight as an interior boundary — which it was not
-    // before, when interior boundaries were double-drawn. Inset fully inside the
-    // board rather than centered on its edge, because the board's box *is* the
-    // touch geometry: `cellFromPoint` resolves taps against this origin, so
-    // nothing here may change where the board's top-left corner sits.
-    const frame = [
-      { key: 'top', style: { top: 0, left: 0, right: 0, height: regionWidth } },
-      { key: 'bottom', style: { bottom: 0, left: 0, right: 0, height: regionWidth } },
-      { key: 'left', style: { top: 0, bottom: 0, left: 0, width: regionWidth } },
-      { key: 'right', style: { top: 0, bottom: 0, right: 0, width: regionWidth } },
-    ];
-
-    return { gridSegments: grid, regionSegments: [...region, ...frame] };
+    // The frame. Inset fully inside the board rather than centred on its edge,
+    // because the board's box *is* the touch geometry: `cellFromPoint` resolves
+    // taps against this origin, so nothing here may move the board's corner.
+    return {
+      lines: drawn,
+      frame: [
+        { key: 'top', style: { top: 0, left: 0, right: 0, height: frameWidth } },
+        { key: 'bottom', style: { bottom: 0, left: 0, right: 0, height: frameWidth } },
+        { key: 'left', style: { top: 0, bottom: 0, left: 0, width: frameWidth } },
+        { key: 'right', style: { top: 0, bottom: 0, right: 0, width: frameWidth } },
+      ],
+    };
   }, [regions, size, cell, width, inkAt]);
 
   return (
     // Purely decorative, and the board owns every touch — the overlay must never
     // intercept one.
     <View style={StyleSheet.absoluteFill} pointerEvents="none">
-      {gridSegments.map((seg) => (
-        <View key={`g-${seg.key}`} style={[styles.segment, seg.style]} />
+      {lines.map((seg) => (
+        <View key={seg.key} style={[styles.segment, seg.style]} />
       ))}
-      {/* Region boundaries last, so they cover the grid lines they cross rather
-          than being interrupted by them. */}
-      {regionSegments.map((seg) => (
-        <View key={`r-${seg.key}`} style={[styles.segment, { backgroundColor: color }, seg.style]} />
+      {frame.map((seg) => (
+        <View key={`frame-${seg.key}`} style={[styles.segment, { backgroundColor: color }, seg.style]} />
       ))}
     </View>
   );

--- a/SudokuApp/games/fungiku/FungikuGridLines.js
+++ b/SudokuApp/games/fungiku/FungikuGridLines.js
@@ -2,87 +2,90 @@ import React, { useMemo } from 'react';
 import { View, StyleSheet, PixelRatio } from 'react-native';
 
 /**
- * The board's grid, drawn as one overlay on top of the cells.
- *
- * ### What is drawn, and what deliberately is not
- *
- * A line is drawn between two cells **of the same region**, and nowhere else.
- * Where two regions meet there is no line at all: the fills change colour, and
- * that colour edge *is* the boundary. Drawing a stroke there as well was drawing
- * the same information twice — see "the boundary stroke" below.
- *
- * So the overlay is: a thin line wherever a region continues into the next cell,
- * and a frame around the board.
+ * The board's lines — every grid line and every region boundary — drawn as one
+ * overlay on top of the cells.
  *
  * ### Why this is not per-cell borders
  *
- * It used to be: each cell set its own four border widths and colours. That is
- * the obvious way to do it and it produces three artifacts, all of which the
- * operator saw on device (2026-07-26) and none of which show in a desktop
- * browser:
+ * It used to be: each cell set its own four border widths and colors, thick
+ * where the neighboring cell belonged to a different region. That is the obvious
+ * way to do it and it produces three artifacts, all of which the operator saw on
+ * device (2026-07-26) and none of which are visible in a browser at desktop
+ * scale:
  *
- * 1. **Every interior line was drawn twice**, once by the cell on each side, so
- *    it rendered at double width while the board's frame was drawn once.
+ * 1. **Every interior region boundary was drawn twice** — once by the cell on
+ *    each side — so it rendered at double width, while the board's outer edge
+ *    was drawn once. Interior boundaries were literally twice the weight of the
+ *    frame around them.
  * 2. **Corners notched.** React Native miters adjacent borders, so a cell with a
- *    thick edge meeting a thin one gets a diagonal seam; where four cells meet,
- *    four independent miters fail to line up.
- * 3. **Borders draw *inside* the cell box**, so a line ate width off both
- *    neighbours' fills — an eighth of the cell at 32px.
+ *    thick top edge and a hairline left edge gets a diagonal seam between the
+ *    two where they meet. Where four cells meet at a region corner there are
+ *    four independent miters, and they do not line up.
+ * 3. **Borders are drawn *inside* the cell box**, so a boundary ate 2px off both
+ *    neighbors' fills. At 32px cells that is an eighth of the cell.
  *
- * Rectangles fix all three by construction: each edge is drawn exactly once, at
- * a width that does not depend on how many cells touch it, centred on the edge
- * rather than inside one cell.
+ * Drawing the lines as absolutely-positioned rectangles fixes all three by
+ * construction: each edge is drawn exactly **once**, at a width that does not
+ * depend on how many cells touch it, **centered on the edge** rather than inside
+ * one cell, and with region segments extended by half a stroke at each end so
+ * corners and T-junctions fill in solid instead of mitering.
  *
- * ### The boundary stroke, and why it went away
+ * Collinear runs are merged, so a boundary that follows a whole row is one View
+ * and not ten. The whole overlay depends only on the puzzle, never on the
+ * player's marks, so it is memoized and does not re-render on taps.
  *
- * Region boundaries used to be drawn as a heavy stroke, on the reasoning that
- * region outlines are the board's structure the way box lines are in Sudoku
- * (plan §3). They are not the same case. Sudoku's boxes are invisible without
- * their lines; a Fungiku region is a **colour**, and ten of them are tuned to be
- * distinguishable by a measured margin (plan §12.2). The stroke was a second
- * rendering of information the fill already carried, and it cost the geometry
- * that produced every artifact above — the double-drawing, the mitering, the
- * half-stroke extensions needed to close corners, and the ticks where those
- * extensions ran past the frame.
+ * ### The boundary stroke is deliberate — it was removed once and put back
  *
- * Removing it makes colour the **only** channel for region identity. That is a
- * real trade for a colourblind player, and the reason `corners` in
- * `utils/symbolSets.js` still exists unused: if the boundary is ever wanted back
- * as an accessibility channel, a shape cue is the cheaper way to pay for it than
- * a stroke on every edge.
+ * It is a fair question whether it earns its keep: a region is a *color*, the ten
+ * fills are tuned to a measured separation floor (plan §12.2), and where two
+ * regions meet the change of fill already marks the edge. Drawing a stroke there
+ * as well is, for a player with normal color vision, the same information twice.
+ * Removing it also deletes every special case in this file — the run extension,
+ * the clamping, the two widths.
  *
- * Collinear runs are merged, so a row of same-region cells is one View and not
- * ten. The overlay depends only on the puzzle, never on the player's marks, so
- * it is memoized and does not re-render on taps.
+ * It was tried without (2026-07-26) and **put back at the operator's call, for
+ * colorblind players.** That is the case color alone does not cover: when two
+ * adjacent fills are hard to tell apart, the stroke is what still says *the
+ * region ends here*. It is a second channel, not decoration — the same reason
+ * conflicts are signalled by a ring **and** a color, and the reason the palette
+ * is checked under dichromat simulation rather than by ΔE alone.
+ *
+ * **So do not remove it as a simplification.** Simplifying this file is not worth
+ * the channel, and that trade has already been made once.
  */
 
 /**
- * Grid lines take their colour from the fill they sit on, the same way glyph ink
- * does, rather than from the theme.
+ * Grid lines *within* a region take their color from the fill they sit on, the
+ * same way glyph ink does, rather than from the theme.
  *
  * The theme's `grid.cellBorder` is tuned for Sudoku's white cells — in the
  * Pastel theme it is `#d0d8e6`, which simply disappears on a saturated orange or
  * green region fill. That is what "the grid lines could use some darker lines"
  * was about. A contrast-picked ink at low alpha is legible on every fill in the
- * palette by construction. A line only ever sits between two cells of the *same*
- * region, so there is exactly one fill to be legible against.
+ * palette by construction.
  */
 const gridInkFor = (ink) => (ink === '#ffffff' ? '#ffffff66' : '#1a1a1a5e');
 
 // One physical-ish line rather than StyleSheet.hairlineWidth: a third of a pixel
-// at low alpha is what made these vanish.
+// at low alpha is what made these vanish. Region boundaries stay clearly the
+// heavier of the two — that contrast is the board's structure (plan §3).
 const GRID_LINE_WIDTH = 1;
 
 /**
  * Round a length to a whole number of **device** pixels.
  *
- * This is the difference between a line and a smear. A line centred on a cell
- * edge lands at a half logical pixel — `y = 35.5, height = 1` — and on a 3×
- * screen that is device rows 106.5 to 109.5. The renderer cannot draw half a
+ * This is the difference between a line and a smear, and it is why the grid
+ * still looked patchy after the overlay fixed everything else. A line centered on
+ * a cell edge lands at a half logical pixel — `y = 35.5, height = 1` — and on a
+ * 3× screen that is device rows 106.5 to 109.5. The renderer cannot draw half a
  * pixel, so it antialiases: 50% coverage, 100%, 100%, 50%. Multiply that by the
  * line's own 37% alpha and the edges all but vanish, unevenly, depending on the
- * fill behind them. On device that read as "the grid has misses" when in fact
- * every edge was drawn (plan §12.5).
+ * fill behind them.
+ *
+ * Region boundaries never showed the problem because their width happened to put
+ * them on integers at the sizes that shipped — which is exactly the kind of
+ * accident that makes this look like "some lines are missing" rather than "every
+ * thin line is half a pixel off".
  *
  * Snapping both the position *and* the thickness means every line covers whole
  * device pixels at full strength.
@@ -93,32 +96,53 @@ const snap = (value) => PixelRatio.roundToNearestPixel(value);
 const snapWidth = (value) => Math.max(StyleSheet.hairlineWidth, snap(value));
 
 /**
- * @param {number}   size    - N
- * @param {number}   cell    - cell size in px
- * @param {number[]} regions - flat region ids
- * @param {number}   width   - the board frame's stroke width
- * @param {string}   color   - the board frame's colour
- * @param {function} inkAt   - (regionId) => the glyph ink for that region's fill
+ * @param {number}   size   - N
+ * @param {number}   cell   - cell size in px
+ * @param {number[]} regions- flat region ids
+ * @param {number}   width  - region-boundary stroke width
+ * @param {string}   color  - region-boundary color
+ * @param {function} inkAt  - (regionId) => the glyph ink for that region's fill
  */
 const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
-  const { lines, frame } = useMemo(() => {
-    const drawn = [];
-    const frameWidth = snapWidth(width);
-    const lineWidth = snapWidth(GRID_LINE_WIDTH);
-    /** A line of `lineWidth` centred on edge position `p`, snapped. */
-    const lineAt = (p) => snap(p - lineWidth / 2);
+  const { gridSegments, regionSegments } = useMemo(() => {
+    const grid = [];
+    const region = [];
+    // Snapped once: every position below is derived from these, so the whole
+    // overlay sits on the device pixel grid.
+    const regionWidth = snapWidth(width);
+    const gridWidth = snapWidth(GRID_LINE_WIDTH);
+    const half = regionWidth / 2;
+    /** A line of `thickness` centered on edge position `p`, snapped. */
+    const lineAt = (p, thickness) => snap(p - thickness / 2);
     const at = (row, col) => regions[row * size + col];
 
     /**
-     * The line on one interior edge, or null where the two cells belong to
-     * different regions — there the change of fill is the edge. The key is what
-     * run-merging compares, so two runs only merge when they draw identically.
+     * What sits on one interior edge: a region boundary, or a grid line in the
+     * color of the region both sides share. The string is what run-merging
+     * compares, so two runs only merge when they would draw identically.
      */
     const edge = (aRow, aCol, bRow, bCol) => {
-      const region = at(aRow, aCol);
-      if (region !== at(bRow, bCol)) return null;
-      const ink = gridInkFor(inkAt(region));
-      return { key: ink, ink };
+      const a = at(aRow, aCol);
+      const b = at(bRow, bCol);
+      if (a !== b) return { key: 'region', boundary: true };
+      const ink = gridInkFor(inkAt(a));
+      return { key: `grid:${ink}`, boundary: false, ink };
+    };
+
+    /**
+     * Where a run of region boundary starts and ends along its line.
+     *
+     * Interior ends are extended half a stroke so a corner or T-junction is
+     * filled by overlap rather than left as a notch — but an end that reaches
+     * the edge of the board is **clamped instead**. Extending there put the
+     * half-stroke *outside* the board, where nothing clips it, and it showed on
+     * device as small ticks poking past the frame. Clamped, the run still runs
+     * right into the frame band and joins it solidly.
+     */
+    const span = (index, last) => {
+      const from = index === 0 ? 0 : snap(index * cell - half);
+      const to = last === size ? size * cell : snap(last * cell + half);
+      return { from, to };
     };
 
     /** Walk one line of edges, emitting a rectangle per run of identical ones. */
@@ -127,8 +151,8 @@ const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
       let run = edgeAtIndex(0);
       for (let i = 1; i <= count; i++) {
         const next = i < count ? edgeAtIndex(i) : null;
-        if (next?.key !== run?.key) {
-          if (run) emit(start, i, run);
+        if (!next || next.key !== run.key) {
+          emit(start, i, run);
           start = i;
           run = next;
         }
@@ -140,17 +164,26 @@ const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
       walk(
         size,
         (col) => edge(r - 1, col, r, col),
-        (c0, c1, run) =>
-          drawn.push({
-            key: `h${r}-${c0}`,
-            style: {
-              top: lineAt(r * cell),
-              left: c0 * cell,
-              width: (c1 - c0) * cell,
-              height: lineWidth,
-              backgroundColor: run.ink,
-            },
-          })
+        (c0, c1, run) => {
+          if (run.boundary) {
+            const { from, to } = span(c0, c1);
+            region.push({
+              key: `h${r}-${c0}`,
+              style: { top: lineAt(r * cell, regionWidth), left: from, width: to - from, height: regionWidth },
+            });
+          } else {
+            grid.push({
+              key: `h${r}-${c0}`,
+              style: {
+                top: lineAt(r * cell, gridWidth),
+                left: c0 * cell,
+                width: (c1 - c0) * cell,
+                height: gridWidth,
+                backgroundColor: run.ink,
+              },
+            });
+          }
+        }
       );
     }
 
@@ -159,43 +192,55 @@ const FungikuGridLines = ({ size, cell, regions, width, color, inkAt }) => {
       walk(
         size,
         (row) => edge(row, c - 1, row, c),
-        (r0, r1, run) =>
-          drawn.push({
-            key: `v${c}-${r0}`,
-            style: {
-              left: lineAt(c * cell),
-              top: r0 * cell,
-              height: (r1 - r0) * cell,
-              width: lineWidth,
-              backgroundColor: run.ink,
-            },
-          })
+        (r0, r1, run) => {
+          if (run.boundary) {
+            const { from, to } = span(r0, r1);
+            region.push({
+              key: `v${c}-${r0}`,
+              style: { left: lineAt(c * cell, regionWidth), top: from, height: to - from, width: regionWidth },
+            });
+          } else {
+            grid.push({
+              key: `v${c}-${r0}`,
+              style: {
+                left: lineAt(c * cell, gridWidth),
+                top: r0 * cell,
+                height: (r1 - r0) * cell,
+                width: gridWidth,
+                backgroundColor: run.ink,
+              },
+            });
+          }
+        }
       );
     }
 
-    // The frame. Inset fully inside the board rather than centred on its edge,
-    // because the board's box *is* the touch geometry: `cellFromPoint` resolves
-    // taps against this origin, so nothing here may move the board's corner.
-    return {
-      lines: drawn,
-      frame: [
-        { key: 'top', style: { top: 0, left: 0, right: 0, height: frameWidth } },
-        { key: 'bottom', style: { bottom: 0, left: 0, right: 0, height: frameWidth } },
-        { key: 'left', style: { top: 0, bottom: 0, left: 0, width: frameWidth } },
-        { key: 'right', style: { top: 0, bottom: 0, right: 0, width: frameWidth } },
-      ],
-    };
+    // The frame, at the same weight as an interior boundary — which it was not
+    // before, when interior boundaries were double-drawn. Inset fully inside the
+    // board rather than centered on its edge, because the board's box *is* the
+    // touch geometry: `cellFromPoint` resolves taps against this origin, so
+    // nothing here may change where the board's top-left corner sits.
+    const frame = [
+      { key: 'top', style: { top: 0, left: 0, right: 0, height: regionWidth } },
+      { key: 'bottom', style: { bottom: 0, left: 0, right: 0, height: regionWidth } },
+      { key: 'left', style: { top: 0, bottom: 0, left: 0, width: regionWidth } },
+      { key: 'right', style: { top: 0, bottom: 0, right: 0, width: regionWidth } },
+    ];
+
+    return { gridSegments: grid, regionSegments: [...region, ...frame] };
   }, [regions, size, cell, width, inkAt]);
 
   return (
     // Purely decorative, and the board owns every touch — the overlay must never
     // intercept one.
     <View style={StyleSheet.absoluteFill} pointerEvents="none">
-      {lines.map((seg) => (
-        <View key={seg.key} style={[styles.segment, seg.style]} />
+      {gridSegments.map((seg) => (
+        <View key={`g-${seg.key}`} style={[styles.segment, seg.style]} />
       ))}
-      {frame.map((seg) => (
-        <View key={`frame-${seg.key}`} style={[styles.segment, { backgroundColor: color }, seg.style]} />
+      {/* Region boundaries last, so they cover the grid lines they cross rather
+          than being interrupted by them. */}
+      {regionSegments.map((seg) => (
+        <View key={`r-${seg.key}`} style={[styles.segment, { backgroundColor: color }, seg.style]} />
       ))}
     </View>
   );

--- a/SudokuApp/games/fungiku/FungikuScreen.js
+++ b/SudokuApp/games/fungiku/FungikuScreen.js
@@ -1,5 +1,13 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Platform, ScrollView, TouchableOpacity } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Platform,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import ScreenHeader from '../../components/ScreenHeader';
 import useAppTheme from '../../hooks/useAppTheme';
@@ -51,6 +59,7 @@ const FungikuScreenContent = ({ onExitToHub }) => {
     revealMushroom,
     dismissHint,
     canReveal,
+    generating,
   } = useFungikuContext();
 
   const titleColor = theme.colors.title;
@@ -60,11 +69,13 @@ const FungikuScreenContent = ({ onExitToHub }) => {
   // The status line follows the state of play instead of always explaining the
   // tap cycle. (Named `statusText`, not `hint` — `hint` is the hint object from
   // context, and shadowing it here silently broke the build once.)
-  const statusText = solved
-    ? 'One per row, column and color — none touching'
-    : conflicts.size > 0
-      ? `${conflicts.size} mushroom${conflicts.size === 1 ? '' : 's'} breaking a rule`
-      : 'Tap to cycle · drag to sweep ✕';
+  const statusText = generating
+    ? 'Generating…'
+    : solved
+      ? 'One per row, column and color — none touching'
+      : conflicts.size > 0
+        ? `${conflicts.size} mushroom${conflicts.size === 1 ? '' : 's'} breaking a rule`
+        : 'Tap to cycle · drag to sweep ✕';
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
@@ -86,16 +97,35 @@ const FungikuScreenContent = ({ onExitToHub }) => {
         scrollEnabled={!boardTouchActive}
         {...(Platform.OS === 'ios' ? { canCancelContentTouches: false } : null)}
       >
-        {/* The `🍄 X/N` counter (plan §1) — how the player tracks the goal. */}
+        {/* The `🍄 X/N` counter (plan §1) — how the player tracks the goal, and
+            where a big board's generation hitch is announced (plan §12.1).
+
+            The "Generating…" state deliberately lives *inside this row* rather
+            than in a banner of its own. A view that mounts above the board moves
+            the board, which invalidates the origin every touch is resolved
+            against — the bug behind the hint banner's re-measure effect. This row
+            is always mounted and keeps its height, so the board never moves and
+            there is no origin to invalidate. */}
         <View style={[styles.counterRow, { backgroundColor: surface, borderColor: border }]}>
-          <MaterialCommunityIcons name="mushroom" size={20} color={titleColor} />
+          {generating ? (
+            <ActivityIndicator size="small" color={titleColor} />
+          ) : (
+            <MaterialCommunityIcons name="mushroom" size={20} color={titleColor} />
+          )}
           <Text
             style={[styles.counterText, { color: titleColor }]}
             accessibilityLabel={`${mushroomCount} of ${size} mushrooms placed`}
           >
             {mushroomCount}/{size}
           </Text>
-          <Text style={[styles.counterHint, { color: titleColor }]}>{statusText}</Text>
+          <Text
+            style={[styles.counterHint, { color: titleColor }]}
+            // Announced, because a player who cannot see the spinner still needs
+            // to know why the board stopped responding.
+            accessibilityLiveRegion={generating ? 'polite' : 'none'}
+          >
+            {statusText}
+          </Text>
         </View>
 
         {/* Hint output (plan §11.2). A hint is an explicit request, so its
@@ -249,19 +279,26 @@ const FungikuScreenContent = ({ onExitToHub }) => {
           </TouchableOpacity>
         </View>
 
-        {/* Board size + next puzzle — the stand-in for the ladder step */}
+        {/* Board size + next puzzle — the stand-in for the ladder step.
+
+            Six chips no longer fit one row on a narrow phone (6 × ~56pt beats a
+            360pt screen), so the row wraps rather than squeezing the chips down
+            to something hard to hit. */}
         <Text style={[styles.label, { color: titleColor }]}>Board size</Text>
-        <View style={styles.controlRow}>
+        <View style={[styles.controlRow, styles.chipRow]}>
           {SIZES.map((option) => (
             <TouchableOpacity
               key={option}
               onPress={() => changeSize(option)}
+              disabled={generating}
               style={[
                 styles.chip,
                 { borderColor: border },
                 option === size && { backgroundColor: titleColor, borderColor: titleColor },
+                generating && styles.toolButtonDisabled,
               ]}
               accessibilityRole="button"
+              accessibilityState={{ disabled: generating, selected: option === size }}
               accessibilityLabel={`${option} by ${option} board`}
             >
               <Text style={[styles.chipText, { color: option === size ? surface : titleColor }]}>
@@ -274,8 +311,16 @@ const FungikuScreenContent = ({ onExitToHub }) => {
         <View style={styles.controlRow}>
           <TouchableOpacity
             onPress={nextPuzzle}
-            style={[styles.wideButton, { borderColor: border }]}
+            // A second tap while the top size is still generating would only
+            // queue work the first tap is already doing.
+            disabled={generating}
+            style={[
+              styles.wideButton,
+              { borderColor: border },
+              generating && styles.toolButtonDisabled,
+            ]}
             accessibilityRole="button"
+            accessibilityState={{ disabled: generating }}
             accessibilityLabel="Generate the next puzzle"
           >
             <MaterialCommunityIcons name="dice-multiple" size={18} color={titleColor} />
@@ -406,12 +451,18 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     marginTop: 18,
   },
+  chipRow: {
+    flexWrap: 'wrap',
+    alignSelf: 'stretch',
+  },
   chip: {
     paddingVertical: 6,
     paddingHorizontal: 12,
     borderRadius: 8,
     borderWidth: 1,
     marginHorizontal: 4,
+    // Spacing for the second row once the chips wrap.
+    marginVertical: 3,
   },
   chipText: {
     fontSize: 13,

--- a/SudokuApp/games/fungiku/__tests__/engine.test.js
+++ b/SudokuApp/games/fungiku/__tests__/engine.test.js
@@ -1,6 +1,8 @@
 import {
   MARKS,
+  MAX_SIZE,
   MIN_SIZE,
+  SIZES,
   nextMark,
   createRng,
   generate,
@@ -14,9 +16,38 @@ import {
   findForcedDeduction,
 } from '../engine';
 
-// Sizes the v1 ladder ships (plan §8). Kept small so the suite stays fast.
-const LADDER = [5, 6, 7, 8];
+// Every size the game offers, the new top sizes included (plan §12).
+const LADDER = SIZES;
 const SEEDS = [1, 2, 3, 7, 42, 1337];
+
+/**
+ * The top size runs against fewer seeds, because generating a 10×10 is not free:
+ * ~0.4s each in plain node, and **~3s each under Jest**, whose transform costs
+ * roughly 7× here. Six seeds at 10×10 put 20 seconds on a suite that otherwise
+ * runs in under three, which is enough friction to stop people running it.
+ *
+ * Two seeds still exercise every invariant at the big sizes; the smaller boards
+ * keep the full six, and they are where a rule bug would show up anyway. Every
+ * 10×10 generation in this file is deliberate — there are three.
+ */
+const BIG_SIZE_SEEDS = [1, 3];
+const seedsFor = (size) => (size >= 9 ? BIG_SIZE_SEEDS : SEEDS);
+
+/**
+ * A ceiling on generation work at the top size, in **perturbation rounds** — not
+ * milliseconds, which would measure the CI runner and flake accordingly. Rounds
+ * are a property of the algorithm and identical on every machine.
+ *
+ * Why this bound exists at all (plan §12.1): cost rises by roughly an order of
+ * magnitude per size above 10 — 10×10 284 ms, 11×11 2.5 s, 12×12 7.3 s. 10×10
+ * sits one step below that cliff, so a change that made the uniqueness loop
+ * modestly less effective would turn the top size from a hitch into a freeze
+ * with no other symptom, and nothing else in the suite would notice.
+ *
+ * The sampled seeds currently need 455 rounds in total. The ceiling is generous
+ * enough not to fail on an unlucky re-tune, tight enough to catch a doubling.
+ */
+const TOP_SIZE_ROUND_BUDGET = 1200;
 
 /** Orthogonal flood fill — an independent contiguity check for a region. */
 const regionIsContiguous = (regions, size, region) => {
@@ -108,11 +139,37 @@ describe('generate', () => {
     expect(() => generate({ size: MIN_SIZE, seed: 1 })).not.toThrow();
   });
 
+  /**
+   * The upper bound is the half of this that did not exist. `generate()` used to
+   * accept any size at all — asked for 12×12 it took 7 seconds, and asked for 20
+   * it simply never returned. These sizes are rejected up front, cheaply, rather
+   * than discovered by waiting.
+   */
+  it.each([MAX_SIZE + 1, 12, 20])('rejects size %i as beyond the ceiling (plan §12)', (size) => {
+    expect(() => generate({ size, seed: 1 })).toThrow(/size/i);
+  });
+
+  it(`tops the ladder out at ${MAX_SIZE}`, () => {
+    // That the top size *generates* is the whole battery below; this is only
+    // about where the ceiling sits.
+    expect(MAX_SIZE).toBe(10);
+  });
+
+  it('names the bounds in the error, so the caller knows what is allowed', () => {
+    expect(() => generate({ size: 99, seed: 1 })).toThrow(
+      new RegExp(`${MIN_SIZE}[^0-9]+${MAX_SIZE}`)
+    );
+  });
+
   describe.each(LADDER)('size %i', (size) => {
-    const puzzles = SEEDS.map((seed) => generate({ size, seed }));
+    const seeds = seedsFor(size);
+    const puzzles = seeds.map((seed) => generate({ size, seed }));
 
     it('is deterministic — same size+seed gives an identical puzzle', () => {
-      SEEDS.forEach((seed, i) => {
+      // One seed at the top size rather than all of them: re-generating is the
+      // whole cost of this test, and determinism does not vary by seed.
+      const repeat = size === MAX_SIZE ? seeds.slice(0, 1) : seeds;
+      repeat.forEach((seed, i) => {
         expect(generate({ size, seed })).toEqual(puzzles[i]);
       });
     });
@@ -182,17 +239,55 @@ describe('generate', () => {
     });
 
     it('echoes back the size and seed it was asked for', () => {
-      SEEDS.forEach((seed, i) => {
+      seeds.forEach((seed, i) => {
         expect(puzzles[i].size).toBe(size);
         expect(puzzles[i].seed).toBe(seed);
       });
     });
+
+    if (size === MAX_SIZE) {
+      it(`generates the top size within ${TOP_SIZE_ROUND_BUDGET} perturbation rounds`, () => {
+        const rounds = puzzles.reduce((total, p) => total + p.rounds, 0);
+
+        // Reported as an object so a regression says how far over it went
+        // instead of "6103 is not less than 5000" — the first thing anyone
+        // touching the uniqueness loop will want to know.
+        expect({ size, rounds, overBudget: rounds > TOP_SIZE_ROUND_BUDGET }).toEqual({
+          size,
+          rounds: expect.any(Number),
+          overBudget: false,
+        });
+      });
+    }
   });
 
   it('produces different puzzles for different seeds', () => {
     const a = generate({ size: 7, seed: 1 });
     const b = generate({ size: 7, seed: 2 });
     expect(a.regions).not.toEqual(b.regions);
+  });
+});
+
+/**
+ * SIZES is what the size chips render from. It lives here, next to the bounds it
+ * is derived from, so the sizes the UI offers and the sizes `generate()` accepts
+ * cannot drift — the previous copy was a hand-written list in the context file.
+ */
+describe('SIZES', () => {
+  it('is every size between the bounds, in order', () => {
+    expect(SIZES).toEqual([5, 6, 7, 8, 9, 10]);
+    expect(SIZES[0]).toBe(MIN_SIZE);
+    expect(SIZES[SIZES.length - 1]).toBe(MAX_SIZE);
+  });
+
+  it('offers nothing the generator would reject', () => {
+    // Bounds, not generation: every size here is run through `generate` by the
+    // battery above, and a 10×10 costs three seconds under Jest.
+    SIZES.forEach((size) => {
+      expect(Number.isInteger(size)).toBe(true);
+      expect(size).toBeGreaterThanOrEqual(MIN_SIZE);
+      expect(size).toBeLessThanOrEqual(MAX_SIZE);
+    });
   });
 });
 

--- a/SudokuApp/games/fungiku/engine.js
+++ b/SudokuApp/games/fungiku/engine.js
@@ -40,6 +40,29 @@ export function nextMark(mark) {
 export const MIN_SIZE = 5;
 
 /**
+ * Largest supported board (plan §12). Not a taste judgement — a measurement.
+ * Generation cost goes off a cliff one size above this:
+ *
+ *   8×8  6 ms median · 9×9 30 ms · **10×10 284 ms** · 11×11 2.5 s · 12×12 7.3 s
+ *
+ * and it runs synchronously on the main thread. 10 is the last size that is a
+ * hitch rather than a freeze, so it is the ceiling until the generator is made
+ * cheaper (four directions for that are kept in plan §12.1).
+ *
+ * Before this bound existed `generate()` would accept size 20 and simply never
+ * return. It is also what makes region colours safe: the palette holds exactly
+ * MAX_SIZE fills, so no two regions can ever share one (see utils/symbolSets.js).
+ */
+export const MAX_SIZE = 10;
+
+/**
+ * Every board size the game supports, derived from the bounds rather than
+ * written out. The size chips render straight from this, so a size the UI offers
+ * and a size the engine accepts cannot drift apart.
+ */
+export const SIZES = Array.from({ length: MAX_SIZE - MIN_SIZE + 1 }, (_, i) => MIN_SIZE + i);
+
+/**
  * mulberry32 — a tiny, fast, well-distributed seeded PRNG. Deterministic across
  * platforms, so a seed reproduces a puzzle exactly (plan §4) and a seed is
  * shareable.
@@ -329,18 +352,33 @@ const REGENERATE_BUDGET = 40;
  * Generate a Fungiku puzzle.
  *
  * @param {object}  opts
- * @param {number}  opts.size - board size N (>= MIN_SIZE)
+ * @param {number}  opts.size - board size N (MIN_SIZE..MAX_SIZE)
  * @param {number}  opts.seed - integer seed; same seed + size => same puzzle
- * @returns {{ size: number, seed: number, regions: number[], solution: number[] }}
+ * @returns {{ size: number, seed: number, regions: number[], solution: number[],
+ *            rounds: number }}
  *   `regions` is a flat size*size array of region ids; `solution[r]` is the
- *   column of row r's mushroom.
+ *   column of row r's mushroom. `rounds` is how many uniqueness passes it took —
+ *   see below.
+ *
+ * ### Why the result carries `rounds`
+ *
+ * Nearly all of generation's cost is the uniqueness loop, and 10×10 sits one
+ * size below a ten-times cliff: a change that made the loop modestly less
+ * effective would turn the top size from a 284 ms hitch into a freeze, with no
+ * other symptom. That needs a regression bound in the suite — and the bound
+ * cannot be milliseconds, which measure the CI runner rather than the code.
+ * `rounds` counts passes through the loop, which is a property of the algorithm
+ * and identical on every machine.
  */
 export function generate({ size, seed }) {
-  if (!Number.isInteger(size) || size < MIN_SIZE) {
-    throw new Error(`Fungiku board size must be an integer >= ${MIN_SIZE} (got ${size})`);
+  if (!Number.isInteger(size) || size < MIN_SIZE || size > MAX_SIZE) {
+    throw new Error(
+      `Fungiku board size must be an integer from ${MIN_SIZE} to ${MAX_SIZE} (got ${size})`
+    );
   }
 
   const rng = createRng(seed);
+  let rounds = 0;
 
   for (let attempt = 0; attempt < REGENERATE_BUDGET; attempt++) {
     const solution = findPlacement(size, rng);
@@ -352,9 +390,10 @@ export function generate({ size, seed }) {
     // (its mushroom cells are never reassigned), so the puzzle we return always
     // has the placement we generated as its unique answer.
     for (let i = 0; i < PERTURB_BUDGET; i++) {
+      rounds++;
       const sols = findSolutions(regions, size, 2);
       if (sols.length === 1) {
-        return { size, seed, regions, solution };
+        return { size, seed, regions, solution, rounds };
       }
 
       // Prefer surgically breaking a solution that isn't ours; fall back to a

--- a/SudokuApp/utils/__tests__/color.test.js
+++ b/SudokuApp/utils/__tests__/color.test.js
@@ -1,4 +1,5 @@
 import {
+  CVD_TYPES,
   closestPair,
   contrastRatio,
   deltaE,
@@ -8,6 +9,7 @@ import {
   readableOn,
   relativeLuminance,
   rgbToHex,
+  simulateCvd,
 } from '../color';
 
 describe('hex and rgb', () => {
@@ -115,5 +117,61 @@ describe('closestPair', () => {
 
   it('reports Infinity for a list too short to have a pair', () => {
     expect(closestPair(['#000000']).distance).toBe(Infinity);
+  });
+});
+
+describe('simulateCvd', () => {
+  it('covers the three dichromacies', () => {
+    expect(CVD_TYPES).toEqual(['protan', 'deutan', 'tritan']);
+  });
+
+  it('keeps every row of every matrix summing to 1', () => {
+    // Which is to say: a neutral survives simulation. This is the property that
+    // catches the wrong matrices — the LMS-space form of these same matrices
+    // looks plausible, applies cleanly, and turns mid-gray into teal.
+    ['#000000', '#404040', '#808080', '#c0c0c0', '#ffffff'].forEach((gray) => {
+      CVD_TYPES.forEach((type) => {
+        expect(simulateCvd(gray, type)).toBe(gray);
+      });
+    });
+  });
+
+  it('collapses red and green onto one confusion line for the red-green types', () => {
+    // A protan or deutan sees red and green as the same hue at different
+    // lightnesses, and the matrices say so literally: the simulated red and
+    // green channels come out equal.
+    ['protan', 'deutan'].forEach((type) => {
+      ['#d55e00', '#009e73', '#0072b2'].forEach((hex) => {
+        const { r, g } = hexToRgb(simulateCvd(hex, type));
+        expect(Math.abs(r - g)).toBeLessThanOrEqual(1); // ±1 for sRGB rounding
+      });
+    });
+  });
+
+  it('pulls red and green together for the red-green types, and not for tritan', () => {
+    // Note what this pair does *not* show: Okabe-Ito's vermillion and bluish
+    // green stay well apart under deutan, because the palette was designed to
+    // survive it through lightness. That robustness is what the region fills
+    // spend when they are tinted toward the theme surface — which is why the
+    // palette is checked under simulation rather than assumed safe.
+    const apart = deltaE('#d55e00', '#009e73');
+    const under = (type) =>
+      deltaE(simulateCvd('#d55e00', type), simulateCvd('#009e73', type));
+
+    expect(under('protan')).toBeLessThan(apart);
+    expect(under('deutan')).toBeLessThan(apart);
+    expect(under('tritan')).toBeGreaterThan(apart * 0.9);
+  });
+
+  it('returns the color unchanged for an unknown type', () => {
+    expect(simulateCvd('#d55e00', 'nope')).toBe('#d55e00');
+  });
+
+  it('stays inside the sRGB gamut', () => {
+    ['#ff0000', '#00ff00', '#0000ff', '#f0e442'].forEach((hex) => {
+      CVD_TYPES.forEach((type) => {
+        expect(simulateCvd(hex, type)).toMatch(/^#[0-9a-f]{6}$/);
+      });
+    });
   });
 });

--- a/SudokuApp/utils/__tests__/symbolSets.test.js
+++ b/SudokuApp/utils/__tests__/symbolSets.test.js
@@ -6,7 +6,8 @@ import {
   resolveSymbol,
   SYMBOL_SET_IDS,
 } from '../symbolSets';
-import { closestPair, contrastRatio, deltaE, hexToLab } from '../color';
+import { MAX_SIZE } from '../../games/fungiku/engine';
+import { CVD_TYPES, closestPair, contrastRatio, deltaE, hexToLab, simulateCvd } from '../color';
 
 /**
  * The region palette's readability is a *measured* property, not a matter of
@@ -16,13 +17,30 @@ import { closestPair, contrastRatio, deltaE, hexToLab } from '../color';
  * tests fail instead of the operator discovering it on a device.
  */
 
-// Comfortably below what the tuned palettes achieve (17.11 light / 18.55 dark),
-// but far above the ΔE 6.67 that motivated the fix.
+// Comfortably below what the tuned palettes achieve, but far above the ΔE 6.67
+// that motivated the fix.
 const MIN_PAIR_DISTANCE = 15;
 
 // WCAG 2.1 SC 1.4.11: non-text graphics need 3:1. Glyph ink aims higher.
 const MIN_GRAPHIC_CONTRAST = 3;
 const MIN_INK_CONTRAST = 4.5;
+
+/**
+ * What the nine-colour palette scored under dichromat simulation before the
+ * tenth colour was added — the bar the ten-colour palette had to clear.
+ *
+ * This is a **relative** bar on purpose. Simulation is a model, and a CIEDE2000
+ * distance between two simulated colours is not a calibrated measure of what a
+ * dichromat can tell apart. What it can honestly answer is "did adding a colour
+ * make this worse?", which is the question §12.2 asks.
+ *
+ * Recorded here rather than derived, because the nine-colour palette no longer
+ * exists to measure — re-tuning changed every fill.
+ */
+const NINE_COLOUR_CVD_BASELINE = {
+  light: { protan: 4.13, deutan: 5.44, tritan: 14.85 },
+  dark: { protan: 5.8, deutan: 6.38, tritan: 18.52 },
+};
 
 describe.each([
   ['light', REGION_PALETTES.light, { lMin: 65, lMax: 97 }],
@@ -30,8 +48,15 @@ describe.each([
 ])('the %s region palette', (mode, palette, band) => {
   const fills = palette.map((entry) => entry.background);
 
-  it('covers all nine regions', () => {
-    expect(palette).toHaveLength(9);
+  /**
+   * One fill per region at the largest board the engine will build. This is the
+   * assertion that makes a colour collision impossible rather than merely
+   * unlikely: `getRegionColor` no longer wraps, so if this ever fails the board
+   * draws magenta cells and logs — which is the point.
+   */
+  it(`covers every region of a ${MAX_SIZE}×${MAX_SIZE} board`, () => {
+    expect(palette.length).toBeGreaterThanOrEqual(MAX_SIZE);
+    expect(palette).toHaveLength(10);
   });
 
   it('has a stable name for every region', () => {
@@ -99,6 +124,38 @@ describe.each([
       );
     });
   });
+
+  /**
+   * ΔE for normal vision is not colourblind safety — different properties, and
+   * the tenth colour is where that stops being a footnote. A hue chosen purely
+   * to maximize separation for trichromats can land straight on top of an
+   * existing fill for a deutan, and every other test in this file would pass.
+   *
+   * So each dichromacy gets its own floor, set at what the nine-colour palette
+   * managed. Ten colours in the same lightness band have less room than nine, so
+   * holding this line was a constraint on the search, not a happy accident.
+   */
+  describe.each(CVD_TYPES)('as a %s sees it', (type) => {
+    const simulated = fills.map((fill) => simulateCvd(fill, type));
+    const floor = NINE_COLOUR_CVD_BASELINE[mode][type];
+
+    it(`keeps its worst pair at least ΔE ${floor} apart, as the nine did`, () => {
+      const worst = closestPair(simulated);
+      const name = (hex) => palette[simulated.indexOf(hex)]?.name;
+
+      expect({
+        worstPair: `${name(worst.a)} vs ${name(worst.b)}`,
+        belowBaseline: worst.distance < floor,
+      }).toEqual({
+        worstPair: expect.any(String),
+        belowBaseline: false,
+      });
+    });
+
+    it('still draws every region a different color', () => {
+      expect(new Set(simulated).size).toBe(simulated.length);
+    });
+  });
 });
 
 describe('getRegionPalette / getRegionColor', () => {
@@ -116,9 +173,45 @@ describe('getRegionPalette / getRegionColor', () => {
     expect(getRegionColor(0, true).background).toBe(REGION_PALETTES.dark[0].background);
   });
 
-  it('wraps around for ids beyond the palette', () => {
-    expect(getRegionColor(9).name).toBe(getRegionColor(0).name);
-    expect(getRegionColor(13).name).toBe(getRegionColor(4).name);
+  /**
+   * The bug this closes: `getRegionColor` used to wrap with
+   * `regionId % palette.length`, so on a 10-region board region 9 was drawn
+   * exactly like region 0. Region colour is how a player tells regions apart, so
+   * that is a wrong board rather than a caught error — and moving the wrap to 11
+   * would only relocate it.
+   */
+  it('gives every region of the largest board its own distinct color', () => {
+    const names = Array.from({ length: MAX_SIZE }, (_, id) => getRegionColor(id).name);
+    expect(new Set(names).size).toBe(MAX_SIZE);
+  });
+
+  it('does not wrap ids back onto earlier regions', () => {
+    expect(getRegionColor(MAX_SIZE - 1).name).not.toBe(getRegionColor(0).name);
+  });
+
+  describe('an id with no colour', () => {
+    let consoleError;
+
+    beforeEach(() => {
+      consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+    afterEach(() => consoleError.mockRestore());
+
+    // Unreachable from a board this app generates — `generate()` rejects sizes
+    // above MAX_SIZE — so this is about how the impossible case behaves: loudly,
+    // and without taking the screen down mid-render.
+    it('returns an unmistakable fill rather than a plausible wrong one', () => {
+      const entry = getRegionColor(999);
+      expect(entry.background).toBe('#FF00FF');
+      expect(entry.name).toBe('unknown region');
+    });
+
+    it('says so on the console, once per id', () => {
+      getRegionColor(1000);
+      getRegionColor(1000);
+      expect(consoleError).toHaveBeenCalledTimes(1);
+      expect(consoleError.mock.calls[0][0]).toMatch(/region 1000/);
+    });
   });
 
   it('keeps light and dark aligned so a region keeps its identity across themes', () => {

--- a/SudokuApp/utils/color.js
+++ b/SudokuApp/utils/color.js
@@ -191,6 +191,73 @@ export const deltaE = (hexA, hexB) => {
 };
 
 /**
+ * Dichromat simulation matrices (Viénot, Brettel & Mollon 1999) in the form
+ * composed for sRGB primaries, applied in **linear** sRGB. `protan` and `deutan`
+ * are the common red-green types; `tritan` is the rare blue-yellow one.
+ *
+ * Every row sums to 1, which is the property to check these against: it means a
+ * neutral stays neutral, because a gray has no hue for a dichromat to lose. The
+ * *other* well-known form of these matrices — `[0, 2.02344, -2.52581]` and
+ * friends — operates on LMS cone responses, not on RGB. Applying that one
+ * directly to linear RGB is a common shortcut and it is wrong: it turns mid-gray
+ * into teal, which is how this version got caught.
+ */
+const CVD_MATRICES = {
+  protan: [
+    [0.11238, 0.88762, 0],
+    [0.11238, 0.88762, 0],
+    [0.00401, -0.00401, 1],
+  ],
+  deutan: [
+    [0.29275, 0.70725, 0],
+    [0.29275, 0.70725, 0],
+    [-0.02234, 0.02234, 1],
+  ],
+  tritan: [
+    [1, 0.14461, -0.14461],
+    [0, 1, 0],
+    [0, 0.15117, 0.84883],
+  ],
+};
+
+/** The colour-vision deficiencies the palette is checked against. */
+export const CVD_TYPES = Object.keys(CVD_MATRICES);
+
+const linearToSrgb = (v) => {
+  const c = v <= 0.0031308 ? v * 12.92 : 1.055 * v ** (1 / 2.4) - 0.055;
+  return Math.max(0, Math.min(255, c * 255));
+};
+
+/**
+ * `hex` as a dichromat sees it.
+ *
+ * This exists because **ΔE and colourblind safety are different properties**, and
+ * the region palette needs both. Okabe–Ito was chosen for hues that survive the
+ * common CVD types — but the board tints those hues toward the theme surface, and
+ * tinting spends exactly the separation the palette was picked for. A tenth fill
+ * chosen only to maximize ΔE for normal vision can sit right on top of an
+ * existing one under deutan, and nothing else in the suite would notice.
+ *
+ * Simulation is a model, not a measurement: treat the numbers as a *relative*
+ * bar ("no worse than what already ships") rather than an absolute threshold.
+ * That is how `utils/__tests__/symbolSets.test.js` uses them.
+ */
+export const simulateCvd = (hex, type) => {
+  const m = CVD_MATRICES[type];
+  if (!m) return hex;
+
+  const { r, g, b } = hexToRgb(hex);
+  const v = [srgbToLinear(r), srgbToLinear(g), srgbToLinear(b)];
+  const out = m.map((row) => row[0] * v[0] + row[1] * v[1] + row[2] * v[2]);
+
+  return rgbToHex({
+    r: linearToSrgb(out[0]),
+    g: linearToSrgb(out[1]),
+    b: linearToSrgb(out[2]),
+  });
+};
+
+/**
  * The closest pair in a list of colors, as `{ a, b, distance }`. The palette
  * test asserts on this: a palette is only as readable as its worst pair.
  */
@@ -216,5 +283,7 @@ export default {
   readableOn,
   hexToLab,
   deltaE,
+  simulateCvd,
+  CVD_TYPES,
   closestPair,
 };

--- a/SudokuApp/utils/symbolSets.js
+++ b/SudokuApp/utils/symbolSets.js
@@ -49,10 +49,24 @@ const FUNGIKU_SWATCHES = {
 };
 
 /**
+ * The tenth region color (docs/fungiku-plan.md §12.2).
+ *
+ * **Region-only, and deliberately not a swatch.** The eight swatches above are
+ * Sudoku cell *values*, and there is no tenth value — this hue exists solely so
+ * a 10×10 Fungiku board has one fill per region. Adding it to FUNGIKU_SWATCHES
+ * would invent a symbol nothing can draw.
+ *
+ * It was searched for, not chosen: see the palette note below for the objective
+ * and what it had to beat.
+ */
+const REGION_ONLY = { color: '#96C115', name: 'lime' };
+
+/**
  * Region colors for the Fungiku board (docs/fungiku-plan.md §3). Regions reuse
  * the same colorblind-safe palette as the swatches above so there is exactly one
- * source of color truth; the mushroom's own red rounds the list out to nine, one
- * per region for boards up to 9×9.
+ * source of color truth; the mushroom's own red and the region-only lime round
+ * the list out to ten — one per region for boards up to 10×10, which is the
+ * engine's MAX_SIZE.
  *
  * Each entry carries the saturated `color` (borders, labels, emphasis), a
  * `background` that fills a whole cell, an `ink` color guaranteed to be legible
@@ -72,14 +86,38 @@ const FUNGIKU_SWATCHES = {
  * The fix is to vary **lightness as well as hue**: each hue gets its own tint
  * weight, chosen by maximizing the worst pairwise CIEDE2000 distance subject to
  * every fill staying inside a lightness band (so the board is still a soft grid,
- * not nine saturated blocks). That search gives:
+ * not ten saturated blocks), and clearing the contrast floors below.
  *
- *   light theme: worst pair ΔE 17.11, **0 of 36 pairs under 15**
- *   dark theme:  worst pair ΔE 18.55, 0 of 36 pairs under 15
+ * ### The tenth color, and why ΔE was not the objective that chose it
  *
- * `utils/__tests__/symbolSets.test.js` pins a floor under those numbers, so a
- * future "let's soften the palette" tweak fails a test instead of quietly
- * reintroducing the bug. Re-tune with the same objective rather than by eye.
+ * Nine fills covered boards to 9×9. At ten regions the old lookup wrapped and
+ * drew region 9 exactly like region 0, so the ceiling moving to 10×10 (§12)
+ * needed a tenth hue. Searching hue space for the one that maximized worst-pair
+ * ΔE produced palettes that scored *better* than today for normal vision and
+ * **worse than today under dichromat simulation** — the exact failure §12.2
+ * warned about. Okabe–Ito's colorblind safety lives at full saturation, and
+ * tinting toward the theme surface spends it.
+ *
+ * So the search was reframed: normal-vision separation is a **constraint** (may
+ * not fall below what the nine achieved) and colorblind separation is the
+ * **objective** maximized underneath it, over all three dichromacies and both
+ * themes. Every tint was re-tuned around the new hue. The result adds a color
+ * and improves all eight measured axes:
+ *
+ *              worst-pair ΔE      nine colors  →  ten colors
+ *   light      normal                   17.11  →  17.21
+ *              protan / deutan / tritan  4.13 / 5.44 / 14.85 → 6.73 / 5.80 / 16.21
+ *   dark       normal                   18.55  →  18.69
+ *              protan / deutan / tritan  5.80 / 6.38 / 18.52 → 6.31 / 6.79 / 19.21
+ *
+ * with 0 of 45 pairs under ΔE 15 in both themes.
+ *
+ * `utils/__tests__/symbolSets.test.js` pins a floor under all of it — the ΔE
+ * floor, the lightness band, the contrast ratios, and now the per-dichromacy
+ * baselines — so a future "let's soften the palette" tweak fails a test instead
+ * of quietly reintroducing the bug. **Re-tune with the same objective rather
+ * than by eye**, and remember that a swatch which looks distinct on your screen
+ * is not evidence about either property.
  */
 const HUE_ORDER = [
   ...Object.keys(FUNGIKU_SWATCHES)
@@ -87,12 +125,13 @@ const HUE_ORDER = [
     .sort((a, b) => a - b)
     .map((value) => FUNGIKU_SWATCHES[value]),
   MUSHROOM,
+  REGION_ONLY,
 ];
 
 // Order matches HUE_ORDER: orange, sky blue, green, yellow, blue, red, pink,
-// gray, mushroom-red. Tuned, not picked by hand — see the note above.
-const LIGHT_TINTS = [0.1, 0.76, 0.62, 0.1, 0.46, 0.62, 0.7, 0.44, 0.54];
-const DARK_TINTS = [0.7, 0.38, 0.55, 0.55, 0.54, 0.12, 0.24, 0.18, 0.55];
+// gray, mushroom-red, lime. Tuned, not picked by hand — see the note above.
+const LIGHT_TINTS = [0, 0, 0.2, 0.75, 0.77, 0.63, 0.49, 0.38, 0.44, 0.25];
+const DARK_TINTS = [0.38, 0.37, 0.18, 0.95, 0.53, 0.65, 0.24, 0.15, 0.04, 0.58];
 
 // What the fills are blended toward. Dark themes blend toward a dark surface
 // instead of white — pastel fills on a near-black background were the untested
@@ -136,10 +175,58 @@ export function getRegionPalette(isDark = false) {
   return isDark ? REGION_PALETTES.dark : REGION_PALETTES.light;
 }
 
-/** The palette entry for a region id, wrapping around if ids exceed the palette. */
+/**
+ * A fill that is unmistakably not part of the palette, returned when a region id
+ * has no colour of its own. It exists so that failure is *loud* — see below.
+ */
+const UNKNOWN_REGION = {
+  color: '#FF00FF',
+  name: 'unknown region',
+  background: '#FF00FF',
+  ink: '#000000',
+  conflictInk: '#000000',
+};
+
+// One report per bad id, not one per cell: a 10×10 board would otherwise log a
+// hundred identical lines and bury everything else.
+const reportedRegionIds = new Set();
+
+/**
+ * The palette entry for a region id.
+ *
+ * **This used to wrap** — `palette[regionId % palette.length]` — which was fine
+ * while boards held at most 9 regions and silently wrong the moment they held
+ * 10: region 9 came out the same colour as region 0, and region colour is how a
+ * player tells one region from another. A wrapping lookup does not fail, it just
+ * draws the wrong board.
+ *
+ * So there are now two lines of defence, and neither of them is a modulo:
+ *
+ * 1. **Impossible by construction.** The palette holds one fill per region up to
+ *    the engine's `MAX_SIZE`, and `generate()` rejects anything larger, so a
+ *    region id outside the palette cannot arise from a board this app built.
+ *    `utils/__tests__/symbolSets.test.js` pins that relationship.
+ * 2. **Loud if it happens anyway** — a corrupt save, or a future size increase
+ *    that forgets the palette. A magenta cell and a console error are both
+ *    impossible to miss, and unlike throwing they do not take the screen down
+ *    mid-render for what is a cosmetic failure.
+ */
 export function getRegionColor(regionId, isDark = false) {
   const palette = getRegionPalette(isDark);
-  return palette[regionId % palette.length];
+  const entry = palette[regionId];
+
+  if (!entry) {
+    if (!reportedRegionIds.has(regionId)) {
+      reportedRegionIds.add(regionId);
+      console.error(
+        `symbolSets: no colour for region ${regionId} — the palette holds ${palette.length}. ` +
+          'Boards with more regions than that are not supported; see MAX_SIZE in games/fungiku/engine.js.'
+      );
+    }
+    return UNKNOWN_REGION;
+  }
+
+  return entry;
 }
 
 /**

--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -296,8 +296,11 @@ to the next one — with the hub's Continue badge naming where you are.
 - **Board constants step down below 40px cells** (`tightCells` in
   `FungikuBoard`): conflict ring inset and stroke, mistake badge. That threshold
   leaves 5×5-8×8 as they were. **The 6px tap-vs-drag threshold was deliberately
-  left alone** — it is the one item in plan §12.3 that only a device can settle,
-  since web draws a 10×10 cell at 45px, larger than a native 5×5 cell.
+  left alone, and the operator confirmed on device that it holds at 10×10** — it
+  is about absolute finger travel, not cell size, so it needs no per-size
+  treatment. Note the shape of that question though: web draws a 10×10 cell at
+  45px, *larger* than a native 5×5 cell, so no browser check could have answered
+  it either way.
 - **The region-boundary stroke is deliberate, and settled.** It was removed on
   2026-07-26 (a region is a colour, so the stroke looked like the same
   information twice, and dropping it deleted 140 lines of special cases) and
@@ -338,4 +341,4 @@ to the next one — with the hub's Continue badge naming where you are.
 | 5 | Board UI — palette fix with a tested ΔE floor, themed + responsive board, animated win | merged to `epic/fungiku` (#71, `905bfa2`) |
 | 6 | Input ergonomics — drag to sweep X's, rule-out button | merged to `epic/fungiku` (#72, `e896fb6`) |
 | 7 | Feedback & hints — mistake flagging, forced-deduction nudge, reveal, placement pop | merged to `epic/fungiku` (#73, `12f72c3`) |
-| 8 | Bigger boards — `MAX_SIZE = 10`, a tenth region colour tuned for CVD, no-wrap `getRegionColor`, generation announced, legibility at 32px, cost bound in rounds, board lines redrawn as an overlay | this PR |
+| 8 | Bigger boards — `MAX_SIZE = 10`, a tenth region colour tuned for CVD, no-wrap `getRegionColor`, generation announced, legibility at 32px, cost bound in rounds, board lines redrawn as a snapped overlay | PR #75, **operator-tested on device** |

--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -306,6 +306,12 @@ to the next one — with the hub's Continue badge naming where you are.
   half a stroke so junctions fill by overlap. **If you add anything to it: it must
   keep `pointerEvents="none"` and must not change the board's box**, because
   `cellFromPoint` resolves every tap against that origin.
+- **Every line is snapped to the device pixel grid** (`PixelRatio.roundToNearestPixel`
+  on position *and* thickness). A 1px line centred on a cell edge lands at
+  `y = 35.5` → device rows 106.5-109.5 on a 3× screen, which antialiases into a
+  faint smear whose visibility depends on the fill behind it. That read as "the
+  grid has misses" when in fact every edge was drawn. **When a rendering bug
+  looks patternless, audit the geometry instead of the screenshot** — plan §12.5.
 - **Within-region grid lines take their colour from the fill, not the theme.**
   `grid.cellBorder` is tuned for Sudoku's white cells — in Pastel it is `#d0d8e6`,
   invisible on a saturated region fill. The contrast-picked ink at low alpha is

--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -298,13 +298,14 @@ to the next one — with the hub's Continue badge naming where you are.
   leaves 5×5-8×8 as they were. **The 6px tap-vs-drag threshold was deliberately
   left alone** — it is the one item in plan §12.3 that only a device can settle,
   since web draws a 10×10 cell at 45px, larger than a native 5×5 cell.
-- **There is no region-boundary stroke any more** (operator, 2026-07-26). A line
-  is drawn only between two cells of the *same* region; where regions meet, the
-  change of fill colour is the edge. §3's "region outlines are the board's
-  structure" no longer describes the board — a Sudoku box is invisible without
-  its line, a Fungiku region is a colour. **This makes colour the only channel
-  for region identity**; the unused `corners` shape cue in `utils/symbolSets.js`
-  is the cheap way to add a second one if that ever matters (plan §12.5).
+- **The region-boundary stroke is deliberate, and settled.** It was removed on
+  2026-07-26 (a region is a colour, so the stroke looked like the same
+  information twice, and dropping it deleted 140 lines of special cases) and
+  **put straight back at the operator's call, for colourblind players** — when
+  two adjacent fills are hard to tell apart, the stroke is what still says the
+  region ends here. **Do not remove it as a simplification; that experiment has
+  been run.** Plan §12.5. `corners` in `utils/symbolSets.js` is still available
+  as a third channel if one is ever wanted.
 - **Every line on the board is drawn by `FungikuGridLines`, not by cell borders**
   (plan §12.5, from an operator device report). Per-cell borders drew every
   interior region boundary **twice** — once by each neighbour, so at double the

--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -298,6 +298,13 @@ to the next one — with the hub's Continue badge naming where you are.
   leaves 5×5-8×8 as they were. **The 6px tap-vs-drag threshold was deliberately
   left alone** — it is the one item in plan §12.3 that only a device can settle,
   since web draws a 10×10 cell at 45px, larger than a native 5×5 cell.
+- **There is no region-boundary stroke any more** (operator, 2026-07-26). A line
+  is drawn only between two cells of the *same* region; where regions meet, the
+  change of fill colour is the edge. §3's "region outlines are the board's
+  structure" no longer describes the board — a Sudoku box is invisible without
+  its line, a Fungiku region is a colour. **This makes colour the only channel
+  for region identity**; the unused `corners` shape cue in `utils/symbolSets.js`
+  is the cheap way to add a second one if that ever matters (plan §12.5).
 - **Every line on the board is drawn by `FungikuGridLines`, not by cell borders**
   (plan §12.5, from an operator device report). Per-cell borders drew every
   interior region boundary **twice** — once by each neighbour, so at double the

--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -92,130 +92,92 @@ operator to test in Expo Go.**
 
 ---
 
-## Next step: **Step 8 — bigger boards, up to 10×10**
+## Next step: **Step 9 — the training ladder, and scoring**
 
-Branch: **`feature/fungiku-big-boards`** off `epic/fungiku`.
-Plan: **§12** end to end (all new, 2026-07-25), plus the §7 note "Why bigger
-boards come before the ladder".
+Branch: **`feature/fungiku-ladder`** off `epic/fungiku`.
+Plan: **§13** (research already gathered for this step — do not re-derive it),
+plus §7's "Why feedback and hints come before scoring".
 
 ### Why this step exists
 
-The ladder needs a ceiling, and it is now decided: **10×10**. The operator asked
-for 12×12 first; measuring the generator showed a 12×12 takes **7.3 seconds
-median and 41.8 seconds worst case**, synchronously on the main thread, so the
-target moved down to the last affordable size. Cost per size goes off a cliff:
+Fungiku is playable and now has a ceiling, but the only way to pick a board is a
+row of raw size chips. There is no sense of progression, nothing to come back
+for, and nothing that uses the two currencies the last two steps deliberately
+built: `hintsUsed` (counted and persisted per puzzle) and `selectMistakes`.
 
-| Size | median | worst |
-|------|--------|-------|
-| 8×8 | 6 ms | 25 ms |
-| 10×10 | **284 ms** | **584 ms** |
-| 11×11 | 2,536 ms | 5,096 ms |
-| 12×12 | 7,286 ms | 41,830 ms |
-
-**Read that as good news for this step.** The hard engineering problem — making
-the uniqueness loop cheap enough for 12×12 — is off the table. What remains is
-small and concrete:
-
-- **The palette wraps at 9.** `getRegionColor` does `regionId % palette.length`
-  over nine entries, so **at 10 regions, region 9 renders identically to region
-  0**. Region colour is the only way the player sees region boundaries, so that is
-  a correctness bug at the new top size. §12.2 measured that 10 well-chosen fills
-  reach worst-pair ΔE 23.78 — *better* separated than the 9 shipping today at
-  17.11 — so this is a one-colour problem with headroom.
-- **There is no upper bound at all.** `MIN_SIZE = 5` exists; `generate()` accepts
-  size 20 and never returns.
-- **Cells get to 32 px** at 10×10 inside the fixed 324pt native board, and several
-  constants were tuned against 5×5.
+The top end is settled — **10×10** — so the ladder can be denominated in sizes
+without being reworked later. That was the whole reason board sizes came first.
 
 ### Read first
 
-- **§12 of the plan.** Generation timings, the palette measurement, the
-  32-pixel legibility list, and (in §12.1) the four ranked approaches to
-  generation cost — kept for the day the ceiling might rise, **not work for this
-  step**. Do not re-derive any of it.
-- `SudokuApp/games/fungiku/engine.js` — `MIN_SIZE` and the perturbation loop
-  (`generate` → `findSolutions` → `breakSolution`, up to `PERTURB_BUDGET` rounds).
-  You are adding a bound here, not rewriting the loop.
-- `SudokuApp/utils/symbolSets.js` — `HUE_ORDER` + `LIGHT_TINTS`/`DARK_TINTS` build
-  both theme palettes; `getRegionColor` wraps. The `corners` shape cue in this
-  module is **defined but unused by the Fungiku board** — worth knowing the second
-  channel exists if the tenth colour proves hard to place.
-- `SudokuApp/utils/__tests__/symbolSets.test.js` — holds the ΔE 15 worst-pair
-  floor that today's palette clears at 17.11. Extending to 10 must keep it green;
-  §12.2 says that is comfortable.
-- `SudokuApp/hooks/useBoardSize.js` — fixed **324** on native, so a 10×10 cell is
-  **32 px** (web's 450 gives 45 px, which is why the browser will not show you the
-  problem).
-- `SudokuApp/games/fungiku/FungikuScreen.js` — where the size chips live. Four
-  chips become six; that is a layout question, not just a data one.
+- **§13 of the plan.** A level is a `{size, seed}` pair; the storage migration;
+  the timer question; the pointer to color-loop's ladder. All of it was
+  researched for this step and parked. Do not repeat that work.
+- `SudokuApp/games/fungiku/storage.js` — `FUNGIKU_STORAGE_VERSION` and what a
+  version mismatch does today (returns null; the board starts fresh).
+- `SudokuApp/games/fungiku/reducer.js` — `buildPuzzleState` is where a level
+  would be turned into a board, and `hintsUsed` already rides along in state.
+- `SudokuApp/games/fungiku/engine.js` — `SIZES`, `MIN_SIZE`, `MAX_SIZE`. The
+  ladder picks its rungs from this range; do not hand-write a size list again.
+- `SudokuApp/utils/gameProgress.js` → `describeFungikuProgress` — what the hub's
+  Continue badge says today.
+- The sibling repo's `games/colorloop/levels.ts` — a ladder with per-level star
+  thresholds, already built and worth copying the shape of.
 
 ### Scope — ONLY this
 
-1. **Add `MAX_SIZE = 10`** to the engine and reject above it, the same way sizes
-   below 5 are rejected today.
-2. **Add a 10th region colour per theme**, derived the same way §5's palette was —
-   maximize the worst pairwise CIEDE2000 distance under the lightness band. **Do
-   not eyeball it, and do not stop at ΔE:** check the new hue under colourblind
-   simulation (§12.2). Okabe–Ito was chosen for CVD survival, and one hue picked
-   purely to maximize ΔE for normal vision can still collide under deutan or
-   protan.
-3. **Make `getRegionColor` stop wrapping silently.** Two regions sharing a colour
-   must be impossible-by-construction or loud, not quiet — that is the bug class
-   this step is closing, and leaving the modulo in place just moves the boundary
-   to 11.
-4. **Sizes 9 and 10 reachable from the UI**, so the operator can actually play a
-   10×10 in Expo Go. Six chips need a layout that survives a narrow phone.
-5. **Confirm the generation hitch is acceptable at the top size** — 284 ms median,
-   584 ms worst, on the main thread. Either show a brief loading state or verify on
-   device that it is imperceptible. **Don't assume; a visible freeze on "New
-   puzzle" reads as a bug.**
-6. **A legibility pass at 32 px** (§12.3): mistake badge (`cell * 0.28` ≈ 9 px),
-   conflict ring, region borders, glyph size.
-7. **Tests** — the palette floor extended to 10 entries, `MAX_SIZE` rejection, and
-   a **generation-cost bound at the top size**. 10×10 sits one size below a
-   ten-times cliff, so a change that makes generation modestly slower would turn
-   the top size from *hitch* into *freeze* with no other symptom.
+1. **The ladder as data** — a table of `{size, seed}` rungs in its own module,
+   plus whatever per-level target the scoring lands on.
+2. **Progression + persistence.** This is the **first change that must not wipe
+   someone's progress**: bump `FUNGIKU_STORAGE_VERSION` and write a real
+   migration for the existing `{size, seed, marks, showMistakes, hintsUsed}`
+   shape. A version mismatch currently discards the save silently, which is fine
+   for a board and not fine for a ladder position.
+3. **A level-select surface** as the primary path into a game, with the size
+   chips kept as a free-play escape hatch (they are how a size gets checked by
+   hand).
+4. **Scoring**, denominated in what already exists — hints used, mistakes made.
+   **Whether Fungiku gets a timer is a decision to make explicitly, not to
+   inherit from Sudoku** (§13); a family puzzle that times you plays differently.
+5. **The hub's Continue badge** naming the level rather than the board size.
+6. **Tests** — above all, **assert that every rung in the table actually
+   generates**. A typo becomes a crash for whoever reaches that level.
 
 ### Behaviors that are easy to get wrong
 
-- **A timing test on CI is a flake factory.** Assert a generous ceiling, or count
-  perturbation rounds instead of milliseconds — rounds are machine-independent,
-  which is what you actually want from a regression bound.
-- **Re-tune the palette with the same objective, never by hand.** The test floor
-  exists precisely so a well-meaning hand-picked swatch can't quietly regress
-  separation.
-- **ΔE is not colourblind safety.** Different properties; one new hue is a small
-  risk, not no risk.
-- **The board's measured origin.** If this step adds anything above the board — a
-  generation spinner, for instance — it must go into the deps of `FungikuBoard`'s
-  re-measure effect, currently `[hint, solved, measure]`, or the first tap after it
-  appears lands on the wrong cell. `onLayout` will not save you; see the note
-  below.
-- **Smaller cells, same fingers.** The 6-pixel tap-vs-drag threshold was tuned
-  against roughly 40 px cells. At 32 px there is less room to press without
-  registering a stroke, and **that is a device question the browser cannot answer**
-  — web renders at 45 px, larger than native, so the browser is the wrong place to
-  judge any of §12.3.
+- **Generation cost is now a design input.** A 10×10 rung costs ~0.4s on the
+  machine that measured it and more on a phone. Any level-select screen that
+  generates boards to preview them, or pre-generates the next rung, will be slow
+  in a way the size chips never were. The `generating` flag and the deferral in
+  `FungikuContext` exist for exactly this and should be reused, not reinvented.
+- **A test that generates every rung is the slowest test in the suite.** Step 8's
+  numbers: a 10×10 takes ~3s *under Jest* (its transform costs ~7×), which is why
+  the engine battery samples two seeds at the top size. If the ladder has several
+  10×10 rungs, budget for it — or assert cheaply on bounds and generate a sample.
+- **The size chips are wired to `SIZES`, derived from the engine bounds.** If the
+  ladder gates sizes behind progression, that derivation is the thing to extend,
+  not to bypass with a second hand-written list.
+- **Anything new above the board joins `FungikuBoard`'s re-measure deps**,
+  currently `[hint, solved, generating, measure]`, or the first tap after it
+  appears lands on the wrong cell. A level banner is exactly that shape.
+- **`hintsUsed` resets per puzzle and `showMistakes` carries across**, by design
+  (`buildPuzzleState`). Scoring has to decide which side of that line it is on.
 
 ### Out of scope for this step
 
-- **No generator re-engineering.** §12.1's four approaches exist for the day the
-  ceiling might rise past 10. At 10 the generator is fast enough; leave it alone
-  and spend the step on the palette, the bound, and legibility.
-- **No ladder, no scoring** — Step 9. This step fixes the ceiling the ladder will
-  use; it does not build progression. Research already gathered for that step is
-  parked in plan **§13** so it isn't lost.
+- **No generator re-engineering.** §12.1's four approaches are for the day the
+  ceiling rises past 10. It isn't this step.
 - **No art swap** — Step 10, gated on artwork rather than code.
-- **No hint-strength work.** §12.4 found the forced-move nudge is shallow (2 of 10
-  deductions from an empty 10×10 board). Real, and worth doing — but strengthening
-  the propagator with pigeonhole reasoning is its own change. Note it in the PR;
-  don't smuggle it in.
+- **No hint-strength work.** §12.4 found the forced-move nudge is shallow (2 of
+  10 deductions from an empty 10×10). Real, and worth doing, but strengthening
+  the propagator with pigeonhole reasoning is its own change.
+- **No second channel for region identity.** Ten fills currently clear every
+  floor with room (§12.2), so the unused `corners` shape cue stays unused.
 
 ### Visible in Expo Go when this lands
 
-**A playable 10×10** — ten visibly different region colours with no repeat,
-legible marks at 32-pixel cells, and a "New puzzle" tap at the top size that
-doesn't read as a freeze.
+**A ladder you can climb**: pick a level, play it, see it recorded, and come back
+to the next one — with the hub's Continue badge naming where you are.
 
 ## Open questions for the operator (carry these forward)
 
@@ -230,9 +192,11 @@ doesn't read as a freeze.
 3. ~~**Hub vs. resume on launch**~~ — built hub-first in Step 3: the app opens on
    the hub and the Sudoku card carries a *Continue* badge. Revisit only if the
    operator dislikes it on device.
-4. **Ladder shape** — **top end decided: 10×10** (operator, 2026-07-25; plan
-   §12). 12×12 was asked for first and withdrawn once measured at 7.3 s to
-   generate. Still open: **is size a free choice or unlocked by progression?**
+4. **Ladder shape** — top end decided and now **built**: sizes 5×5 through
+   10×10 are all reachable from the size chips (plan §12). 12×12 was asked for
+   first and withdrawn once measured at 7.3 s to generate. Still open, and
+   **Step 9 needs an answer**: is size a free choice, or unlocked by progression?
+   Absent a steer it will ship as a ladder plus free play.
 5. ~~**Assist defaults**~~ — moot: the rule-out assist became a button you tap
    rather than a mode with a setting, so there is no default to choose. (§2)
 6. **How strong should hints go?** (§11) The ladder ends at *reveal a correct
@@ -310,10 +274,31 @@ doesn't read as a freeze.
   writes through to it when the player cycles themes — but Sudoku still hydrates
   its own `currentThemeName` from its own save. Making Sudoku read the shared key
   is the other half, and it touches Sudoku's hydration path, so it was left out.
-- **The region palette is tuned, not hand-picked.** `utils/symbolSets.js` derives
-  its fills from per-hue tint weights chosen by maximizing the worst pairwise
-  CIEDE2000 distance under a lightness band. `utils/__tests__/symbolSets.test.js`
-  holds the floor. **Re-tune with the same objective — do not eyeball it.**
+- **The region palette is tuned, not hand-picked — and ΔE is not its objective.**
+  `utils/symbolSets.js` derives ten fills from per-hue tint weights. Step 8
+  found that maximizing worst-pair CIEDE2000 for normal vision produces palettes
+  that are *worse than the previous one under dichromat simulation*, so the
+  objective is now inverted: normal-vision separation is a constraint (no worse
+  than before), colourblind separation is what gets maximized, and the contrast
+  floors are constraints on which tints are candidates at all. Plan §12.2 has
+  the numbers and the method. **Re-tune with that objective — do not eyeball it,
+  and do not "simplify" it back to ΔE.**
+- **Simulating colourblindness: check that gray stays gray.** The widely-copied
+  Viénot matrices come in two forms, and the LMS-space one applied to linear RGB
+  is wrong in a way that is invisible on saturated colours — it turned mid-gray
+  teal and survived an entire tuning run. Every row of the correct sRGB form sums
+  to 1. `simulateCvd` in `utils/color.js` is the one implementation; use it.
+- **A generation hitch above 8×8 is announced, not hidden.** `startPuzzle` defers
+  through `requestAnimationFrame` *and* a `setTimeout` for sizes ≥ 9, because
+  setting a flag only schedules a render — generating in the same turn blocks the
+  thread before the spinner is ever drawn. The indicator lives inside the
+  always-mounted counter row so the board never moves (see the origin note above).
+- **Board constants step down below 40px cells** (`tightCells` in
+  `FungikuBoard`): region borders, conflict ring inset and stroke, mistake badge.
+  The threshold leaves 5×5-8×8 pixel-identical to what shipped. **The 6px
+  tap-vs-drag threshold was deliberately left alone** — it is the one item in
+  plan §12.3 that only a device can settle, since web draws a 10×10 cell at 45px,
+  larger than a native 5×5 cell.
 
 ## Steps already done
 
@@ -328,3 +313,4 @@ doesn't read as a freeze.
 | 5 | Board UI — palette fix with a tested ΔE floor, themed + responsive board, animated win | merged to `epic/fungiku` (#71, `905bfa2`) |
 | 6 | Input ergonomics — drag to sweep X's, rule-out button | merged to `epic/fungiku` (#72, `e896fb6`) |
 | 7 | Feedback & hints — mistake flagging, forced-deduction nudge, reveal, placement pop | merged to `epic/fungiku` (#73, `12f72c3`) |
+| 8 | Bigger boards — `MAX_SIZE = 10`, a tenth region colour tuned for CVD, no-wrap `getRegionColor`, generation announced, legibility at 32px, cost bound in rounds | this PR |

--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -294,11 +294,22 @@ to the next one — with the hub's Continue badge naming where you are.
   thread before the spinner is ever drawn. The indicator lives inside the
   always-mounted counter row so the board never moves (see the origin note above).
 - **Board constants step down below 40px cells** (`tightCells` in
-  `FungikuBoard`): region borders, conflict ring inset and stroke, mistake badge.
-  The threshold leaves 5×5-8×8 pixel-identical to what shipped. **The 6px
-  tap-vs-drag threshold was deliberately left alone** — it is the one item in
-  plan §12.3 that only a device can settle, since web draws a 10×10 cell at 45px,
-  larger than a native 5×5 cell.
+  `FungikuBoard`): conflict ring inset and stroke, mistake badge. That threshold
+  leaves 5×5-8×8 as they were. **The 6px tap-vs-drag threshold was deliberately
+  left alone** — it is the one item in plan §12.3 that only a device can settle,
+  since web draws a 10×10 cell at 45px, larger than a native 5×5 cell.
+- **Every line on the board is drawn by `FungikuGridLines`, not by cell borders**
+  (plan §12.5, from an operator device report). Per-cell borders drew every
+  interior region boundary **twice** — once by each neighbour, so at double the
+  frame's weight — and mitered at every corner, and ate width off both fills.
+  The overlay draws each edge once, centred on it, with region segments extended
+  half a stroke so junctions fill by overlap. **If you add anything to it: it must
+  keep `pointerEvents="none"` and must not change the board's box**, because
+  `cellFromPoint` resolves every tap against that origin.
+- **Within-region grid lines take their colour from the fill, not the theme.**
+  `grid.cellBorder` is tuned for Sudoku's white cells — in Pastel it is `#d0d8e6`,
+  invisible on a saturated region fill. The contrast-picked ink at low alpha is
+  legible on every fill by construction, the same rule the glyph already used.
 
 ## Steps already done
 
@@ -313,4 +324,4 @@ to the next one — with the hub's Continue badge naming where you are.
 | 5 | Board UI — palette fix with a tested ΔE floor, themed + responsive board, animated win | merged to `epic/fungiku` (#71, `905bfa2`) |
 | 6 | Input ergonomics — drag to sweep X's, rule-out button | merged to `epic/fungiku` (#72, `e896fb6`) |
 | 7 | Feedback & hints — mistake flagging, forced-deduction nudge, reveal, placement pop | merged to `epic/fungiku` (#73, `12f72c3`) |
-| 8 | Bigger boards — `MAX_SIZE = 10`, a tenth region colour tuned for CVD, no-wrap `getRegionColor`, generation announced, legibility at 32px, cost bound in rounds | this PR |
+| 8 | Bigger boards — `MAX_SIZE = 10`, a tenth region colour tuned for CVD, no-wrap `getRegionColor`, generation announced, legibility at 32px, cost bound in rounds, board lines redrawn as an overlay | this PR |

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -749,16 +749,20 @@ a browser one.**
 
 #### What shipped
 
-`FungikuBoard` derives four constants from a single `tightCells = cell < 40`
-test, so **every size that had already shipped is drawn exactly as before** (5×5
-through 8×8 are 64px down to 40px cells) and only 9×9 and 10×10 change:
+`FungikuBoard` derives three constants from a single `tightCells = cell < 40`
+test, so the sizes that had already shipped keep them unchanged (5×5 through 8×8
+are 64px down to 40px cells) and only 9×9 and 10×10 step down:
 
 | | ≥ 40px cells | < 40px cells |
 |---|---|---|
-| region-boundary border | 2 | 1.5 |
 | conflict-ring inset | 6 | 4 |
 | conflict-ring stroke | 2.5 | 2 |
 | mistake badge | `cell × 0.28` | `max(11, cell × 0.28)` |
+
+**The board's lines are the exception, and they changed at every size** — see
+§12.5. The first cut of this pass treated the region border as one more constant
+to step down, which was treating a symptom: the lines were drawn in a way that
+was wrong at every size and merely most obvious at the smallest.
 
 The mushroom glyph stays at `cell × 0.62` — 20px at the top size, which the plan
 guessed was fine and nothing since has contradicted.
@@ -791,6 +795,56 @@ row's mushroom is in this region" — which eliminate far more.
 That is not a blocker for 10×10, but a hint that helps twice out of ten placements
 will feel thin. Worth strengthening the propagator, or accepting that the reveal
 rung carries more of the load on large boards (§8 #6).
+
+### 12.5 The board's lines (operator device report, 2026-07-26)
+
+> *"The grid lines could use some darker lines and a clean up of how lines come
+> together."* — operator, on a 9×9 in the Pastel theme
+
+Three defects, one cause. Every line on the board was drawn as a **per-cell
+border**: each cell set its own four border widths and colours, thick where the
+neighbouring cell belonged to a different region. That is the obvious way to do
+it, and it is wrong in three ways that a desktop browser hides:
+
+1. **Every interior region boundary was drawn twice** — once by the cell on each
+   side — so it rendered at *double* width, while the frame around the board was
+   drawn once. Interior boundaries were literally twice the weight of the border
+   containing them.
+2. **Corners notched.** React Native miters adjacent borders, so a cell with a
+   thick top edge and a hairline left edge gets a diagonal seam where they meet;
+   where four cells meet at a region corner, four independent miters fail to line
+   up. This is the "how lines come together" half of the report.
+3. **Borders draw *inside* the cell box**, so a boundary ate width off both
+   neighbours' fills — at 32px cells, an eighth of the cell.
+
+And the darkness half had its own cause: within-region grid lines used the
+theme's `grid.cellBorder`, which is tuned for **Sudoku's white cells**. In the
+Pastel theme that is `#d0d8e6`, which is invisible on a saturated orange or green
+region fill.
+
+**The fix is `FungikuGridLines`**, one memoized overlay of absolutely-positioned
+rectangles drawn on top of the cells. Each edge is drawn exactly once at a width
+that does not depend on how many cells touch it; lines are centred on the edge
+rather than inside one cell; and region segments are extended by half a stroke at
+each end so corners and T-junctions fill in by overlap instead of mitering.
+Collinear runs are merged, so a boundary following a whole row is one View rather
+than ten. Grid lines take their colour from the **fill they sit on** — the
+contrast-picked ink at low alpha, the same rule the mushroom glyph already used —
+so they are legible on every fill in the palette by construction.
+
+Two constraints worth knowing if this is ever touched again:
+
+- **The overlay may not change the board's box.** `cellFromPoint` resolves every
+  tap against the board's measured origin, so the frame is inset fully inside the
+  bounds rather than centred on the edge like the interior lines. A `borderWidth`
+  on the board container would shift every cell out from under the player's
+  finger.
+- **`pointerEvents="none"`.** The board claims every touch at touch-down (§2); an
+  overlay that swallowed one would break the whole gesture layer.
+
+**This changed how every size looks, not just the new ones.** A single-drawn
+2.5px boundary replaces a double-drawn 2px one, so boundaries are lighter and
+even, and the grid inside a region is darker than it was.
 
 ## 13. Ladder & scoring — notes parked for Step 9
 

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -832,23 +832,24 @@ than ten. Grid lines take their colour from the **fill they sit on** — the
 contrast-picked ink at low alpha, the same rule the mushroom glyph already used —
 so they are legible on every fill in the palette by construction.
 
-**And then the stroke went away entirely** (operator, 2026-07-26: *"Do we need
-extra grid lines for color shapes. Try it without"*). The answer was no.
+**The boundary stroke was removed, and put back** (2026-07-26). The operator
+asked *"Do we need extra grid lines for color shapes. Try it without"* — a fair
+challenge: a region is a **colour**, the ten fills are tuned to a measured
+separation floor (§12.2), and where two regions meet the change of fill already
+marks the edge. For normal colour vision the stroke is the same information
+twice. Removing it also deleted every special case in `FungikuGridLines` — the
+run extension, the clamping, the two widths — 140 lines.
 
-§3 called region outlines the board's structure, by analogy with Sudoku's box
-lines. The analogy does not hold: **a Sudoku box is invisible without its line,
-whereas a Fungiku region is a colour** — and ten of them are tuned to a measured
-separation floor (§12.2). The stroke was drawing information the fill already
-carried, and it was the direct cause of nearly every artifact in this section:
-the double-drawing, the mitering, the half-stroke extensions needed to close
-corners, and the ticks where those extensions ran past the frame. A line is now
-drawn only between two cells of the **same** region; where regions meet there is
-nothing, and the change of colour is the edge. The component lost 140 lines.
+It was tried and **rejected on sight**, for colourblind players. That is exactly
+the case colour alone does not cover: when two adjacent fills are hard to tell
+apart, the stroke is what still says *the region ends here*. It is a second
+channel, the same principle as signalling a conflict with a ring **and** a
+colour, and the same reason the palette is checked under dichromat simulation
+instead of by ΔE alone.
 
-**What that spends:** colour becomes the only channel for region identity. It is
-the reason `corners` in `utils/symbolSets.js` is still there, unused — if the
-boundary is ever wanted back for accessibility, a shape cue is a cheaper way to
-pay for it than a stroke on every edge.
+**Record it as decided.** The stroke is not redundant and not a simplification
+opportunity; the experiment has been run. `corners` in `utils/symbolSets.js`
+remains available as a *third* channel if region identity ever needs one.
 
 **A fourth defect, found after the overlay landed.** The operator's next
 screenshot still showed the grid "with misses" — some lines present, some not,

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -832,6 +832,24 @@ than ten. Grid lines take their colour from the **fill they sit on** — the
 contrast-picked ink at low alpha, the same rule the mushroom glyph already used —
 so they are legible on every fill in the palette by construction.
 
+**And then the stroke went away entirely** (operator, 2026-07-26: *"Do we need
+extra grid lines for color shapes. Try it without"*). The answer was no.
+
+§3 called region outlines the board's structure, by analogy with Sudoku's box
+lines. The analogy does not hold: **a Sudoku box is invisible without its line,
+whereas a Fungiku region is a colour** — and ten of them are tuned to a measured
+separation floor (§12.2). The stroke was drawing information the fill already
+carried, and it was the direct cause of nearly every artifact in this section:
+the double-drawing, the mitering, the half-stroke extensions needed to close
+corners, and the ticks where those extensions ran past the frame. A line is now
+drawn only between two cells of the **same** region; where regions meet there is
+nothing, and the change of colour is the edge. The component lost 140 lines.
+
+**What that spends:** colour becomes the only channel for region identity. It is
+the reason `corners` in `utils/symbolSets.js` is still there, unused — if the
+boundary is ever wanted back for accessibility, a shape cue is a cheaper way to
+pay for it than a stroke on every edge.
+
 **A fourth defect, found after the overlay landed.** The operator's next
 screenshot still showed the grid "with misses" — some lines present, some not,
 with no pattern. Auditing the rendered geometry rather than the screenshot

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -832,6 +832,34 @@ than ten. Grid lines take their colour from the **fill they sit on** — the
 contrast-picked ink at low alpha, the same rule the mushroom glyph already used —
 so they are legible on every fill in the palette by construction.
 
+**A fourth defect, found after the overlay landed.** The operator's next
+screenshot still showed the grid "with misses" — some lines present, some not,
+with no pattern. Auditing the rendered geometry rather than the screenshot
+showed **every interior edge was covered**: nothing was missing. The problem was
+sub-pixel.
+
+A 1px line centered on a cell edge sits at `y = 35.5`, which on a 3× screen is
+device rows **106.5 to 109.5**. Half pixels cannot be drawn, so the renderer
+antialiases the line across four rows at 50/100/100/50 coverage — and multiplied
+by the line's own 37% alpha, the result is a faint smear whose visibility then
+depends on the fill behind it. Hence "misses": strong enough to see on a pale
+yellow, invisible on a saturated orange.
+
+Region boundaries never showed it because their width happened to put them on
+integers at the sizes that had shipped. That accident is what made this look
+like *some lines are missing* rather than *every thin line is half a pixel off*.
+
+The fix is `PixelRatio.roundToNearestPixel` on both the position **and** the
+thickness of every line, so each covers whole device pixels at full strength.
+Verified by re-auditing: grid lines moved from device rows `106.5..109.5` to
+`107.0..110.0`.
+
+**The lesson is about method, not about pixels.** Two rounds were spent reading
+screenshots for a defect that a twenty-line DOM audit located exactly. When a
+rendering bug looks patternless, measure the geometry — "is every edge covered?"
+and "where does each line land in device pixels?" are both cheap questions with
+unambiguous answers.
+
 Two constraints worth knowing if this is ever touched again:
 
 - **The overlay may not change the board's box.** `cellFromPoint` resolves every

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -771,9 +771,14 @@ guessed was fine and nothing since has contradicted.
 against (a shaky tap registering as a stroke) is measured in absolute pixels of
 finger travel and does not change with cell size. What *does* change is the cost
 of being wrong, since 6px of travel now crosses a fifth of a cell rather than a
-tenth. **This is the one item on the list that cannot be settled anywhere but a
-device** — web renders a 10×10 cell at 45px, *larger* than a native 5×5 cell, so
+tenth. This was the one item on the list that could not be settled anywhere but a
+device — web renders a 10×10 cell at 45px, *larger* than a native 5×5 cell, so
 the browser is structurally incapable of showing the problem.
+
+**Settled on device (operator, 2026-07-26): 6px holds at 10×10.** The reasoning
+above was right — the threshold is about finger travel, not cell size — so it
+needs no per-size treatment. Leave it alone unless a *smaller* cell than 32px
+ever ships.
 
 ### 12.4 A finding about hints on bigger boards
 

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -368,7 +368,7 @@ the step's real acceptance test, alongside its automated checks.
 | 5 | ~~**Board UI**~~ ✅ — the real board component: region-boundary borders, themed styling, win flow, **palette tuning** | The **finished board**, styled to the app's themes, replacing the preview's rough grid |
 | 6 | ~~**Input ergonomics & assists**~~ ✅ (§2) — **drag to sweep X's**, rule-out button | **Swipe a finger across cells to rule them out**; a *Rule out* button |
 | 7 | ~~**Feedback & hints**~~ ✅ (§11) — correctness feedback on placements, and a hint ladder | **Optional "show mistakes" for mushrooms**, and a hint you can ask for when stuck |
-| 8 | **Bigger boards, up to 10×10** (§12) — a 10th region colour, legibility at 32px cells, a generation-cost bound | **A playable 10×10** that generates without a visible freeze |
+| 8 | ~~**Bigger boards, up to 10×10**~~ ✅ (§12) — `MAX_SIZE`, a 10th region colour, legibility at 32px cells, a generation-cost bound | **A playable 10×10** that generates without a visible freeze |
 | 9 | **Ladder & scoring** — training ladder, size progression, scoring | Level progression and a score |
 | 10 | **Art swap** (floating, asset-only — gated on artwork, not on code) | Static mushroom art replaces the icon glyph |
 
@@ -520,7 +520,27 @@ Requirements on any hint:
 Carried into §8 as #6 and #7: how strong hints should go for a family game, and
 whether correctness feedback should default on for younger players.
 
-## 12. Board sizes up to 10×10 (operator request, 2026-07-25)
+## 12. Board sizes up to 10×10 (operator request, 2026-07-25) — **shipped, Step 8**
+
+**What landed.** `MAX_SIZE = 10` in the engine, with `SIZES` derived from the
+bounds so the chips cannot offer a size `generate()` rejects; a tenth region
+colour, searched for rather than picked; `getRegionColor` no longer wraps; a
+"Generating…" state for the sizes where the hitch is visible; and a legibility
+pass that steps down four constants below 40px cells. Details and measurements
+are in the subsections below, updated with what was found rather than predicted.
+
+**Three things turned out differently from this brief, and all three are worth
+knowing before touching the palette again:**
+
+1. **ΔE and colourblind safety did not merely differ — they pulled in opposite
+   directions.** Maximizing worst-pair ΔE produced ten-colour palettes that beat
+   the shipping nine for normal vision and were *worse than it* under dichromat
+   simulation. §12.2 has the reframed objective that resolved it.
+2. **The first simulation was wrong, and it was the palette's own test that
+   caught it.** See §12.2, "The matrices are a trap".
+3. **The contrast floors are part of the search space, not a check afterwards.**
+   A palette optimized for separation alone failed three existing tests on dark
+   fills; the floors are now constraints on which tints are candidates at all.
 
 The operator first asked for the ladder to reach **12×12**. Measuring the cost
 (§12.1) showed a 12×12 takes **7.3 seconds to generate, synchronously on the main
@@ -557,17 +577,36 @@ up to `PERTURB_BUDGET` times). Each `findSolutions` call is a backtracking searc
 re-run after every perturbation.
 
 **At a 10×10 ceiling, none of that needs fixing** — 284 ms median is a hitch, not a
-freeze. Two things it does need:
+freeze. Two things it does need, and both shipped:
 
-1. **A generation hitch you can see is worse than one you are told about.** Half a
-   second of frozen UI on "New puzzle" at the top size reads as a bug. Either show
-   a brief loading state, or confirm on device that it is imperceptible — don't
-   assume.
-2. **A regression bound in the test suite.** 10×10 sits one size below a
-   ten-times cliff, so a change that makes generation modestly slower would push
-   the top size from *hitch* to *freeze* with no other symptom. Assert a generous
-   ceiling (or count perturbation rounds, which is machine-independent) so that
-   regression is visible.
+1. **A generation hitch you can see is worse than one you are told about.** The
+   counter row shows **"Generating…"** with a spinner at sizes ≥ 9, and the board
+   stops taking touches until the new puzzle arrives.
+
+   Two details that are easy to get wrong. First, **setting the flag is not
+   enough** — the state update only schedules a render, so generating in the same
+   turn blocks the main thread before the spinner is ever drawn. `startPuzzle`
+   hops through `requestAnimationFrame` *and then* a `setTimeout`, which puts the
+   generator after the frame has been handed off. Second, the indicator lives
+   **inside the always-mounted counter row**, not in a banner of its own,
+   precisely because a view mounting above the board moves the board and
+   invalidates the origin every touch is resolved against (§2).
+
+   The threshold is 9, not 10, because a phone is slower than the machine these
+   numbers came from and 9×9's 51 ms median has a 174 ms tail. Below it,
+   generation finishes inside the frame and deferring would only add latency —
+   verified in the browser: a 5×5 never shows the state, a 10×10 always does.
+
+2. **A regression bound in the test suite.** `generate()` now returns the number
+   of **perturbation rounds** it took, and the suite caps the total at the top
+   size. Rounds rather than milliseconds is not a detail: the same generation
+   that takes 0.4s in node takes ~3s under Jest's transform, so a millisecond
+   bound would measure the runner. Rounds are identical everywhere.
+
+   Sampling matters too. Six seeds at 10×10 put 20 seconds on a suite that
+   otherwise runs in three — enough friction to stop people running it — so the
+   top size runs the full battery against two seeds and the sizes below it keep
+   six.
 
 If the ceiling is ever to rise past 10, the generator has to get cheaper first,
 and there are four directions worth trying, cheapest first:
@@ -623,6 +662,72 @@ respect:
   it is worth knowing the second channel already exists if the tenth colour proves
   hard to place.
 
+#### What the search actually found (2026-07-25)
+
+**The warning above understated it.** Maximizing ΔE and preserving colourblind
+separation are not merely different properties — over this hue space they are in
+direct conflict. The ΔE-optimal ten-colour palettes reached worst-pair ΔE 19-21
+for normal vision (against the shipping 17.11) while scoring **below the
+shipping nine** under simulation. Okabe–Ito's CVD robustness lives at full
+saturation, and tinting every hue toward the theme surface is exactly what
+spends it. A palette tuned on ΔE alone would have looked like an improvement in
+every number anyone was checking.
+
+So the objective was inverted. **Normal-vision separation became a constraint** —
+may not fall below what the nine achieved — and **colourblind separation became
+the thing maximized underneath it**, across protan, deutan and tritan in both
+themes, with the contrast floors (§below) as feasibility constraints on which
+tints are candidates at all. The search was a coordinate ascent over per-hue
+tints with random restarts, run across a 288-point grid of candidate tenth hues.
+
+The winner is a lime, **`#96C115`**, and it adds a colour while improving all
+eight measured axes:
+
+| | worst-pair ΔE | nine colours | ten colours |
+|---|---|---|---|
+| light | normal | 17.11 | **17.21** |
+| | protan / deutan / tritan | 4.13 / 5.44 / 14.85 | **6.73 / 5.80 / 16.21** |
+| dark | normal | 18.55 | **18.69** |
+| | protan / deutan / tritan | 5.80 / 6.38 / 18.52 | **6.31 / 6.79 / 19.21** |
+
+0 of 45 pairs under ΔE 15 in both themes. Those per-dichromacy numbers are now
+floors in `utils/__tests__/symbolSets.test.js`.
+
+Two notes on reading them. They are a **relative** bar — simulate, then measure
+ΔE — and a CIEDE2000 distance between two simulated colours is not a calibrated
+statement about what a dichromat can distinguish. It answers "did this get
+worse?", which is the question being asked. And the tenth colour is region-only:
+there is no tenth Sudoku cell value, so it is deliberately not a `FUNGIKU_SWATCHES`
+entry.
+
+**The re-tune changed every fill, not just the new one** — the whole point was
+freedom to move the other nine. Two light fills (orange, sky blue) now sit at
+full strength where they were tinted before. Both are inside the L\* 65-97 band
+that encodes "a soft grid, not saturated blocks", but it is the most visible
+difference and worth a look on device.
+
+#### The matrices are a trap
+
+The first CVD simulation used the Viénot–Brettel–Mollon matrices in their
+**LMS-space** form applied directly to linear RGB — `[0, 2.02344, -2.52581]` and
+friends. This is a common shortcut and it is wrong. It has no obvious symptom on
+saturated colours, which is why it survived a whole tuning run and produced a
+plausible-looking answer.
+
+What exposed it was a one-line test asserting that **mid-gray survives
+simulation** — a gray has no hue for a dichromat to lose. It came out teal. The
+correct form for sRGB primaries has **every row summing to 1**, which is the
+property to check any such matrix against:
+
+```
+protan [0.11238, 0.88762, 0]   deutan [0.29275, 0.70725, 0]   tritan [1, 0.14461, -0.14461]
+       [0.11238, 0.88762, 0]          [0.29275, 0.70725, 0]          [0, 1, 0]
+       [0.00401, -0.00401, 1]         [-0.02234, 0.02234, 1]         [0, 0.15117, 0.84883]
+```
+
+`simulateCvd` in `utils/color.js` is the one implementation, used by both the
+tests and any future tuning, so this cannot diverge again.
+
 ### 12.3 Legibility at 32-pixel cells
 
 `useBoardSize()` returns a fixed 324 on native, so a 10×10 cell is **32 px** (450
@@ -641,6 +746,30 @@ inheriting constants tuned for 5×5. The 6-pixel tap-vs-drag threshold deserves 
 same scrutiny: it was tuned against roughly 40 px cells, and a 32 px cell means
 less room to press without registering a stroke. **That is a device question, not
 a browser one.**
+
+#### What shipped
+
+`FungikuBoard` derives four constants from a single `tightCells = cell < 40`
+test, so **every size that had already shipped is drawn exactly as before** (5×5
+through 8×8 are 64px down to 40px cells) and only 9×9 and 10×10 change:
+
+| | ≥ 40px cells | < 40px cells |
+|---|---|---|
+| region-boundary border | 2 | 1.5 |
+| conflict-ring inset | 6 | 4 |
+| conflict-ring stroke | 2.5 | 2 |
+| mistake badge | `cell × 0.28` | `max(11, cell × 0.28)` |
+
+The mushroom glyph stays at `cell × 0.62` — 20px at the top size, which the plan
+guessed was fine and nothing since has contradicted.
+
+**The tap-vs-drag threshold was left at 6px**, deliberately: the risk it guards
+against (a shaky tap registering as a stroke) is measured in absolute pixels of
+finger travel and does not change with cell size. What *does* change is the cost
+of being wrong, since 6px of travel now crosses a fifth of a cell rather than a
+tenth. **This is the one item on the list that cannot be settled anywhere but a
+device** — web renders a 10×10 cell at 45px, *larger* than a native 5×5 cell, so
+the browser is structurally incapable of showing the problem.
 
 ### 12.4 A finding about hints on bigger boards
 


### PR DESCRIPTION
Sizes **9×9 and 10×10 are now reachable and playable**. Refs #65. Plan §12. **Operator-tested on device.**

> **Branch name.** This session was pinned to `claude/fungiku-epic-next-og7flc`, so the work is here rather than on the `feature/fungiku-big-boards` the handoff named. Branched off `epic/fungiku` and targeting it, as normal.

## The ceiling

`MAX_SIZE = 10` in the engine, rejected the same way sizes below 5 are. **There was no upper bound at all before** — `generate()` accepted size 20 and never returned. `SIZES` is now derived from the bounds and the chips render from it, so the UI cannot offer a size the generator rejects.

## The tenth region colour — where this diverged from the brief

`getRegionColor` wrapped with `regionId % palette.length`, so at ten regions **region 9 was drawn exactly like region 0**. That is a wrong board, not a caught error, and moving the wrap to 11 would only relocate it. It no longer wraps: the palette holds one fill per region up to `MAX_SIZE` (pinned by a test), and an id outside it returns magenta and logs once rather than throwing mid-render.

The brief said to check the new hue under colourblind simulation and *not* to stop at ΔE. Doing that found something stronger than the warning: **ΔE and CVD separation are actively opposed over this hue space.** The ΔE-optimal ten-colour palettes beat the shipping nine for normal vision and scored **below it** under dichromat simulation — Okabe–Ito's robustness lives at full saturation, and tinting toward the theme surface is what spends it. Tuning on ΔE alone would have looked like an improvement in every number anyone was checking.

So the objective was inverted: **normal-vision separation is a constraint** (no worse than the nine), **colourblind separation is what gets maximized underneath it**, with the existing contrast floors as constraints on which tints are candidates at all. The winner is a lime, `#96C115`, and it adds a colour while improving **all eight measured axes**:

| | worst-pair ΔE | nine colours | ten colours |
|---|---|---|---|
| light | normal | 17.11 | **17.21** |
| | protan / deutan / tritan | 4.13 / 5.44 / 14.85 | **6.73 / 5.80 / 16.21** |
| dark | normal | 18.55 | **18.69** |
| | protan / deutan / tritan | 5.80 / 6.38 / 18.52 | **6.31 / 6.79 / 19.21** |

0 of 45 pairs under ΔE 15 in both themes.

A one-line "mid-gray survives simulation" test then caught that **the first simulation was wrong**: the LMS-form Viénot matrices applied to linear RGB, a common shortcut with no symptom on saturated colours that had survived an entire tuning run. Gray came out teal. `simulateCvd` in `utils/color.js` is now the single implementation, used by the tests and any future tuning.

The re-tune moved every fill, not just the new one — that freedom is what bought the numbers above. Two light fills (orange, sky blue) now sit at full strength where they were tinted, both inside the L\* 65–97 band that encodes "a soft grid, not saturated blocks".

## No visible freeze

Generation is synchronous and costs ~0.4s at 10×10, so sizes ≥ 9 show **"Generating…"** first and the board stops taking touches. Two details that were easy to get wrong:

- The deferral goes through `requestAnimationFrame` **and then** a `setTimeout`. Setting the flag only *schedules* a render — generating in the same turn blocks the thread before the spinner is ever drawn.
- The indicator lives **inside the always-mounted counter row**, not a banner, because a view mounting above the board moves the board and invalidates the origin every touch is resolved against.

Threshold is 9, not 10: a phone is slower than the machine these numbers came from, and 9×9's 51 ms median has a 174 ms tail.

## The board's lines, rebuilt (§12.5)

Three device reports, one root cause: **every line was a per-cell border.**

- Interior region boundaries were drawn **twice**, once by the cell on each side, so they rendered at double width while the board's frame was drawn once.
- React Native **miters** adjacent borders, so a thick edge meeting a thin one leaves a diagonal seam; four cells meeting at a region corner produce four miters that don't line up.
- Borders draw **inside** the cell box, eating width off both fills — an eighth of a cell at 32px.

Faintness was a wrong colour *source*, not a wrong colour: within-region lines used the theme's `grid.cellBorder`, tuned for Sudoku's **white** cells (`#d0d8e6` in Pastel, invisible on a saturated orange fill). They now take the contrast-picked ink of the fill they sit on.

`FungikuGridLines` draws each edge exactly once, centred on the edge, region runs extended half a stroke so junctions fill by overlap and clamped where they meet the frame, collinear runs merged, memoized on the puzzle.

**"Still the grid has misses" turned out to be sub-pixel.** A geometry audit found **0 uncovered edges** — every line was being drawn. A 1px line centred on a cell edge lands at `y = 35.5`, which on a 3× screen is device rows 106.5–109.5, antialiased to 50/100/100/50 and multiplied by the line's own 37% alpha. Region boundaries never showed it because their width *happened* to land them on integers — which is what made this look patternless rather than like one systematic half-pixel offset. Fixed with `PixelRatio.roundToNearestPixel` on position **and** thickness.

**The boundary stroke was removed, then restored.** Redundant for normal colour vision — a region *is* a colour — and removing it deleted 140 lines and every special case in the file. But it is the second channel a colourblind player needs when two adjacent fills are hard to tell apart. Kept, and **recorded as decided** in the component and §12.5 so it is not re-removed as a simplification.

## Legibility at 32px cells

The conflict ring and mistake badge step down below 40px cells, leaving 5×5 through 8×8 as they were:

| | ≥ 40px | < 40px |
|---|---|---|
| conflict ring inset | 6 | 4 |
| conflict ring stroke | 2.5 | 2 |
| mistake badge | `cell × 0.28` | `max(11, cell × 0.28)` |

The board's **lines** are the exception — they changed at every size, because they were drawn wrong at every size and merely most visible at 32px.

## Tests — 269, up from 220

The cost bound counts **perturbation rounds, not milliseconds**: the same generation takes 0.4s in node and ~3s under Jest's transform, so a time bound would measure the runner. Six seeds at 10×10 would have added 20s to a 3s suite, so the top size runs the full battery against two seeds and the sizes below keep six — the engine file went 54s → 11s with the top size still fully covered.

## Verification

- `npm test` — 269 passed
- `npx expo-doctor` — 18/18
- `npx expo export --platform all` — web, iOS and Android all bundle
- **Web build driven in Chromium** across Pastel/Dark/Classic at 5×5, 9×9 and 10×10: ten distinct region fills at 10×10 in both themes, taps landing on the cell aimed at, "Generating…" observed at 10×10 and correctly absent at 5×5, chips wrapping at 320px with no overflow, geometry audit clean, **no page errors**
- **Operator device test** — line rendering ✅, **6px tap-vs-drag threshold holds at 10×10** ✅ (the one item a browser structurally could not answer: web draws a 10×10 cell at 45px, *larger* than a native 5×5 cell)

## Noted, deliberately not done

- **The forced-move nudge is shallow** — §12.4 measured 2 of 10 deductions from an empty 10×10. Real and worth fixing, but strengthening the propagator with pigeonhole reasoning is its own change.
- **No generator re-engineering.** §12.1's four approaches are for the day the ceiling rises past 10.
- **The `corners` shape cue stays unused** — it remains available as a *third* channel for region identity if one is ever wanted.

Handoff rewritten for **Step 9 — the training ladder, and scoring**.