### PR TITLE
Fungiku Step 9: the difficulty menu

### DIFF
--- a/SudokuApp/components/ScreenHeader.js
+++ b/SudokuApp/components/ScreenHeader.js
@@ -8,8 +8,17 @@ const ICON_SIZE = 24;
  * Header for game screens that aren't Sudoku: a home affordance back to the hub
  * plus the game's title. Sudoku keeps its own richer GameHeader (menu + theme
  * cycle) and gets the same home button added there.
+ *
+ * `onMenuPress` is optional and adds a menu button on the right, in the same
+ * corner Sudoku's GameHeader puts its own — a game with a difficulty menu should
+ * open it from the same place in either game.
+ *
+ * `subtitle` is optional: one line under the title for what the current game *is*
+ * (Fungiku uses it for "Easy · 6×6"). Callers should pass it either always or
+ * never for a given screen — a subtitle that appears and disappears changes the
+ * header's height, which moves everything under it.
  */
-const ScreenHeader = ({ title, theme, onHomePress }) => {
+const ScreenHeader = ({ title, subtitle, theme, onHomePress, onMenuPress }) => {
   const titleColor = theme?.colors?.title || '#333';
 
   return (
@@ -28,10 +37,28 @@ const ScreenHeader = ({ title, theme, onHomePress }) => {
 
       <View style={styles.centerSection}>
         <Text style={[styles.title, { color: titleColor }]}>{title}</Text>
+        {!!subtitle && (
+          <Text style={[styles.subtitle, { color: titleColor }]} numberOfLines={1}>
+            {subtitle}
+          </Text>
+        )}
       </View>
 
-      {/* Balances the row so the title stays optically centered. */}
-      <View style={styles.rightSection} />
+      {/* Also balances the row so the title stays optically centered — the View
+          stays even with no menu button in it. */}
+      <View style={styles.rightSection}>
+        {onMenuPress && (
+          <TouchableOpacity
+            style={[styles.iconButton, { borderColor: titleColor }]}
+            onPress={onMenuPress}
+            accessibilityLabel="Game menu"
+            accessibilityRole="button"
+            accessibilityHint="Choose a difficulty or start a new puzzle"
+          >
+            <MaterialCommunityIcons name="menu" size={ICON_SIZE} color={titleColor} />
+          </TouchableOpacity>
+        )}
+      </View>
     </View>
   );
 };
@@ -55,10 +82,20 @@ const styles = StyleSheet.create({
   },
   rightSection: {
     flex: 1,
+    alignItems: 'flex-end',
+    paddingRight: 8,
   },
   title: {
     fontSize: 24,
     fontWeight: 'bold',
+  },
+  subtitle: {
+    fontSize: 12,
+    fontWeight: '600',
+    opacity: 0.7,
+    // Single line by construction (numberOfLines={1}), so the header's height is
+    // the same whatever the subtitle says.
+    marginTop: 1,
   },
   iconButton: {
     paddingVertical: 3,

--- a/SudokuApp/games/fungiku/FungikuContext.js
+++ b/SudokuApp/games/fungiku/FungikuContext.js
@@ -16,6 +16,7 @@ import {
   selectMushroomCount,
   selectRevealCell,
   selectRuleOutCells,
+  resolvePuzzleIdentity,
 } from './reducer';
 
 /**
@@ -32,10 +33,12 @@ const FungikuContext = createContext();
 /**
  * Board sizes offered today — every size the engine supports, derived there from
  * MIN_SIZE/MAX_SIZE rather than listed here, so a chip the UI offers and a size
- * `generate()` accepts cannot drift apart. The real ladder arrives in a later
- * step and will pick its rungs from this same range.
+ * `generate()` accepts cannot drift apart. The difficulty rungs map *into* this
+ * range (see ./difficulty.js); the chips are the free-play escape hatch that
+ * reaches a single size directly (plan §14.1).
  */
 export { SIZES } from './engine';
+export { DIFFICULTIES } from './difficulty';
 
 // Stable object identity, so the persistence hook never sees a "new" adapter.
 const FUNGIKU_PERSISTENCE = { load: loadFungikuState, save: saveFungikuState };
@@ -162,14 +165,25 @@ export const FungikuProvider = ({ children }) => {
    * failure surfaces as a caught error instead of a throw mid-dispatch.
    */
   const startPuzzle = useCallback(
-    ({ size = state.size, seed = state.seed }) => {
+    ({ difficulty = state.difficulty, size, seed = state.seed }) => {
+      // Resolved here, before anything is dispatched, because whether this
+      // generation has to be deferred depends on the size — and the difficulty
+      // menu hands over a rung, not a size. Same rule the reducer uses, so the
+      // size decided here is the size that gets built.
+      const identity = resolvePuzzleIdentity({ difficulty, size, seed });
+
       const run = () => {
         try {
           dispatch({
             type: FUNGIKU_ACTIONS.NEW_PUZZLE,
             // The feedback switch is a preference and carries over; the hint
             // count is per-puzzle and resets.
-            payload: buildPuzzleState({ size, seed, showMistakes: state.showMistakes }),
+            payload: buildPuzzleState({
+              difficulty: identity.difficulty,
+              size: identity.size,
+              seed,
+              showMistakes: state.showMistakes,
+            }),
           });
         } catch (error) {
           console.error('Fungiku generation failed:', error);
@@ -178,7 +192,7 @@ export const FungikuProvider = ({ children }) => {
 
       // Small boards: generate inline. The work finishes inside the same frame,
       // so deferring would add a frame of latency and buy nothing.
-      if (size < DEFER_GENERATION_AT_SIZE) {
+      if (identity.size < DEFER_GENERATION_AT_SIZE) {
         run();
         return;
       }
@@ -202,17 +216,40 @@ export const FungikuProvider = ({ children }) => {
         }, 0);
       });
     },
-    [dispatch, state.size, state.seed, state.showMistakes]
+    [dispatch, state.difficulty, state.seed, state.showMistakes]
   );
 
+  /**
+   * Another board like this one. Keeps the *size* rather than re-resolving the
+   * difficulty, so "New puzzle" on a 6×6 easy board never hands back a 5×5 —
+   * a size change is something the player asks for, not a side effect of a
+   * reroll.
+   */
   const nextPuzzle = useCallback(
-    () => startPuzzle({ size: state.size, seed: state.seed + 1 }),
-    [startPuzzle, state.size, state.seed]
+    () => startPuzzle({ difficulty: state.difficulty, size: state.size, seed: state.seed + 1 }),
+    [startPuzzle, state.difficulty, state.size, state.seed]
   );
 
+  /** The menu's primary path in (plan §14.1): a rung, and the seed picks the size. */
+  const changeDifficulty = useCallback(
+    (difficulty, seed = DEFAULT_SEED) => startPuzzle({ difficulty, seed }),
+    [startPuzzle]
+  );
+
+  /** The free-play escape hatch: one exact size, whatever rung it belongs to. */
   const changeSize = useCallback(
     (size) => startPuzzle({ size, seed: DEFAULT_SEED }),
     [startPuzzle]
+  );
+
+  /**
+   * Developer-only: jump straight to a `{difficulty, seed}` board so a reported
+   * one can be reopened by hand. Keeps the current size when there is one, so
+   * typing a seed does not also move you to another board size.
+   */
+  const changeSeed = useCallback(
+    (seed) => startPuzzle({ difficulty: state.difficulty, size: state.size, seed }),
+    [startPuzzle, state.difficulty, state.size]
   );
 
   const clearMarks = useCallback(() => dispatch({ type: FUNGIKU_ACTIONS.CLEAR_MARKS }), [dispatch]);
@@ -245,7 +282,9 @@ export const FungikuProvider = ({ children }) => {
       dismissHint,
       startPuzzle,
       nextPuzzle,
+      changeDifficulty,
       changeSize,
+      changeSeed,
       clearMarks,
       undo,
       redo,
@@ -271,7 +310,9 @@ export const FungikuProvider = ({ children }) => {
       dismissHint,
       startPuzzle,
       nextPuzzle,
+      changeDifficulty,
       changeSize,
+      changeSeed,
       clearMarks,
       undo,
       redo,

--- a/SudokuApp/games/fungiku/FungikuMenuModal.js
+++ b/SudokuApp/games/fungiku/FungikuMenuModal.js
@@ -1,0 +1,357 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Animated,
+  Modal,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { DIFFICULTIES } from './difficulty';
+import { SIZES } from './engine';
+
+const ICON_SIZE = 24;
+
+/**
+ * The one constant that hides the developer controls (plan §14.1).
+ *
+ * Seeds and raw sizes are how a reported board gets reopened by hand, so they
+ * stay reachable while the game is being built — but they are a developer
+ * control, not a way a player picks a puzzle. Flip this to `false` and the menu
+ * is four difficulty buttons; nothing else has to change, which is the point of
+ * putting it behind a constant rather than deleting the UI later.
+ */
+export const SHOW_DEVELOPER_CONTROLS = true;
+
+/**
+ * Fungiku's way in (docs/fungiku-plan.md §14.1).
+ *
+ * Deliberately built to Sudoku's `components/modals/GameMenuModal` — the same
+ * four rungs, the same words, the same emoji, the same button colors, in the same
+ * order. The platform hosts several games and picking a difficulty should not be
+ * a different act in each one. It is a separate component rather than a shared
+ * one because Sudoku's menu is wired straight into `GameContext` and carries
+ * Sudoku-only controls; sharing the *shape* is what matters here.
+ *
+ * Below the rungs: free play. A size chip reaches one exact board size, which is
+ * how a size gets checked by hand, and the seed field reopens a specific
+ * `{difficulty, seed}` board. Both sit behind SHOW_DEVELOPER_CONTROLS.
+ */
+const FungikuMenuModal = ({
+  visible,
+  theme,
+  difficulty,
+  size,
+  seed,
+  generating,
+  onPickDifficulty,
+  onPickSize,
+  onPickSeed,
+  onClose,
+}) => {
+  const [menuAnim] = useState(new Animated.Value(0));
+
+  // Local, so typing is not a state update per keystroke on the game — and so a
+  // half-typed seed is never dispatched. Re-synced whenever the menu opens or
+  // the board's seed changes underneath it (New puzzle, for instance).
+  const [seedText, setSeedText] = useState(String(seed));
+  useEffect(() => {
+    setSeedText(String(seed));
+  }, [seed, visible]);
+
+  useEffect(() => {
+    Animated.timing(menuAnim, {
+      toValue: visible ? 1 : 0,
+      duration: visible ? 400 : 200,
+      useNativeDriver: true,
+    }).start();
+  }, [visible, menuAnim]);
+
+  const titleColor = theme.colors.title;
+  const surface = theme.colors.numberPad.background;
+  const border = theme.colors.numberPad.border;
+
+  const submitSeed = () => {
+    const parsed = Number.parseInt(seedText, 10);
+    // A seed that is not a number is a typo, not a request. Snap the field back
+    // rather than generating something the typist did not ask for.
+    if (!Number.isFinite(parsed)) {
+      setSeedText(String(seed));
+      return;
+    }
+    onPickSeed(parsed);
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Animated.View style={[styles.overlay, { opacity: menuAnim }]}>
+        <View style={[styles.box, { backgroundColor: surface, borderColor: border }]}>
+          <TouchableOpacity
+            style={styles.closeButton}
+            onPress={onClose}
+            accessibilityLabel="Close menu"
+            accessibilityRole="button"
+          >
+            <MaterialCommunityIcons name="close" size={ICON_SIZE} color={titleColor} />
+          </TouchableOpacity>
+
+          <Text style={[styles.title, { color: titleColor }]}>Fungiku</Text>
+          <Text style={[styles.subtitle, { color: titleColor }]}>Select Difficulty</Text>
+
+          {/* A menu tall enough to scroll on a short screen once free play is
+              showing. Bounded by maxHeight rather than left to overflow. */}
+          <ScrollView
+            style={styles.scroll}
+            contentContainerStyle={styles.scrollBody}
+            showsVerticalScrollIndicator={false}
+          >
+            {DIFFICULTIES.map((rung) => {
+              const current = rung.id === difficulty;
+
+              return (
+                <TouchableOpacity
+                  key={rung.id}
+                  style={[
+                    styles.button,
+                    BUTTON_TINTS[rung.id],
+                    current && { borderColor: titleColor, borderWidth: 2 },
+                    generating && styles.disabled,
+                  ]}
+                  onPress={() => onPickDifficulty(rung.id)}
+                  disabled={generating}
+                  accessibilityRole="button"
+                  accessibilityState={{ disabled: !!generating, selected: current }}
+                  // The rung's sizes are announced because "Hard" on its own does
+                  // not say the board is about to get bigger — and the state is
+                  // named in the label because accessibilityState.selected does
+                  // not reach the web reliably.
+                  accessibilityLabel={`Start ${rung.label} game${current ? ', current' : ''}, ${describeSizes(rung.sizes)}`}
+                >
+                  <Text style={styles.buttonEmoji}>{rung.emoji}</Text>
+                  <Text style={[styles.buttonText, { color: theme.colors.text || '#333' }]}>
+                    {rung.label}
+                  </Text>
+                  <Text style={[styles.buttonMeta, { color: theme.colors.text || '#333' }]}>
+                    {describeSizes(rung.sizes)}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+
+            {SHOW_DEVELOPER_CONTROLS && (
+              <View style={styles.devSection}>
+                <Text style={[styles.sectionLabel, { color: titleColor }]}>
+                  Free play (developer)
+                </Text>
+
+                {/* Board size chips — moved off the game screen into the menu, so
+                    the board is a board and every way into a puzzle is in one
+                    place. Still every size the engine supports, straight from
+                    SIZES (plan §14.1). */}
+                <View style={styles.chipRow}>
+                  {SIZES.map((option) => (
+                    <TouchableOpacity
+                      key={option}
+                      onPress={() => onPickSize(option)}
+                      disabled={generating}
+                      style={[
+                        styles.chip,
+                        { borderColor: border },
+                        option === size && { backgroundColor: titleColor, borderColor: titleColor },
+                        generating && styles.disabled,
+                      ]}
+                      accessibilityRole="button"
+                      accessibilityState={{ disabled: !!generating, selected: option === size }}
+                      accessibilityLabel={`${option} by ${option} board${option === size ? ', current' : ''}`}
+                    >
+                      <Text
+                        style={[styles.chipText, { color: option === size ? surface : titleColor }]}
+                      >
+                        {option}×{option}
+                      </Text>
+                    </TouchableOpacity>
+                  ))}
+                </View>
+
+                <Text style={[styles.sectionLabel, { color: titleColor }]}>Seed</Text>
+                <View style={styles.seedRow}>
+                  <TextInput
+                    value={seedText}
+                    onChangeText={setSeedText}
+                    onSubmitEditing={submitSeed}
+                    keyboardType="number-pad"
+                    returnKeyType="go"
+                    style={[styles.seedInput, { color: titleColor, borderColor: border }]}
+                    accessibilityLabel="Puzzle seed"
+                    accessibilityHint="A seed and a difficulty always rebuild the same board"
+                  />
+                  <TouchableOpacity
+                    onPress={submitSeed}
+                    disabled={generating}
+                    style={[
+                      styles.seedButton,
+                      { borderColor: border },
+                      generating && styles.disabled,
+                    ]}
+                    accessibilityRole="button"
+                    accessibilityLabel="Open this seed"
+                  >
+                    <MaterialCommunityIcons name="dice-multiple" size={16} color={titleColor} />
+                    <Text style={[styles.seedButtonText, { color: titleColor }]}>Go</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            )}
+          </ScrollView>
+        </View>
+      </Animated.View>
+    </Modal>
+  );
+};
+
+/** "5×5 or 6×6" / "10×10" — how a rung says what it will hand you. */
+const describeSizes = (sizes) => sizes.map((n) => `${n}×${n}`).join(' or ');
+
+// Sudoku's menu button colors, matched rung for rung: easy green, medium amber,
+// hard and expert red.
+const BUTTON_TINTS = {
+  easy: { backgroundColor: '#d4edda' },
+  medium: { backgroundColor: '#ffeeba' },
+  hard: { backgroundColor: '#f8d7da' },
+  expert: { backgroundColor: '#f8d7da' },
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.35)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 100,
+  },
+  box: {
+    width: 280,
+    maxHeight: '88%',
+    borderRadius: 12,
+    borderWidth: 1,
+    paddingHorizontal: 20,
+    paddingTop: 24,
+    paddingBottom: 16,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+    elevation: 6,
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 10,
+    right: 10,
+    padding: 5,
+    zIndex: 1,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 16,
+    marginBottom: 14,
+  },
+  scroll: {
+    alignSelf: 'stretch',
+  },
+  scrollBody: {
+    alignItems: 'center',
+    paddingBottom: 4,
+  },
+  button: {
+    width: 200,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: 'transparent',
+    marginBottom: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  buttonEmoji: {
+    fontSize: 20,
+    marginRight: 8,
+  },
+  buttonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    flex: 1,
+  },
+  buttonMeta: {
+    fontSize: 11,
+    opacity: 0.7,
+  },
+  disabled: {
+    opacity: 0.35,
+  },
+  devSection: {
+    alignSelf: 'stretch',
+    alignItems: 'center',
+    marginTop: 6,
+  },
+  sectionLabel: {
+    fontSize: 11,
+    fontWeight: '700',
+    opacity: 0.7,
+    marginTop: 8,
+    marginBottom: 6,
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+  },
+  chip: {
+    paddingVertical: 5,
+    paddingHorizontal: 9,
+    borderRadius: 8,
+    borderWidth: 1,
+    marginHorizontal: 3,
+    marginVertical: 3,
+  },
+  chipText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  seedRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  seedInput: {
+    width: 96,
+    paddingVertical: 5,
+    paddingHorizontal: 8,
+    borderWidth: 1,
+    borderRadius: 8,
+    fontSize: 13,
+    marginRight: 8,
+  },
+  seedButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+  },
+  seedButtonText: {
+    fontSize: 12,
+    fontWeight: '600',
+    marginLeft: 4,
+  },
+});
+
+export default FungikuMenuModal;

--- a/SudokuApp/games/fungiku/FungikuScreen.js
+++ b/SudokuApp/games/fungiku/FungikuScreen.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -12,8 +12,10 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 import ScreenHeader from '../../components/ScreenHeader';
 import useAppTheme from '../../hooks/useAppTheme';
 import FungikuBoard from './FungikuBoard';
+import FungikuMenuModal from './FungikuMenuModal';
 import FungikuWinBanner from './FungikuWinBanner';
-import { FungikuProvider, SIZES, useFungikuContext } from './FungikuContext';
+import { difficultyLabel } from './difficulty';
+import { FungikuProvider, useFungikuContext } from './FungikuContext';
 
 // The accent Fungiku is identified by on the hub card; reused for the win banner
 // so winning looks like Fungiku rather than a generic green success box.
@@ -35,6 +37,7 @@ const FungikuScreenContent = ({ onExitToHub }) => {
   const [boardTouchActive, setBoardTouchActive] = useState(false);
 
   const {
+    difficulty,
     size,
     seed,
     mushroomCount,
@@ -46,7 +49,9 @@ const FungikuScreenContent = ({ onExitToHub }) => {
     undo,
     redo,
     clearMarks,
+    changeDifficulty,
     changeSize,
+    changeSeed,
     nextPuzzle,
     ruleOut,
     ruleOutCount,
@@ -66,6 +71,41 @@ const FungikuScreenContent = ({ onExitToHub }) => {
   const surface = theme.colors.numberPad.background;
   const border = theme.colors.numberPad.border;
 
+  // --- the difficulty menu (plan §14.1) ------------------------------------
+  const [menuVisible, setMenuVisible] = useState(false);
+
+  // Opened once, on arrival, when there is nothing to come back to — the same
+  // way Sudoku opens its menu when no game is in progress. A restored board (or
+  // one already being played) is not interrupted: the header button is how you
+  // reach the menu then.
+  //
+  // The provider withholds its children until hydration, so this component's
+  // first render already sees the restored board and `hasMarks` is trustworthy
+  // here. Guarded by a ref rather than by `hasMarks` alone, or clearing the
+  // board mid-game would pop the menu open.
+  const openedOnArrival = useRef(false);
+  useEffect(() => {
+    if (openedOnArrival.current) return;
+    openedOnArrival.current = true;
+    if (!hasMarks) setMenuVisible(true);
+  }, [hasMarks]);
+
+  const closeMenu = () => setMenuVisible(false);
+
+  // Every path out of the menu starts a board, so every one of them closes it.
+  const pickDifficulty = (next) => {
+    closeMenu();
+    changeDifficulty(next);
+  };
+  const pickSize = (next) => {
+    closeMenu();
+    changeSize(next);
+  };
+  const pickSeed = (next) => {
+    closeMenu();
+    changeSeed(next);
+  };
+
   // The status line follows the state of play instead of always explaining the
   // tap cycle. (Named `statusText`, not `hint` — `hint` is the hint object from
   // context, and shadowing it here silently broke the build once.)
@@ -79,7 +119,32 @@ const FungikuScreenContent = ({ onExitToHub }) => {
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
-      <ScreenHeader title="Fungiku" theme={theme} onHomePress={onExitToHub} />
+      {/* Which board you are on lives in the header (plan §14.1), not in a
+          banner above the board. A view that mounts above the board *moves* the
+          board, which invalidates the origin every tap is resolved against —
+          the bug behind FungikuBoard's re-measure effect. The header is always
+          mounted and its subtitle is always present, so its height never
+          changes and there is no origin to invalidate. */}
+      <ScreenHeader
+        title="Fungiku"
+        subtitle={`${difficultyLabel(difficulty)} · ${size}×${size}`}
+        theme={theme}
+        onHomePress={onExitToHub}
+        onMenuPress={() => setMenuVisible(true)}
+      />
+
+      <FungikuMenuModal
+        visible={menuVisible}
+        theme={theme}
+        difficulty={difficulty}
+        size={size}
+        seed={seed}
+        generating={generating}
+        onPickDifficulty={pickDifficulty}
+        onPickSize={pickSize}
+        onPickSeed={pickSeed}
+        onClose={closeMenu}
+      />
 
       {/* Two halves of one fix for "a vertical drag scrolls instead of painting"
           (the board claims the touch at touch-down; see FungikuBoard):
@@ -118,6 +183,7 @@ const FungikuScreenContent = ({ onExitToHub }) => {
           >
             {mushroomCount}/{size}
           </Text>
+
           <Text
             style={[styles.counterHint, { color: titleColor }]}
             // Announced, because a player who cannot see the spinner still needs
@@ -279,35 +345,13 @@ const FungikuScreenContent = ({ onExitToHub }) => {
           </TouchableOpacity>
         </View>
 
-        {/* Board size + next puzzle — the stand-in for the ladder step.
+        {/* Another board at this difficulty, and the way to the menu.
 
-            Six chips no longer fit one row on a narrow phone (6 × ~56pt beats a
-            360pt screen), so the row wraps rather than squeezing the chips down
-            to something hard to hit. */}
-        <Text style={[styles.label, { color: titleColor }]}>Board size</Text>
-        <View style={[styles.controlRow, styles.chipRow]}>
-          {SIZES.map((option) => (
-            <TouchableOpacity
-              key={option}
-              onPress={() => changeSize(option)}
-              disabled={generating}
-              style={[
-                styles.chip,
-                { borderColor: border },
-                option === size && { backgroundColor: titleColor, borderColor: titleColor },
-                generating && styles.toolButtonDisabled,
-              ]}
-              accessibilityRole="button"
-              accessibilityState={{ disabled: generating, selected: option === size }}
-              accessibilityLabel={`${option} by ${option} board`}
-            >
-              <Text style={[styles.chipText, { color: option === size ? surface : titleColor }]}>
-                {option}×{option}
-              </Text>
-            </TouchableOpacity>
-          ))}
-        </View>
-
+            The size chips and the seed both moved into the menu (plan §14.1) —
+            picking a puzzle is one place now, not a row of developer controls
+            under the board. What is left here is the two things a player wants
+            mid-game without going shopping: another board like this one, and the
+            menu. */}
         <View style={styles.controlRow}>
           <TouchableOpacity
             onPress={nextPuzzle}
@@ -324,7 +368,18 @@ const FungikuScreenContent = ({ onExitToHub }) => {
             accessibilityLabel="Generate the next puzzle"
           >
             <MaterialCommunityIcons name="dice-multiple" size={18} color={titleColor} />
-            <Text style={[styles.buttonText, { color: titleColor }]}>New puzzle (seed {seed})</Text>
+            <Text style={[styles.buttonText, { color: titleColor }]}>New puzzle</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            onPress={() => setMenuVisible(true)}
+            style={[styles.wideButton, styles.menuButtonSpacing, { borderColor: border }]}
+            accessibilityRole="button"
+            accessibilityLabel="Change difficulty"
+            accessibilityHint="Opens the menu to pick a difficulty"
+          >
+            <MaterialCommunityIcons name="tune-variant" size={18} color={titleColor} />
+            <Text style={[styles.buttonText, { color: titleColor }]}>Difficulty</Text>
           </TouchableOpacity>
         </View>
       </ScrollView>
@@ -446,27 +501,8 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     marginLeft: 5,
   },
-  label: {
-    fontSize: 12,
-    fontWeight: '600',
-    marginTop: 18,
-  },
-  chipRow: {
-    flexWrap: 'wrap',
-    alignSelf: 'stretch',
-  },
-  chip: {
-    paddingVertical: 6,
-    paddingHorizontal: 12,
-    borderRadius: 8,
-    borderWidth: 1,
-    marginHorizontal: 4,
-    // Spacing for the second row once the chips wrap.
-    marginVertical: 3,
-  },
-  chipText: {
-    fontSize: 13,
-    fontWeight: '600',
+  menuButtonSpacing: {
+    marginLeft: 8,
   },
   wideButton: {
     flexDirection: 'row',

--- a/SudokuApp/games/fungiku/__tests__/difficulty.test.js
+++ b/SudokuApp/games/fungiku/__tests__/difficulty.test.js
@@ -1,0 +1,156 @@
+import {
+  DEFAULT_DIFFICULTY,
+  DIFFICULTIES,
+  DIFFICULTY_IDS,
+  difficultyForSize,
+  difficultyLabel,
+  isDifficulty,
+  sizeForDifficulty,
+  sizesForDifficulty,
+} from '../difficulty';
+import { MAX_SIZE, MIN_SIZE, SIZES, generate } from '../engine';
+
+describe('the difficulty table', () => {
+  it('offers the four rungs Sudoku offers, in the same order', () => {
+    expect(DIFFICULTY_IDS).toEqual(['easy', 'medium', 'hard', 'expert']);
+    expect(DIFFICULTIES.map((rung) => rung.label)).toEqual(['Easy', 'Medium', 'Hard', 'Expert']);
+  });
+
+  it('maps to the sizes the plan specifies (§14.1)', () => {
+    expect(sizesForDifficulty('easy')).toEqual([5, 6]);
+    expect(sizesForDifficulty('medium')).toEqual([7]);
+    expect(sizesForDifficulty('hard')).toEqual([8, 9]);
+    expect(sizesForDifficulty('expert')).toEqual([10]);
+  });
+
+  it('never names a size the engine does not support', () => {
+    DIFFICULTIES.forEach((rung) => {
+      expect(rung.sizes.length).toBeGreaterThan(0);
+      rung.sizes.forEach((size) => {
+        expect(SIZES).toContain(size);
+        expect(size).toBeGreaterThanOrEqual(MIN_SIZE);
+        expect(size).toBeLessThanOrEqual(MAX_SIZE);
+      });
+    });
+  });
+
+  it('covers every size the engine supports exactly once', () => {
+    // Both halves matter: no size is unreachable from the menu, and no size is
+    // claimed by two rungs (which would make difficultyForSize ambiguous).
+    const claimed = DIFFICULTIES.flatMap((rung) => rung.sizes);
+    expect([...claimed].sort((a, b) => a - b)).toEqual([...SIZES]);
+  });
+
+  it('starts on the gentlest rung', () => {
+    expect(DEFAULT_DIFFICULTY).toBe('easy');
+  });
+
+  it('recognizes its own rungs and nothing else', () => {
+    DIFFICULTY_IDS.forEach((id) => expect(isDifficulty(id)).toBe(true));
+    ['', 'EASY', 'trivial', null, undefined, 7].forEach((bad) =>
+      expect(isDifficulty(bad)).toBe(false)
+    );
+  });
+
+  it('falls back to the default rung for an unknown difficulty', () => {
+    expect(sizesForDifficulty('impossible')).toEqual(sizesForDifficulty(DEFAULT_DIFFICULTY));
+    expect(sizesForDifficulty(undefined)).toEqual(sizesForDifficulty(DEFAULT_DIFFICULTY));
+  });
+
+  it('labels a rung for the hub badge, and says nothing for a non-rung', () => {
+    expect(difficultyLabel('hard')).toBe('Hard');
+    expect(difficultyLabel('nonsense')).toBe('');
+  });
+});
+
+describe('picking a size for a difficulty', () => {
+  it('is determined by the seed, so {difficulty, seed} is always the same board', () => {
+    for (let seed = 0; seed < 12; seed++) {
+      DIFFICULTY_IDS.forEach((id) => {
+        expect(sizeForDifficulty(id, seed)).toBe(sizeForDifficulty(id, seed));
+      });
+    }
+  });
+
+  it('always resolves to one of that difficulty’s sizes', () => {
+    for (let seed = -5; seed < 20; seed++) {
+      DIFFICULTY_IDS.forEach((id) => {
+        expect(sizesForDifficulty(id)).toContain(sizeForDifficulty(id, seed));
+      });
+    }
+  });
+
+  it('reaches both sizes of a two-size rung across seeds', () => {
+    const seen = new Set();
+    for (let seed = 0; seed < 8; seed++) seen.add(sizeForDifficulty('easy', seed));
+    expect([...seen].sort()).toEqual([5, 6]);
+  });
+
+  it('is stable for a single-size rung whatever the seed', () => {
+    for (let seed = 0; seed < 8; seed++) {
+      expect(sizeForDifficulty('expert', seed)).toBe(10);
+      expect(sizeForDifficulty('medium', seed)).toBe(7);
+    }
+  });
+
+  it('survives a seed that is not a usable number', () => {
+    [undefined, null, NaN, Infinity, 'four'].forEach((seed) => {
+      expect(sizesForDifficulty('easy')).toContain(sizeForDifficulty('easy', seed));
+    });
+  });
+
+  it('treats a negative seed as its magnitude rather than returning undefined', () => {
+    expect(sizeForDifficulty('easy', -3)).toBe(sizeForDifficulty('easy', 3));
+  });
+});
+
+describe('naming the rung a raw size belongs to', () => {
+  it('inverts the table', () => {
+    expect(difficultyForSize(5)).toBe('easy');
+    expect(difficultyForSize(6)).toBe('easy');
+    expect(difficultyForSize(7)).toBe('medium');
+    expect(difficultyForSize(8)).toBe('hard');
+    expect(difficultyForSize(9)).toBe('hard');
+    expect(difficultyForSize(10)).toBe('expert');
+  });
+
+  it('falls back to the default rung for a size that is not on the table', () => {
+    // What a save from a build with different engine bounds would look like.
+    [0, 4, 11, 99, undefined, null].forEach((size) =>
+      expect(difficultyForSize(size)).toBe(DEFAULT_DIFFICULTY)
+    );
+  });
+});
+
+/**
+ * The point of this file. A typo in the table is not a wrong label — it is a
+ * crash for whoever picks that difficulty, because `generate()` throws for a size
+ * outside the engine's bounds.
+ *
+ * Deliberately slow: this generates 10×10, which is ~3s under Jest (the babel
+ * transform costs ~7× — plan §12.1), so the whole battery gets a generous
+ * timeout rather than being trimmed to the cheap sizes.
+ */
+describe('every difficulty generates a real board at every size it maps to', () => {
+  DIFFICULTIES.forEach((rung) => {
+    rung.sizes.forEach((size) => {
+      it(`${rung.id} at ${size}×${size}`, () => {
+        const puzzle = generate({ size, seed: 1 });
+
+        expect(puzzle.size).toBe(size);
+        expect(puzzle.solution).toHaveLength(size);
+        expect(puzzle.regions).toHaveLength(size * size);
+      }, 30000);
+    });
+  });
+
+  it('generates whatever the seed resolves to, for every rung', () => {
+    DIFFICULTY_IDS.forEach((id) => {
+      // Seed 2 exercises the other branch of a two-size rung than seed 1 does.
+      [1, 2].forEach((seed) => {
+        const size = sizeForDifficulty(id, seed);
+        expect(() => generate({ size, seed })).not.toThrow();
+      });
+    });
+  }, 60000);
+});

--- a/SudokuApp/games/fungiku/__tests__/reducer.test.js
+++ b/SudokuApp/games/fungiku/__tests__/reducer.test.js
@@ -14,8 +14,10 @@ import {
   selectMushroomCount,
   selectRevealCell,
   selectRuleOutCells,
+  resolvePuzzleIdentity,
 } from '../reducer';
 import { MARKS, MIN_SIZE, createEmptyMarks } from '../engine';
+import { DEFAULT_DIFFICULTY, sizesForDifficulty } from '../difficulty';
 
 const cycle = (state, cell) =>
   fungikuReducer(state, { type: FUNGIKU_ACTIONS.CYCLE_CELL, payload: { cell } });
@@ -274,6 +276,86 @@ describe('starting another puzzle', () => {
     expect(restored.seed).toBe(9);
     expect(restored.marks[12]).toBe(MARKS.MUSHROOM);
     expect(selectMushroomCount(restored)).toBe(1);
+  });
+});
+
+/**
+ * The difficulty menu's half of the puzzle identity (plan §14.1). Everything
+ * above the reducer speaks in rungs; `resolvePuzzleIdentity` is the one place a
+ * rung becomes a size, and it has to resolve in both directions.
+ */
+describe('resolving a puzzle identity', () => {
+  it('turns a rung into a size, deterministically from the seed', () => {
+    const a = resolvePuzzleIdentity({ difficulty: 'expert', seed: 4 });
+    expect(a).toEqual({ difficulty: 'expert', size: 10 });
+
+    expect(resolvePuzzleIdentity({ difficulty: 'easy', seed: 3 })).toEqual(
+      resolvePuzzleIdentity({ difficulty: 'easy', seed: 3 })
+    );
+  });
+
+  it('lets an explicit size win, and names the rung it belongs to', () => {
+    expect(resolvePuzzleIdentity({ size: 9, seed: 1 })).toEqual({ difficulty: 'hard', size: 9 });
+  });
+
+  it('keeps the caller’s rung when the size really is one of its sizes', () => {
+    // 6×6 is an easy board even on the seed where easy would have generated 5×5.
+    expect(resolvePuzzleIdentity({ difficulty: 'easy', size: 6, seed: 1 })).toEqual({
+      difficulty: 'easy',
+      size: 6,
+    });
+  });
+
+  it('lets the size overrule a rung it does not belong to', () => {
+    expect(resolvePuzzleIdentity({ difficulty: 'easy', size: 10, seed: 1 })).toEqual({
+      difficulty: 'expert',
+      size: 10,
+    });
+  });
+
+  it('resolves from the rung only when no size was given', () => {
+    const resolved = resolvePuzzleIdentity({ seed: 1 });
+    expect(resolved.difficulty).toBe(DEFAULT_DIFFICULTY);
+    expect(sizesForDifficulty(DEFAULT_DIFFICULTY)).toContain(resolved.size);
+  });
+
+  it('passes a bad size through rather than quietly rounding it into range', () => {
+    // `generate()` throwing is how a caller with a bug finds out; a silently
+    // substituted board would hide it. (buildPuzzleState's own test covers the
+    // throw.)
+    expect(resolvePuzzleIdentity({ size: 42, seed: 1 }).size).toBe(42);
+  });
+});
+
+describe('difficulty on built state', () => {
+  it('is carried on every board', () => {
+    expect(buildPuzzleState({ difficulty: 'medium', seed: 1 })).toMatchObject({
+      difficulty: 'medium',
+      size: 7,
+    });
+  });
+
+  it('is derived when only a size is given (the free-play chips)', () => {
+    expect(buildPuzzleState({ size: 8, seed: 1 }).difficulty).toBe('hard');
+  });
+
+  it('boots on the smallest board, labelled easy', () => {
+    // Pinned rather than resolved from the seed: this one generates at mount on
+    // the main thread with no "Generating…" state to hide behind.
+    const state = createInitialFungikuState();
+    expect(state.size).toBe(MIN_SIZE);
+    expect(state.difficulty).toBe(DEFAULT_DIFFICULTY);
+  });
+
+  it('reopens a restored board at its saved size, not at whatever the rung would pick', () => {
+    const marks = createEmptyMarks(6);
+    marks[3] = MARKS.MUSHROOM;
+
+    const restored = buildPuzzleState({ difficulty: 'easy', size: 6, seed: 1, marks });
+
+    expect(restored.size).toBe(6);
+    expect(restored.difficulty).toBe('easy');
+    expect(restored.marks[3]).toBe(MARKS.MUSHROOM);
   });
 });
 

--- a/SudokuApp/games/fungiku/__tests__/saveMigration.test.js
+++ b/SudokuApp/games/fungiku/__tests__/saveMigration.test.js
@@ -1,0 +1,115 @@
+import { FUNGIKU_STORAGE_VERSION, migrateFungikuSave } from '../saveMigration';
+import { MARKS, createEmptyMarks } from '../engine';
+
+/** A v1 save exactly as Steps 4-8 wrote one. */
+const v1Save = (overrides = {}) => {
+  const marks = createEmptyMarks(6);
+  marks[3] = MARKS.MUSHROOM;
+  marks[4] = MARKS.X;
+
+  return {
+    _v: 1,
+    size: 6,
+    seed: 7,
+    marks,
+    showMistakes: true,
+    hintsUsed: 2,
+    ...overrides,
+  };
+};
+
+describe('migrating a v1 save', () => {
+  it('names the difficulty the saved size belongs to', () => {
+    const migrated = migrateFungikuSave(v1Save());
+
+    expect(migrated._v).toBe(FUNGIKU_STORAGE_VERSION);
+    expect(migrated.difficulty).toBe('easy');
+  });
+
+  it('does not wipe or alter the board — this is the whole point', () => {
+    const saved = v1Save();
+    const migrated = migrateFungikuSave(saved);
+
+    expect(migrated.size).toBe(6);
+    expect(migrated.seed).toBe(7);
+    expect(migrated.marks).toEqual(saved.marks);
+  });
+
+  it('keeps the size even though the new difficulty could resolve to another one', () => {
+    // Easy spans 5-6. A migration that re-derived the size from the difficulty
+    // would hand back a 5×5 and strand the player's deductions on a board that
+    // no longer exists.
+    expect(migrateFungikuSave(v1Save({ size: 6, seed: 2 })).size).toBe(6);
+    expect(migrateFungikuSave(v1Save({ size: 5, seed: 1 })).size).toBe(5);
+  });
+
+  it('carries the other v1 fields forward untouched', () => {
+    const migrated = migrateFungikuSave(v1Save());
+
+    expect(migrated.showMistakes).toBe(true);
+    expect(migrated.hintsUsed).toBe(2);
+  });
+
+  it('maps every size a v1 save could hold onto a real rung', () => {
+    const expected = {
+      5: 'easy',
+      6: 'easy',
+      7: 'medium',
+      8: 'hard',
+      9: 'hard',
+      10: 'expert',
+    };
+
+    Object.entries(expected).forEach(([size, difficulty]) => {
+      const marks = createEmptyMarks(Number(size));
+      marks[0] = MARKS.X;
+      expect(migrateFungikuSave(v1Save({ size: Number(size), marks })).difficulty).toBe(difficulty);
+    });
+  });
+
+  it('does not mutate the blob it was handed', () => {
+    const saved = v1Save();
+    migrateFungikuSave(saved);
+    expect(saved._v).toBe(1);
+    expect(saved.difficulty).toBeUndefined();
+  });
+});
+
+describe('a current save', () => {
+  it('passes through unchanged', () => {
+    const saved = { ...v1Save(), _v: FUNGIKU_STORAGE_VERSION, difficulty: 'easy' };
+    expect(migrateFungikuSave(saved)).toEqual(saved);
+  });
+
+  it('has a corrupt difficulty repaired from its size rather than being discarded', () => {
+    const saved = { ...v1Save(), _v: FUNGIKU_STORAGE_VERSION, difficulty: 'legendary' };
+    expect(migrateFungikuSave(saved).difficulty).toBe('easy');
+    expect(migrateFungikuSave(saved).marks).toEqual(saved.marks);
+  });
+});
+
+describe('saves there is nothing trustworthy to restore from', () => {
+  it('refuses nothing at all', () => {
+    expect(migrateFungikuSave(null)).toBeNull();
+    expect(migrateFungikuSave(undefined)).toBeNull();
+    expect(migrateFungikuSave('{}')).toBeNull();
+  });
+
+  it('refuses a blob with no board in it', () => {
+    expect(migrateFungikuSave({ _v: 1, seed: 1, marks: [] })).toBeNull();
+    expect(migrateFungikuSave({ _v: 1, size: 6, seed: 1 })).toBeNull();
+    expect(migrateFungikuSave({ _v: 1, size: 'six', seed: 1, marks: [] })).toBeNull();
+  });
+
+  it('refuses a version from the future — a downgraded app cannot know the shape', () => {
+    expect(
+      migrateFungikuSave({ ...v1Save(), _v: FUNGIKU_STORAGE_VERSION + 1 })
+    ).toBeNull();
+  });
+
+  it('refuses a version with no path forward', () => {
+    // v0 never existed; there is no migration registered for it.
+    expect(migrateFungikuSave({ ...v1Save(), _v: 0 })).toBeNull();
+    expect(migrateFungikuSave({ ...v1Save(), _v: undefined })).toBeNull();
+  });
+});

--- a/SudokuApp/games/fungiku/difficulty.js
+++ b/SudokuApp/games/fungiku/difficulty.js
@@ -1,0 +1,135 @@
+/**
+ * Fungiku's difficulty menu (docs/fungiku-plan.md §14.1).
+ *
+ * Pure data and pure functions — no React, no storage — so the mapping is
+ * unit-testable and the UI has nothing to decide.
+ *
+ * **Difficulty is denominated in board size, and only board size, for now.**
+ * That is a deliberate narrowing, not an oversight: `generate({size, seed})`
+ * produces whatever it produces, there is no board rating, and the honest
+ * measure for this genre (how deep the forced-deduction chain runs) leans on
+ * `findForcedDeduction`, which §12.4 measured as shallow — 2 of 10 deductions
+ * from an empty 10×10. Rating boards with it today would score nearly everything
+ * expert.
+ *
+ * So the menu is built as a **seam**: everything above it speaks in
+ * `difficulty`, and the only thing difficulty currently resolves to is a size.
+ * Rated seeds can slot in behind `sizeForDifficulty` later with no UI change.
+ */
+import { SIZES } from './engine';
+
+/**
+ * The rungs, in order, with the shape the menu draws.
+ *
+ * `share` is **how many of the engine's sizes this rung claims**, walking `SIZES`
+ * from the bottom — not a size list. That is the whole point: the sizes come out
+ * of `SIZES` (derived from MIN_SIZE/MAX_SIZE in the engine), so the menu can
+ * never offer a size `generate()` rejects, and a change to the engine's bounds
+ * cannot leave a second hand-written list behind to drift (plan §14.1, §12).
+ *
+ * Shares of 2·1·2·1 over sizes 5-10 produce the plan's table:
+ *
+ *   | Easy | 5×5, 6×6 |  | Medium | 7×7 |  | Hard | 8×8, 9×9 |  | Expert | 10×10 |
+ *
+ * Labels and emoji match Sudoku's menu deliberately (`GameMenuModal`) — the
+ * platform hosts several games and the basics should read the same in each.
+ */
+const RUNGS = [
+  { id: 'easy', label: 'Easy', emoji: '😊', share: 2 },
+  { id: 'medium', label: 'Medium', emoji: '😐', share: 1 },
+  { id: 'hard', label: 'Hard', emoji: '😎', share: 2 },
+  { id: 'expert', label: 'Expert', emoji: '😈', share: 1 },
+];
+
+/**
+ * Hand out `SIZES` to the rungs by share, bottom up.
+ *
+ * Two guards, both about surviving a change to the engine's bounds rather than
+ * about today's numbers:
+ *   - the **top rung absorbs the remainder**, so a new largest size becomes
+ *     expert rather than silently dropping out of the menu;
+ *   - a rung that would come out **empty** (sizes got scarcer than the shares
+ *     assume) falls back to the largest size there is, so every rung in the menu
+ *     always starts a real board.
+ */
+const assignSizes = () => {
+  const out = {};
+  const top = SIZES[SIZES.length - 1];
+  let cursor = 0;
+
+  RUNGS.forEach((rung, index) => {
+    const isTop = index === RUNGS.length - 1;
+    const take = isTop ? Math.max(0, SIZES.length - cursor) : Math.min(rung.share, Math.max(0, SIZES.length - cursor));
+    const sizes = SIZES.slice(cursor, cursor + take);
+    cursor += take;
+    out[rung.id] = sizes.length > 0 ? sizes : [top];
+  });
+
+  return out;
+};
+
+const SIZES_BY_DIFFICULTY = assignSizes();
+
+/** The rungs the menu renders, in order: `{id, label, emoji, sizes}`. */
+export const DIFFICULTIES = RUNGS.map(({ id, label, emoji }) => ({
+  id,
+  label,
+  emoji,
+  sizes: SIZES_BY_DIFFICULTY[id],
+}));
+
+/** Just the ids, in menu order. */
+export const DIFFICULTY_IDS = DIFFICULTIES.map((rung) => rung.id);
+
+/**
+ * Where a player with nothing saved starts. The gentlest rung, matching how
+ * Sudoku's menu reads top-down.
+ */
+export const DEFAULT_DIFFICULTY = DIFFICULTY_IDS[0];
+
+/** Is this one of the menu's rungs? */
+export const isDifficulty = (difficulty) => DIFFICULTY_IDS.includes(difficulty);
+
+/** The sizes a difficulty can mean. Always a non-empty subset of `SIZES`. */
+export const sizesForDifficulty = (difficulty) =>
+  SIZES_BY_DIFFICULTY[isDifficulty(difficulty) ? difficulty : DEFAULT_DIFFICULTY];
+
+/** Human label for a difficulty ("Easy"), for the hub badge and the board. */
+export const difficultyLabel = (difficulty) => {
+  const rung = DIFFICULTIES.find((entry) => entry.id === difficulty);
+  return rung ? rung.label : '';
+};
+
+/**
+ * Which size a `{difficulty, seed}` pair means.
+ *
+ * A rung spanning two sizes has to pick one per game, and it picks **from the
+ * seed** so the pair is an identity: the same `{difficulty, seed}` is always the
+ * same board, which is what makes a save restorable and a seed shareable
+ * (plan §14.1).
+ */
+export const sizeForDifficulty = (difficulty, seed) => {
+  const sizes = sizesForDifficulty(difficulty);
+  if (sizes.length === 1) return sizes[0];
+
+  const safeSeed = Number.isFinite(seed) ? Math.abs(Math.trunc(seed)) : 0;
+  return sizes[safeSeed % sizes.length];
+};
+
+/**
+ * Which rung a raw size belongs to — the inverse of the table.
+ *
+ * Needed by the free-play size chips (a chip has to leave the state's difficulty
+ * label coherent) and by the storage migration, which has a saved `size` and no
+ * saved difficulty to read (plan §14.1).
+ *
+ * Note this is not a round trip: picking the 6×6 chip gives `easy`, but
+ * `sizeForDifficulty('easy', seed)` may well resolve to 5. `size` stays the
+ * authoritative fact about the board; difficulty is what the player picked it by.
+ */
+export const difficultyForSize = (size) => {
+  const rung = DIFFICULTIES.find((entry) => entry.sizes.includes(size));
+  return rung ? rung.id : DEFAULT_DIFFICULTY;
+};
+
+export default DIFFICULTIES;

--- a/SudokuApp/games/fungiku/reducer.js
+++ b/SudokuApp/games/fungiku/reducer.js
@@ -5,13 +5,13 @@
  * here: every rule question is answered by `engine.js`, so there is exactly one
  * place a row/column/region/adjacency check exists.
  *
- * What lives in state: the puzzle identity (`size` + `seed`), the puzzle data
- * rebuilt from it (`regions`, `solution`), and the player's `marks`. Conflicts,
- * the mushroom count and the win condition are **derived** from `marks` by the
- * selectors at the bottom rather than stored — storing them would let undo
- * rewind marks and leave stale highlights behind.
+ * What lives in state: the puzzle identity (`difficulty` + `size` + `seed`), the
+ * puzzle data rebuilt from it (`regions`, `solution`), and the player's `marks`.
+ * Conflicts, the mushroom count and the win condition are **derived** from
+ * `marks` by the selectors at the bottom rather than stored — storing them would
+ * let undo rewind marks and leave stale highlights behind.
  *
- * Only `size`, `seed` and `marks` are ever persisted (see ./storage.js);
+ * Only the identity plus `marks` is ever persisted (see ./storage.js);
  * generation is deterministic, so regions and the solution are rebuilt.
  */
 import {
@@ -26,6 +26,13 @@ import {
   isSolved,
   nextMark,
 } from './engine';
+import {
+  DEFAULT_DIFFICULTY,
+  difficultyForSize,
+  isDifficulty,
+  sizeForDifficulty,
+  sizesForDifficulty,
+} from './difficulty';
 
 export const FUNGIKU_ACTIONS = {
   NEW_PUZZLE: 'FUNGIKU_NEW_PUZZLE',
@@ -64,26 +71,70 @@ export const HINT_KINDS = {
 /** What a drag stroke does to the cells it crosses. */
 export const PAINT_MODES = { X: 'x', ERASE: 'erase' };
 
+/**
+ * The board the app boots on, before anything is picked or restored.
+ *
+ * Pinned to the smallest size rather than resolved from `DEFAULT_DIFFICULTY`,
+ * because this one runs at mount on the main thread with no "Generating…" state
+ * to hide behind — the cheapest board there is, is the right one. It is still a
+ * legitimate *easy* board (easy spans 5-6), so the identity stays coherent.
+ */
 export const DEFAULT_SIZE = MIN_SIZE;
 export const DEFAULT_SEED = 1;
+
+/**
+ * Resolve a puzzle identity, keeping `difficulty` and `size` consistent whichever
+ * one the caller actually knows (plan §14.1).
+ *
+ * Two entry paths, and they resolve in opposite directions:
+ *   - **the difficulty menu** knows a rung and not a size, so the size comes from
+ *     `sizeForDifficulty(difficulty, seed)`;
+ *   - **a free-play size chip, and a restored save**, know a size — that size is
+ *     authoritative and the difficulty is the rung it belongs to.
+ *
+ * The second case is why a save is not rewritten on load: a v1 save of a 6×6
+ * reopens as a 6×6 labelled *Easy*, not as whatever Easy would have generated.
+ *
+ * A size that was *given* is passed through even when the engine will reject it,
+ * rather than being quietly rounded into range — `generate()` throwing is how a
+ * caller with a bug (or a corrupt save) finds out. Only an **absent** size is
+ * resolved from the difficulty.
+ */
+export const resolvePuzzleIdentity = ({ difficulty, size, seed }) => {
+  if (size === undefined || size === null) {
+    const rung = isDifficulty(difficulty) ? difficulty : DEFAULT_DIFFICULTY;
+    return { difficulty: rung, size: sizeForDifficulty(rung, seed) };
+  }
+
+  // Keep the caller's rung when the size really is one of its sizes; otherwise
+  // the size wins and names its own rung.
+  const named = isDifficulty(difficulty) && sizesForDifficulty(difficulty).includes(size);
+  return { difficulty: named ? difficulty : difficultyForSize(size), size };
+};
 
 /**
  * Build a fresh state for a puzzle identity. Calls `generate`, which throws for
  * an unsupported size — callers do this outside the reducer so a generation
  * failure never happens mid-dispatch.
  *
- * @param {{size: number, seed: number, marks?: string[]}} opts
+ * @param {{difficulty?: string, size?: number, seed?: number, marks?: string[]}} opts
  */
 export const buildPuzzleState = ({
-  size = DEFAULT_SIZE,
+  difficulty,
+  size,
   seed = DEFAULT_SEED,
   marks,
   showMistakes = false,
   hintsUsed = 0,
 } = {}) => {
-  const puzzle = generate({ size, seed });
+  const identity = resolvePuzzleIdentity({ difficulty, size, seed });
+  const puzzle = generate({ size: identity.size, seed });
 
   return {
+    // What the player picked, and what it resolved to. Both are persisted: the
+    // difficulty is what the hub's Continue badge names, the size is what the
+    // board actually is.
+    difficulty: identity.difficulty,
     size: puzzle.size,
     seed: puzzle.seed,
     regions: puzzle.regions,
@@ -111,7 +162,14 @@ export const buildPuzzleState = ({
   };
 };
 
-export const createInitialFungikuState = () => buildPuzzleState();
+export const createInitialFungikuState = () =>
+  buildPuzzleState({
+    difficulty: DEFAULT_DIFFICULTY,
+    // Explicit, so booting never resolves a seed into a bigger board than it has
+    // to generate synchronously at mount (see DEFAULT_SIZE).
+    size: DEFAULT_SIZE,
+    seed: DEFAULT_SEED,
+  });
 
 /**
  * Undo entries hold a whole `marks` snapshot rather than a per-cell delta.

--- a/SudokuApp/games/fungiku/saveMigration.js
+++ b/SudokuApp/games/fungiku/saveMigration.js
@@ -1,0 +1,83 @@
+/**
+ * Fungiku's saved-game shape, and how an older one is brought forward.
+ *
+ * Pure: no AsyncStorage, no React. That is why it is not in `./storage.js` —
+ * the migration is the part worth unit-testing, and the test runner is a plain
+ * node environment (see package.json's jest config).
+ *
+ * **Why this exists now.** Until Step 9 a version mismatch just returned null:
+ * a Fungiku board was seconds of play, so discarding it beat guessing at an old
+ * shape. Step 9 is where that stops being true — `difficulty` is the first field
+ * a save carries that the player *chose*, and Step 11's assist wallet will ride
+ * along behind it. From here a bump migrates (plan §14.1, §13).
+ *
+ * **The rule for the next bump:** add a `MIGRATIONS` entry keyed by the version
+ * it upgrades *from*, returning the next version's shape. Never edit an existing
+ * one — it describes a shape already on real devices.
+ */
+import { difficultyForSize, isDifficulty } from './difficulty';
+
+/**
+ * v1 — `{size, seed, marks, showMistakes, hintsUsed}` (Steps 4-8).
+ * v2 — v1 plus `difficulty`, the rung the player picked (Step 9).
+ */
+export const FUNGIKU_STORAGE_VERSION = 2;
+
+/**
+ * v1 → v2: name the rung the saved board belongs to.
+ *
+ * The saved **size is left exactly as it was**, and the difficulty is derived
+ * *from* it rather than the other way around. Re-resolving the size from the new
+ * difficulty would silently hand back a different board — which is the one thing
+ * a migration must not do: the marks in this save are deductions about *this*
+ * grid.
+ */
+const v1ToV2 = (saved) => ({
+  ...saved,
+  difficulty: difficultyForSize(saved.size),
+});
+
+/** Keyed by the version each function upgrades *from*. */
+const MIGRATIONS = {
+  1: v1ToV2,
+};
+
+/**
+ * Bring a saved blob up to `FUNGIKU_STORAGE_VERSION`.
+ *
+ * @param {Object|null} saved - the parsed blob straight out of storage
+ * @returns {Object|null} a current-shape blob, or null when there is nothing
+ *   trustworthy to restore: no save, a shape with no board in it, a version from
+ *   the future (a downgraded app — it cannot know what was added), or a version
+ *   with no path forward.
+ */
+export const migrateFungikuSave = (saved) => {
+  if (!saved || typeof saved !== 'object') return null;
+  if (!Number.isFinite(saved.size) || !Array.isArray(saved.marks)) return null;
+
+  let version = Number.isFinite(saved._v) ? saved._v : 0;
+  let current = saved;
+
+  // A future version is not a mismatch to repair — the fields it added are
+  // unknown here, so the honest move is to leave it alone and start fresh.
+  if (version > FUNGIKU_STORAGE_VERSION) return null;
+
+  while (version < FUNGIKU_STORAGE_VERSION) {
+    const step = MIGRATIONS[version];
+    if (!step) return null;
+    current = step(current);
+    version += 1;
+  }
+
+  // Belt and braces: a hand-edited or corrupt `difficulty` should not reach the
+  // menu as a rung that does not exist.
+  return {
+    ...current,
+    _v: FUNGIKU_STORAGE_VERSION,
+    difficulty: isDifficulty(current.difficulty)
+      ? current.difficulty
+      : difficultyForSize(current.size),
+  };
+};
+
+export default migrateFungikuSave;

--- a/SudokuApp/games/fungiku/storage.js
+++ b/SudokuApp/games/fungiku/storage.js
@@ -1,19 +1,24 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import debounce from '../../utils/debounce';
 import { buildPuzzleState } from './reducer';
+import { FUNGIKU_STORAGE_VERSION, migrateFungikuSave } from './saveMigration';
 import { describeFungikuProgress } from '../../utils/gameProgress';
 
 /**
  * Fungiku's persistence — its **own** key, so the two games can never clobber
  * each other's saved state (docs/fungiku-plan.md §6).
  *
- * Only `size`, `seed` and `marks` are written. Generation is deterministic, so
- * regions and the solution are rebuilt with `generate()` on restore rather than
- * stored — a second copy of derived data is just a staler copy. It also means a
- * saved game is tiny and survives changes to region-growing internals.
+ * Only the puzzle identity (`difficulty`, `size`, `seed`) and `marks` are
+ * written. Generation is deterministic, so regions and the solution are rebuilt
+ * with `generate()` on restore rather than stored — a second copy of derived data
+ * is just a staler copy. It also means a saved game is tiny and survives changes
+ * to region-growing internals.
+ *
+ * The version and how an old save is brought forward live in ./saveMigration.js,
+ * which is pure and therefore testable.
  */
 export const FUNGIKU_STORAGE_KEY = '@FungikuGame';
-export const FUNGIKU_STORAGE_VERSION = 1;
+export { FUNGIKU_STORAGE_VERSION };
 
 /**
  * Load and rehydrate a saved Fungiku game.
@@ -26,16 +31,15 @@ export const loadFungikuState = async () => {
     const serialized = await AsyncStorage.getItem(FUNGIKU_STORAGE_KEY);
     if (serialized === null) return null;
 
-    const saved = JSON.parse(serialized);
-    if (saved._v !== FUNGIKU_STORAGE_VERSION) {
-      // Nothing worth migrating yet: a Fungiku board is seconds of play, so
-      // starting fresh beats guessing at an old shape.
-      return null;
-    }
+    // An older save is upgraded rather than discarded — from Step 9 on, a save
+    // carries choices the player made (plan §14.1).
+    const saved = migrateFungikuSave(JSON.parse(serialized));
+    if (!saved) return null;
 
     // Rebuilding through buildPuzzleState also validates the save: a `marks`
     // array of the wrong length for this size is discarded, not rendered.
     return buildPuzzleState({
+      difficulty: saved.difficulty,
       size: saved.size,
       seed: saved.seed,
       marks: saved.marks,
@@ -55,6 +59,10 @@ export const saveFungikuState = debounce(async (state) => {
       FUNGIKU_STORAGE_KEY,
       JSON.stringify({
         _v: FUNGIKU_STORAGE_VERSION,
+        // The rung the player picked. Stored alongside the size rather than
+        // instead of it: the size is what the board *is*, the difficulty is what
+        // it was chosen by, and a rung spanning two sizes cannot recover which.
+        difficulty: state.difficulty,
         size: state.size,
         seed: state.seed,
         marks: state.marks,
@@ -80,7 +88,9 @@ export const readFungikuProgress = async () => {
   try {
     const serialized = await AsyncStorage.getItem(FUNGIKU_STORAGE_KEY);
     if (serialized === null) return null;
-    return describeFungikuProgress(JSON.parse(serialized));
+    // Migrated first, so a save written before difficulty existed still draws a
+    // badge — and draws it with a rung name rather than falling back to a size.
+    return describeFungikuProgress(migrateFungikuSave(JSON.parse(serialized)));
   } catch (error) {
     console.error('Error reading Fungiku progress:', error);
     return null;

--- a/SudokuApp/utils/__tests__/gameProgress.test.js
+++ b/SudokuApp/utils/__tests__/gameProgress.test.js
@@ -68,10 +68,10 @@ describe('describeFungikuProgress', () => {
   const saveWith = (mutate) => {
     const marks = createEmptyMarks(5);
     mutate(marks);
-    return { size: 5, seed: 3, marks };
+    return { difficulty: 'easy', size: 5, seed: 3, marks };
   };
 
-  it('summarizes a board in progress', () => {
+  it('summarizes a board in progress, named by its difficulty', () => {
     const saved = saveWith((marks) => {
       marks[0] = MARKS.MUSHROOM;
       marks[7] = MARKS.MUSHROOM;
@@ -79,7 +79,7 @@ describe('describeFungikuProgress', () => {
     });
 
     expect(describeFungikuProgress(saved)).toEqual({
-      label: '5×5',
+      label: 'Easy',
       detail: '2 of 5 placed',
     });
   });
@@ -90,9 +90,29 @@ describe('describeFungikuProgress', () => {
     });
 
     expect(describeFungikuProgress(saved)).toEqual({
-      label: '5×5',
+      label: 'Easy',
       detail: '0 of 5 placed',
     });
+  });
+
+  it('names the harder rungs too', () => {
+    const marks = createEmptyMarks(10);
+    marks[0] = MARKS.MUSHROOM;
+
+    expect(describeFungikuProgress({ difficulty: 'expert', size: 10, marks })).toEqual({
+      label: 'Expert',
+      detail: '1 of 10 placed',
+    });
+  });
+
+  it('falls back to the rung the size belongs to when the save has no difficulty', () => {
+    // Belt and braces: callers migrate first, so this covers a blob that did not.
+    const saved = saveWith((marks) => {
+      marks[0] = MARKS.MUSHROOM;
+    });
+    delete saved.difficulty;
+
+    expect(describeFungikuProgress(saved).label).toBe('Easy');
   });
 
   it('returns null for an untouched board', () => {

--- a/SudokuApp/utils/gameProgress.js
+++ b/SudokuApp/utils/gameProgress.js
@@ -6,6 +6,7 @@
  * plain node environment (see package.json's jest config).
  */
 import { MARKS } from '../games/fungiku/engine';
+import { difficultyForSize, difficultyLabel } from '../games/fungiku/difficulty';
 
 const TOTAL_SUDOKU_CELLS = 81;
 
@@ -47,8 +48,14 @@ export const describeSudokuProgress = (saved) => {
 /**
  * Summarize a saved Fungiku board for a hub card.
  *
- * Takes the raw saved blob (`{ size, seed, marks }`) rather than a rebuilt
- * state, so the hub never has to run the generator just to draw a badge.
+ * Takes the raw saved blob (`{ difficulty, size, seed, marks }`) rather than a
+ * rebuilt state, so the hub never has to run the generator just to draw a badge.
+ * Callers pass it through `migrateFungikuSave` first, which is what guarantees
+ * `difficulty` is there; the fallback below covers a blob that skipped that.
+ *
+ * The label **names the rung, not the size** (plan §14.1) — it is what the player
+ * chose, and it is the same vocabulary Sudoku's badge uses one card away. The
+ * size is still visible, in the detail line's total.
  *
  * @param {Object|null} saved
  * @returns {{label: string, detail: string}|null} null when the board is
@@ -63,9 +70,10 @@ export const describeFungikuProgress = (saved) => {
   if (!touched) return null;
 
   const placed = saved.marks.filter((mark) => mark === MARKS.MUSHROOM).length;
+  const label = difficultyLabel(saved.difficulty) || difficultyLabel(difficultyForSize(saved.size));
 
   return {
-    label: `${saved.size}×${saved.size}`,
+    label,
     detail: `${placed} of ${saved.size} placed`,
   };
 };

--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -92,97 +92,129 @@ operator to test in Expo Go.**
 
 ---
 
-## Next step: **Step 9 — the difficulty menu**
+## Next step: **Step 10 — lives and mistakes**
 
-Branch: **`feature/fungiku-difficulty`** off `epic/fungiku`.
-Plan: **§14** — read **all of it** before starting, not just §14.1. It records
-five operator requirements decided on 2026-07-26 that reshape Steps 9–12, and
-three of them contradict decisions earlier steps made deliberately. §14 explains
-why each reversal is sound; do not re-derive those arguments and do not "fix" the
-contradictions back.
+Branch: **`feature/fungiku-lives`** off `epic/fungiku`.
+Plan: **§14.2 and §14.3** — read **both, in full**, plus §14's preamble and
+§11.1 (which §14.3 supersedes). This step deletes things earlier steps built
+deliberately. §14.3 explains why each removal is sound; do not re-derive those
+arguments and do not put the deleted behaviors back.
 
-### What changed, in one paragraph
+### Why these two are one step
 
-**The training ladder is cancelled.** The operator asked for Fungiku to use the
-same difficulty menu the platform's other game already has — easy · medium ·
-hard · expert — on the reasoning that basic mechanics should work the same way
-across games. §13's ladder research is superseded but kept. Steps 10 and 11 are
-new (lives, then earned assists); the art swap floats out to Step 12.
-
-### Why this step exists
-
-Fungiku's only way into a game is a row of raw size chips. That is a developer
-control, not a way a player picks a puzzle, and it does not match how Sudoku
-works two taps away in the same app.
+§14.2 is a new input gesture (tap = ✕, double-tap = 🍄) and §14.3 is what a
+mushroom placement now costs. They are the same input surface, and building the
+double-tap without the life cost would ship a mushroom-placing gesture with no
+consequence attached. **Do not split them.**
 
 ### Scope — ONLY this
 
-1. **Difficulty as data.** Easy 5×5/6×6 · Medium 7×7 · Hard 8×8/9×9 ·
-   Expert 10×10 (§14.1). **Map into `SIZES`; do not write a second size list** —
-   `SIZES` is derived from the engine bounds so the UI cannot offer a size
-   `generate()` rejects. A difficulty spanning two sizes must pick one
-   **deterministically from the seed**, so `{difficulty, seed}` is always the
-   same board.
-2. **A difficulty picker as the primary path in**, matching Sudoku's vocabulary
-   and placement — `components/modals/GameMenuModal.js` is the shape to copy.
-   Keep the size chips as a free-play escape hatch; they are how a size gets
-   checked by hand.
-3. **The seed field moves into the menu**, developer-only, behind **one flag**
-   (the `BuildNotes` pattern) so hiding it later is a one-constant change.
-4. **The storage migration.** This is the **first change that must not wipe
-   someone's progress**: bump `FUNGIKU_STORAGE_VERSION` and write a real
-   migration for the existing `{size, seed, marks, showMistakes, hintsUsed}`
-   shape. A version mismatch currently discards the save silently — fine for a
-   board, not fine once difficulty and (Step 11) a wallet ride along.
-5. **The hub Continue badge** naming the difficulty rather than the board size
-   (`utils/gameProgress.js` → `describeFungikuProgress`).
-6. **Tests** — above all, **assert every difficulty generates a board at every
-   size it maps to.** A typo becomes a crash for whoever picks that difficulty.
+1. **Tap places ✕, double-tap places 🍄** (§14.2), replacing the three-state
+   cycle. Tap on a filled cell (either mark) clears it — that is what keeps every
+   state reachable once the cycle is gone. Drag-to-sweep is unchanged: a stroke
+   still only paints or erases ✕ and still never disturbs a mushroom.
+2. **A wrong mushroom is flagged immediately, leaves a red ✕, and costs a life**
+   (§14.3). **Three lives at every size** — not scaled per difficulty (the
+   operator's answer). At zero lives the **same board** restarts: same seed,
+   marks cleared, lives reset. A fresh board would punish twice and throw away
+   deduction already done.
+3. **Undo does not refund a life** — *"you don't get lives with info."* Undo still
+   retracts the mark.
+4. **Delete the "Show mistakes" toggle**, `TOGGLE_MISTAKES` and the
+   `showMistakes` field (§14.3 answers open question §8 #7 by deletion). This
+   needs a **storage migration to v3** — the plumbing is now in
+   `games/fungiku/saveMigration.js`, so it is one `MIGRATIONS[2]` entry.
+5. **Decide the conflict rendering explicitly, and say which in the PR** — see
+   below. This is a required output of this step, not an optional note.
+6. **Lives visible on screen**, and it should not move the board (see the deps
+   note below).
 
 ### Read first
 
-- **§14 of the plan**, all of it.
-- `SudokuApp/components/modals/GameMenuModal.js` — Sudoku's four difficulty
-  buttons: the vocabulary, placement and labels to match.
-- `SudokuApp/games/fungiku/storage.js` — `FUNGIKU_STORAGE_VERSION` and what a
-  version mismatch does today.
-- `SudokuApp/games/fungiku/reducer.js` — `buildPuzzleState` turns an identity
-  into a board; it grows a `difficulty` alongside `size`/`seed`.
-- `SudokuApp/games/fungiku/engine.js` — `SIZES`, `MIN_SIZE`, `MAX_SIZE`.
+- **§14.2, §14.3** of the plan, and §11.1 for what is being superseded.
+- `SudokuApp/games/fungiku/reducer.js` — `CYCLE_CELL` is the action that becomes
+  two, and `nextMark`/`MARK_CYCLE` in `engine.js` is the cycle being retired.
+- `SudokuApp/games/fungiku/FungikuBoard.js` — the `PanResponder`, the 6px
+  tap-vs-drag threshold, and where a second tap has to be detected.
+- `SudokuApp/games/fungiku/saveMigration.js` — how to add the v2 → v3 step. The
+  file's header states the rule: **add an entry, never edit an existing one.**
+- `SudokuApp/games/fungiku/difficulty.js` — three lives at every size means this
+  file should need **no change at all**; if you are editing it, re-read §14.3.
 
 ### Behaviors that are easy to get wrong
 
-- **Difficulty is board size and nothing else, on purpose.** There is no board
-  rating and building one is not this step. §12.4 measured `findForcedDeduction`
-  finding **2 of 10 deductions from an empty 10×10** — rating with it today would
-  score nearly everything expert. Build the menu so **rated seeds can slot in
-  behind it later without a UI change**, and leave it there.
-- **Expert generates a 10×10, which costs ~0.4s** and more on a phone. The
-  `generating` flag and the `requestAnimationFrame` + `setTimeout` deferral in
-  `FungikuContext` exist for exactly this — reuse them, do not reinvent. Any
-  picker that generates boards to preview them will be slow in a way the chips
-  never were.
-- **A test that generates every difficulty is the slowest in the suite.** A 10×10
-  costs ~3s *under Jest* (its transform is ~7×), which is why the engine battery
-  samples two seeds at the top size. Budget accordingly.
+- **Do not make single taps wait for the double-tap window.** The naive detector
+  delays every ✕ by ~250 ms, and the ✕ is the most common gesture in the game.
+  Place the ✕ **immediately** and *upgrade* the cell if a second tap lands inside
+  the window.
+- **The upgrade must be one undo entry, not two.** Otherwise undo after a
+  double-tap strands a ✕ the player never asked for. `BEGIN_STROKE`/`PAINT_CELLS`
+  already solve exactly this shape for drags — the same trick applies.
+- **The detector belongs inside the existing gesture, not beside it.** The board
+  claims every touch at touch-down to win the ScrollView race (§2). A second
+  `PanResponder` or a child `Touchable` will never see the second tap.
+- **A screen reader cannot express a double tap.** Cells carry
+  `onAccessibilityTap`; placing a mushroom needs an explicit alternative action
+  named in the `accessibilityLabel` (`accessibilityState` does not survive to the
+  web).
+- **This is a device question.** Double-tap timing — and whether a child can
+  produce one reliably — cannot be answered in a browser (§2, "A pattern worth
+  knowing"). Both native bugs the operator has found were invisible on web.
 - **Anything new above the board joins `FungikuBoard`'s re-measure deps**
   (`[hint, solved, generating, measure]`), or the first tap after it appears
-  lands on the wrong cell. A difficulty banner is exactly that shape.
+  lands on the wrong cell. A lives counter is exactly that shape. **Two places
+  now dodge this properly and are the patterns to copy:** the always-mounted
+  counter row (which is where "Generating…" lives) and the header's subtitle,
+  which Step 9 used for the difficulty because its height never changes.
+
+### The decision this step owes the next one
+
+Once a wrong mushroom is converted to a ✕ on placement, every mushroom left on
+the board sits at a solution cell — and two solution cells can never share a row,
+column or region, or touch. **So two placed mushrooms can no longer conflict,
+ever.** That makes several existing paths unreachable by construction:
+
+- the live conflict rendering from Steps 4–5,
+- `selectMistakes`, `showMistakes` / `TOGGLE_MISTAKES`,
+- hint rung 1 (`HINT_KINDS.MISTAKE`),
+- `selectRevealCell`'s -1 branch.
+
+§14.3 calls the loss of the "these two are fighting" read real, and asks you to
+**decide explicitly whether to remove the conflict rendering or leave it dormant,
+and say which in the PR.** Otherwise a later session finds highlighting that
+never fires and assumes it is broken. `findConflicts` itself **stays** — the
+engine needs it for generation, solving and the reveal-safety check.
+
+Note the screen's status line currently reports conflicts
+(`${conflicts.size} mushrooms breaking a rule` in `FungikuScreen`); whichever way
+you decide, that string is part of the decision.
 
 ### Out of scope for this step
 
-- **No lives, no double-tap** — that is Step 10 (§14.2, §14.3), and it is where
-  `showMistakes` and the conflict rendering get resolved. **Do not start deleting
-  them here.**
-- **No wallet or metering** — Step 11 (§14.4).
-- **No board rating / propagator work.** §14.1 is explicit that difficulty is
-  size-only for now.
-- **No generator re-engineering** (§12.1) and **no art swap** (Step 12).
+- **No wallet or metering** — Step 11 (§14.4). `hintsUsed` stays the per-puzzle
+  counter it is.
+- **No art swap** — Step 12.
+- **No board rating / propagator work** (§14.1, §12.1); difficulty stays
+  size-only.
+- **No new difficulty work.** The menu landed in Step 9 and lives are not
+  per-difficulty.
 
 ### Visible in Expo Go when this lands
 
-**You pick a difficulty, the way you do in Sudoku** — and the hub's Continue
-badge says which one you are in the middle of.
+**A wrong guess costs you something.** You tap to rule a cell out, double-tap to
+commit a mushroom, and a wrong commitment turns red and takes one of your three
+lives — three mistakes and the board you were working on starts over.
+
+### How to verify
+
+`npm test` · `npx expo-doctor` (18/18) · `npx expo export --platform all`, then
+drive the web build (serve `dist/`, Chromium at
+`/opt/pw-browsers/chromium-1194/chrome-linux/chrome` —
+**note the versioned path**, `/opt/pw-browsers/chromium` is a file, not the
+binary; do not run `playwright install`). Prove the migration on a **real** save:
+write a v2 blob into `localStorage['@FungikuGame']`, reload, and confirm the
+board and its marks come back. Then **ask the operator for a device pass** — the
+double-tap is the part a browser cannot answer.
 
 ## Open questions for the operator (carry these forward)
 
@@ -215,20 +247,42 @@ badge says which one you are in the middle of.
 8. **Should metering Rule out survive contact with a child?** (plan §14.4)
    Decided metered, but rule-out saves tedium rather than insight. Worth
    re-checking after a family play session.
+9. **Does a rung that spans two sizes read as inconsistent?** (new, Step 9) Easy
+   hands out 5×5 or 6×6 and Hard 8×8 or 9×9, picked from the seed — so two Easy
+   games in a row can be different sizes. It is deterministic (a
+   `{difficulty, seed}` pair is always the same board) and it is what the plan's
+   table asks for, but on device it may just read as "Easy is sometimes bigger".
+   Pinning each rung to one size is a one-line change in
+   `games/fungiku/difficulty.js` (`share` counts) if the operator prefers it.
 
 ### Noted in passing, for a later step
 
-- **Step 10 makes several existing code paths unreachable, by construction — not
-  by accident.** Once a wrong mushroom is converted to a ✕ on placement, every
-  mushroom left on the board is at a solution cell, and two solution cells can
-  never share a row, column or region or touch. So **two placed mushrooms can no
-  longer conflict**: the live conflict rendering from Steps 4–5 becomes dead UI,
-  along with `selectMistakes`, `showMistakes`/`TOGGLE_MISTAKES`, hint rung 1
-  (`HINT_KINDS.MISTAKE`) and `selectRevealCell`'s -1 branch. Plan §14.3 says
-  this is a real loss to weigh, and asks Step 10 to **decide explicitly whether
-  to remove the conflict rendering or leave it dormant, and say which in the
-  PR** — otherwise a later session finds highlighting that never fires and
-  assumes it is broken. `findConflicts` itself stays; the engine needs it.
+- **A save is migrated now, not discarded — and the plumbing has one rule.**
+  `games/fungiku/saveMigration.js` holds `FUNGIKU_STORAGE_VERSION` and a
+  `MIGRATIONS` map keyed by the version each function upgrades *from*. **Add an
+  entry; never edit an existing one** — an old entry describes a shape already on
+  real devices. It is a separate module from `storage.js` on purpose: it is pure,
+  and the Jest environment is plain node with no AsyncStorage.
+- **The migration derives difficulty from size, never size from difficulty.**
+  Easy spans 5-6, so re-resolving a saved board's size from its new rung would
+  hand the player a different board and strand their deductions. `size` is what
+  the board *is*; `difficulty` is what it was chosen by, and a rung spanning two
+  sizes cannot recover which. Both are persisted for that reason.
+- **An explicitly-passed bad size still throws.** `resolvePuzzleIdentity` resolves
+  a size from the difficulty **only when no size was given**; a size that *was*
+  given passes straight through so `generate()` rejects it loudly. A caller
+  passing size 4 has a bug, and quietly substituting a 5×5 would hide it. There
+  is a test pinning this in both directions.
+- **The difficulty menu is a seam, and rated seeds are what it is waiting for.**
+  Everything above `sizeForDifficulty` speaks in rungs; the only thing a rung
+  resolves to today is a board size. When the propagator is strong enough to rate
+  boards (§12.4 measured it at 2 of 10 deductions from an empty 10×10), rating
+  slots in behind that one function **with no UI change**. Do not add a second
+  concept of difficulty next to it.
+- **Free play and the seed field are behind one constant.**
+  `SHOW_DEVELOPER_CONTROLS` in `FungikuMenuModal.js`. Flip it to `false` and the
+  menu is four difficulty buttons; the size chips and the seed input are how a
+  size or a reported board gets checked by hand until then.
 - **A reveal is only reachable when nothing is forced.** The hint button gives the
   weakest hint that still helps, so while any forced deduction exists you get a
   nudge and never a reveal. That is deliberate — it is the pedagogically right
@@ -360,12 +414,12 @@ badge says which one you are in the middle of.
 | 6 | Input ergonomics — drag to sweep X's, rule-out button | merged to `epic/fungiku` (#72, `e896fb6`) |
 | 7 | Feedback & hints — mistake flagging, forced-deduction nudge, reveal, placement pop | merged to `epic/fungiku` (#73, `12f72c3`) |
 | 8 | Bigger boards — `MAX_SIZE = 10`, a tenth region colour tuned for CVD, no-wrap `getRegionColor`, generation announced, legibility at 32px, cost bound in rounds, board lines redrawn as a snapped overlay | merged to `epic/fungiku` (#75, `d4d2018`), operator-tested on device |
+| 9 | Difficulty menu — rungs mapped into `SIZES`, size-from-seed, menu modal, free play + seed behind one flag, real v1→v2 save migration, hub badge names the rung | PR to `epic/fungiku` |
 
 ## Steps still to come
 
 | # | Step | Plan |
 |---|------|------|
-| 9 | **Difficulty menu** — easy/medium/hard/expert mapped to board size, seeds into the menu, storage migration | §14.1 |
 | 10 | **Lives & mistakes** — tap ✕ / double-tap 🍄, wrong guess costs a life, three lives then restart | §14.2, §14.3 |
 | 11 | **Earned assists** — a wallet; hints and rule-out metered, earned by solving | §14.4 |
 | 12 | **Art swap** — floating, gated on artwork rather than code | §7 |

--- a/docs/fungiku-plan.md
+++ b/docs/fungiku-plan.md
@@ -374,7 +374,7 @@ the step's real acceptance test, alongside its automated checks.
 | 6 | ~~**Input ergonomics & assists**~~ ✅ (§2) — **drag to sweep X's**, rule-out button | **Swipe a finger across cells to rule them out**; a *Rule out* button |
 | 7 | ~~**Feedback & hints**~~ ✅ (§11) — correctness feedback on placements, and a hint ladder | **Optional "show mistakes" for mushrooms**, and a hint you can ask for when stuck |
 | 8 | ~~**Bigger boards, up to 10×10**~~ ✅ (§12) — `MAX_SIZE`, a 10th region colour, legibility at 32px cells, a generation-cost bound | **A playable 10×10** that generates without a visible freeze |
-| 9 | **Difficulty menu** (§14.1) — easy/medium/hard/expert mapped to board size, seeds moved into the menu, storage migration | **Pick a difficulty like you do in Sudoku**, instead of picking a raw board size |
+| 9 | ~~**Difficulty menu**~~ ✅ (§14.1) — rungs mapped *into* `SIZES`, size picked from the seed, menu modal matching Sudoku's, free play + seed field behind one flag, a real v1→v2 save migration, hub badge names the rung | **Pick a difficulty like you do in Sudoku**, instead of picking a raw board size |
 | 10 | **Lives & mistakes** (§14.2, §14.3) — tap ✕ / double-tap 🍄, wrong guess costs a life, three lives then the board restarts | **A wrong mushroom turns red and costs you a life**; run out and the board resets |
 | 11 | **Earned assists** (§14.4) — a wallet, hints and rule-out metered, earning on solve | **Hints and Rule out can run out**, and solving boards earns more |
 | 12 | **Art swap** (floating, asset-only — gated on artwork, not on code) | Static mushroom art replaces the icon glyph |
@@ -1000,6 +1000,13 @@ empty 10×10.** Rating boards with it today would score nearly everything
 "expert". Strengthening it with pigeonhole reasoning is real work and its own
 change.
 
+**How this shipped (Step 9).** `games/fungiku/difficulty.js` is the seam: the
+rungs declare a `share` — *how many of `SIZES` each claims*, walking up from the
+bottom — rather than a size list, so the sizes come out of the engine's bounds and
+a second list cannot drift. Shares of 2·1·2·1 over sizes 5-10 produce exactly the
+table below. Everything above `sizeForDifficulty(difficulty, seed)` speaks in
+rungs, so rated seeds slot in behind that one function with no UI change.
+
 So the mapping ships as sizes, and the menu is built so rated seeds can slot in
 behind it later **without a UI change**:
 
@@ -1024,6 +1031,21 @@ game is done. They are currently visible only in the "New puzzle (seed 3)" butto
 label and are not selectable. Put the field behind one flag — the same pattern
 `BuildNotes` already uses — so hiding it later is a one-constant change rather
 than a UI edit.
+
+**Shipped as** `SHOW_DEVELOPER_CONTROLS` in `games/fungiku/FungikuMenuModal.js`,
+covering both the seed input and the free-play size chips (which moved off the
+game screen into the same section). Flip the constant and the menu is four
+difficulty buttons.
+
+**The migration shipped as its own pure module**,
+`games/fungiku/saveMigration.js`: `FUNGIKU_STORAGE_VERSION` plus a `MIGRATIONS`
+map keyed by the version each function upgrades *from*. Separate from
+`storage.js` because that imports AsyncStorage and the Jest environment is plain
+node. The rule for the next bump is **add an entry, never edit an existing one** —
+an old entry describes a shape already on real devices. The v1→v2 step derives
+`difficulty` **from** the saved `size` and leaves the size alone; re-resolving the
+size from the new rung would hand the player a different board (easy spans 5-6)
+and strand the deductions the save exists to preserve.
 
 ### 14.2 Tap places X, double-tap places a mushroom
 


### PR DESCRIPTION
Step 9 of the Fungiku epic — refs #65, plan §14.1.

Fungiku's only way into a game was a row of raw board-size chips. That is a developer control, not a way a player picks a puzzle, and it does not match how Sudoku works two taps away in the same app. Now you pick a difficulty.

## Difficulty as data — `games/fungiku/difficulty.js`

| Difficulty | Sizes |
|---|---|
| Easy | 5×5, 6×6 |
| Medium | 7×7 |
| Hard | 8×8, 9×9 |
| Expert | 10×10 |

**The rungs declare a `share` of `SIZES`, not a size list.** Each rung claims *how many* of the engine's sizes it takes, walking up from the bottom; shares of 2·1·2·1 over sizes 5-10 produce exactly the table above. That is deliberate — the plan asked for the table to map *into* `SIZES` rather than becoming a second hand-written list, so the menu cannot offer a size `generate()` rejects and a change to `MIN_SIZE`/`MAX_SIZE` cannot leave a stale list behind to drift. Two guards for that day: the top rung absorbs any remainder (a new largest size becomes expert rather than dropping out of the menu), and a rung that would come out empty falls back to the largest size there is.

**A rung spanning two sizes picks one from the seed**, so `{difficulty, seed}` is an identity — the same pair is always the same board, which is what makes a save restorable and a seed shareable.

**Difficulty is board size and nothing else, on purpose.** There is no board rating, and §12.4 measured `findForcedDeduction` at 2 of 10 deductions from an empty 10×10, so rating with it today would score nearly everything expert. Everything above `sizeForDifficulty(difficulty, seed)` speaks in rungs, so **rated seeds slot in behind that one function later with no UI change**. No propagator work here.

## The menu — `games/fungiku/FungikuMenuModal.js`

Built to `components/modals/GameMenuModal` — same four rungs, same words, same emoji, same button colours, same order. Separate component rather than a shared one because Sudoku's menu is wired straight into `GameContext` and carries Sudoku-only controls; sharing the *shape* is the point.

- Opens **on arrival when there is nothing to continue**, the way Sudoku's does. A restored or in-progress board is not interrupted — guarded by a ref, so clearing the board mid-game does not pop it open.
- Reachable any time from a new header button, or the **Difficulty** button under the board.
- Each rung announces the sizes it will hand you (`Hard · 8×8 or 9×9`) — "Hard" alone does not say the board is about to get bigger.
- **Free play and the seed field sit behind one constant**, `SHOW_DEVELOPER_CONTROLS`. The size chips moved off the game screen into that section and the seed became an editable field instead of leaking through the `New puzzle (seed 3)` label. Flip the constant and the menu is four difficulty buttons; nothing else changes.

## The storage migration

The first change that must not wipe someone's progress, so a version mismatch now **migrates instead of silently discarding**.

`FUNGIKU_STORAGE_VERSION` and the migration moved to `games/fungiku/saveMigration.js` — its own module because it is pure, and `storage.js` imports AsyncStorage while the Jest environment is plain node. `MIGRATIONS` is keyed by the version each function upgrades *from*; the file states the rule for the next bump: **add an entry, never edit an existing one**, because an old entry describes a shape already on real devices.

**v1 → v2 derives `difficulty` from the saved `size` and leaves the size alone.** The other direction would be a bug: easy spans 5-6, so re-resolving a saved 6×6 from its new rung could hand back a 5×5 and strand the deductions the save exists to preserve. Both fields are persisted for that reason — `size` is what the board *is*, `difficulty` is what it was chosen by, and a rung spanning two sizes cannot recover which.

Also refuses, rather than guessing: a blob with no board in it, a version from the future (a downgraded app cannot know what was added), and a version with no path forward. A corrupt `difficulty` is repaired from the size rather than costing the player their board.

`readFungikuProgress` migrates too, so a save written before difficulty existed still draws a hub badge.

## Elsewhere

- `buildPuzzleState` carries a `difficulty` alongside `size`/`seed`. `resolvePuzzleIdentity` is the one place a rung becomes a size, and it resolves in whichever direction the caller knows: the menu knows a rung, a free-play chip and a restored save know a size.
- **A size that *was* given still passes through so `generate()` throws loudly** — only an *absent* size is resolved from the rung. A caller passing size 4 has a bug and quietly substituting a 5×5 would hide it. Pinned by tests in both directions; this is why the existing `rejects a board smaller than the engine supports` test still passes unchanged.
- The hub's Continue badge names the rung: **`Easy · 1 of 6 placed`**.
- `ScreenHeader` gains an optional `subtitle` and `onMenuPress`.

### Why the difficulty is in the header, not a banner

A view that mounts above the board **moves** the board, which invalidates the origin every tap is resolved against — the bug behind `FungikuBoard`'s re-measure effect, and the reason "Generating…" lives inside the always-mounted counter row. So this step did not add a banner. The header's subtitle (`Easy · 6×6`) is always present and `numberOfLines={1}`, so the header's height never changes and there is no origin to invalidate.

Checked rather than assumed: clicked the visual centre of a known cell in the browser and asserted the mark landed in *that* cell and nowhere else — both with and without a hint banner mounted above the board.

## Verification

- **`npm test` — 316 pass** (269 before). New batteries: `difficulty.test.js` and `saveMigration.test.js`, plus identity-resolution cases in the reducer.
  - The headline assertion the plan asked for: **every difficulty generates a real board at every size it maps to**, one test per rung/size pair. A typo in the table is not a wrong label, it is a crash for whoever picks that difficulty. Budgeted for the cost — a 10×10 is ~3s under Jest, so the battery carries a generous timeout rather than being trimmed to the cheap sizes.
- `npx expo-doctor` — **18/18**.
- `npx expo export --platform all` — web, iOS and Android all bundle.
- **Web build driven end to end in Chromium, no page errors**: menu on arrival → each rung → the deferred 10×10 expert generation → a free-play chip → the seed field → marks placed → hub badge → re-entry without the menu re-opening.
- **The migration proved on a real save, not just in unit tests**: wrote a v1 blob into `localStorage['@FungikuGame']`, reloaded, and confirmed the 6×6 seed 7 board came back with its marks intact, `showMistakes`/`hintsUsed` carried forward, header reading `Easy · 6×6`, and the save rewritten at `_v: 2`.

## Deliberately out of scope

No lives and no double-tap (Step 10 — `showMistakes` and the conflict rendering are still untouched here, on purpose); no wallet or metering (Step 11); no board rating or propagator work; no generator re-engineering; no art swap. Sudoku is untouched apart from `ScreenHeader`, which it does not use.

## For the operator

Two things worth an opinion on device:

1. **A rung that spans two sizes** means two Easy games in a row can be different sizes (deterministic from the seed, and what the plan's table asks for — but it may just read as "Easy is sometimes bigger"). Pinning each rung to one size is a one-line change to the `share` counts. Carried into the handoff as open question #9.
2. **Whether the menu opening on arrival** is right, or whether it should only ever open when asked for.

`docs/fungiku-handoff.md` is rewritten for **Step 10 — lives and mistakes**, including the conflict-rendering decision §14.3 requires that step to make explicitly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsDXXfTZaF5B8LT9cbkgfW)_