### PR TITLE
CI: install deps before eas branch:delete, so preview cleanup actually runs

### DIFF
--- a/.github/workflows/eas-publish.yml
+++ b/.github/workflows/eas-publish.yml
@@ -196,6 +196,15 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      # Required, and the reason this job silently did nothing for five PRs:
+      # `eas branch:delete` reads the app config, and resolving app.json's
+      # `expo-font` plugin needs node_modules. Without this step the command
+      # exits 1 on "Failed to resolve plugin for module expo-font" before it ever
+      # reaches the API -- and `continue-on-error` below hid that as a green job.
+      - name: Install dependencies
+        run: npm install
+        working-directory: ${{ env.APP_DIR }}
+
       - name: Set up EAS CLI (with token auth)
         uses: expo/expo-github-action@v8
         with:
@@ -203,9 +212,11 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Delete the preview branch
-        # Never fail the run over cleanup: the branch may not exist (a PR closed
-        # before any preview published), and a missing branch is the desired
-        # end state anyway.
+        # Still never fail the run over cleanup, but now for the case it was
+        # written for rather than by accident: `branch:delete` exits 1 when the
+        # branch does not exist ("Could not find branch pr-N"), which happens for
+        # a PR closed before any preview published -- and a missing branch is the
+        # desired end state anyway.
         continue-on-error: true
         run: eas branch:delete "pr-${{ github.event.number }}" --non-interactive
         working-directory: ${{ env.APP_DIR }}


### PR DESCRIPTION
The `cleanup-preview` job has never deleted a branch. Found while verifying that the EAS integration was publishing correctly after Step 9 merged.

## What was wrong

`cleanup-preview` is the **only job in this workflow with no `npm install` step**. `eas branch:delete` reads the app config, and resolving `app.json`'s `expo-font` plugin needs `node_modules`, so the command died before it ever reached the API:

```
Run eas branch:delete "pr-77" --non-interactive
Failed to resolve plugin for module "expo-font" relative to ".../SudokuApp".
Do you have node modules installed?
    Error: branch:delete command failed.
##[error]Process completed with exit code 1
```

`continue-on-error: true` then swallowed the exit code, so **the job reported green** — which is why this went unnoticed for five PRs.

## The evidence it has always been broken

Live branch list on `@mjohnson139/expo-sudoku` before this change:

```
epic/fungiku, pr-77, pr-75, pr-74, pr-73, pr-72, main
```

`pr-72` is the PR that *added* this job, and its own preview branch was still published — so it has failed from its very first run. This is the same accumulation the job exists to prevent; the workflow's own comment notes 68 stale branches had built up before it was written.

## The fix

Add the `npm install` step the other three jobs already have. Reproduced the diagnosis in both directions before and after:

- **In CI**, without `node_modules`: fails on plugin resolution (log above).
- **Locally, with `node_modules` present**: gets past config loading and reaches the API — `Could not find branch pr-nonexistent-probe-9999`, which is the expected response for a branch that does not exist.

`continue-on-error: true` **stays**, now for the case it was written for rather than by accident: `branch:delete` genuinely exits 1 when the branch does not exist, which is what happens for a PR closed before any preview published. The comment is updated to say so, since the flag's real justification was being obscured by the bug it was hiding.

## Cleanup done alongside

The five stale branches were deleted by hand, so the account is back to just the two long-lived ones:

```
epic/fungiku   updates=10   Auto-publish from epic/fungiku (8e8fb5b)
main           updates=10   Auto-publish from main (a4c1ed1)
```

Safe by the workflow's own reasoning: a `pr-<N>` branch is only ever reachable through the QR code in that PR's preview comment, which is dead once the PR is closed, and it is not mapped to a channel, so no installed build resolves updates from it.

## Why this targets the epic branch

`main` has no `cleanup-preview` job at all — it arrived in #72, which targeted `epic/fungiku`. So the fix belongs here and reaches `main` when the epic does.

## Verifying it

This PR is its own first live test: when it merges, the `closed` run should delete the `pr-<N>` branch its preview publishes. I'll check the branch list afterwards and confirm rather than assume — if the closed-event run resolves the workflow from a version that predates the fix, the real proof will be the PR after this one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsDXXfTZaF5B8LT9cbkgfW)_