### PR TITLE
Fungiku Step 10: lives and mistakes (refs #65)

### DIFF
--- a/SudokuApp/games/fungiku/FungikuBoard.js
+++ b/SudokuApp/games/fungiku/FungikuBoard.js
@@ -34,22 +34,52 @@ const MARK_LABELS = {
 };
 
 /**
+ * Placing a mushroom needs a way in that is not a double tap, because a screen
+ * reader has no way to produce one (plan §14.2). Hoisted to module scope so the
+ * array identity is stable across every cell and every render.
+ *
+ * Known gap, carried in the handoff: react-native-web does not map custom
+ * accessibility actions, so on the web build this reaches native screen readers
+ * only. `onAccessibilityTap` — the ✕ — works everywhere.
+ */
+const ACCESSIBILITY_ACTIONS = [
+  { name: 'activate', label: 'Rule out or clear' },
+  { name: 'placeMushroom', label: 'Place mushroom' },
+];
+
+/**
  * How far the finger must travel before a touch becomes a stroke instead of a
  * tap. Small enough that the cell you started on is still under your finger, big
  * enough that a slightly shaky tap does not paint.
  */
 const DRAG_THRESHOLD = 6;
 
+/**
+ * How long after a tap a second tap on the same cell still counts as a
+ * double-tap, and therefore places a mushroom (plan §14.2).
+ *
+ * Longer than the ~250 ms a platform double-tap usually allows, on purpose: the
+ * player this game is for is a child, and a child's second tap is slower than an
+ * adult's. The cost of being generous here is small — the only thing a late
+ * second tap does instead is clear the X the first tap placed, which is one more
+ * tap to put back — while the cost of being strict is a mushroom that "won't go
+ * in".
+ *
+ * **A number to check on device, not in a browser** (plan §2). A mouse click and
+ * a small finger on glass are not the same gesture.
+ */
+const DOUBLE_TAP_MS = 320;
+
 const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
   const {
     size,
     regions,
     marks,
-    conflicts,
-    mistakes,
-    showMistakes,
+    mistakeCells,
+    lives,
     hint,
-    cycleCell,
+    tapCell,
+    placeMushroom,
     paintCells,
     beginStroke,
     endStroke,
@@ -68,10 +98,10 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
   // --- legibility at the top size (plan §12.3) ------------------------------
   //
   // The board is a fixed 324pt on native however many cells it holds, so a cell
-  // is 64px at 5×5 and **32px at 10×10**. The conflict ring and the mistake badge
-  // were tuned against the large end and stop working at the small one, so they
-  // step down at a threshold that leaves 5×5 through 8×8 (cells 64 down to 40)
-  // exactly as they were, and changes only the two sizes this step adds.
+  // is 64px at 5×5 and **32px at 10×10**. Anything drawn inside a cell was tuned
+  // against the large end and stops working at the small one, so it steps down at
+  // a threshold that leaves 5×5 through 8×8 (cells 64 down to 40) exactly as they
+  // were.
   //
   // The board's *lines* are a different story: they changed at every size, because
   // the way they were drawn was wrong at every size and only obvious at small
@@ -87,16 +117,6 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
   // came out at double this, which is why 2 looked heavy and the frame around
   // the board looked thin by comparison.
   const regionBorder = tightCells ? 2 : 2.5;
-
-  // The conflict ring is inset from the cell edge. A fixed 6px inset leaves only
-  // 20px of clear ring at 32px cells, which crowds the 20px mushroom glyph
-  // inside it, so tight cells give the ring more room and a thinner stroke.
-  const ringInset = tightCells ? 4 : 6;
-  const ringWidth = tightCells ? 2 : 2.5;
-
-  // The mistake badge is a corner glyph at 28% of the cell — 18px at 5×5 but
-  // 9px at 10×10, which is below the size an alert triangle still reads as one.
-  const badge = Math.max(11, Math.round(cell * 0.28));
 
   // --- drag to sweep X's (plan §2) -----------------------------------------
   //
@@ -124,6 +144,10 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
   const lastCell = useRef(-1);
   const paintMode = useRef(PAINT_MODES.X);
   const isStroke = useRef(false);
+
+  // The previous tap, for the double-tap detector. A ref because it is written
+  // on every touch and must never cause a render of its own.
+  const previousTap = useRef({ cell: -1, at: 0 });
 
   // Tap feedback, which the per-cell Touchables used to give for free.
   const [pressedCell, setPressedCell] = useState(-1);
@@ -200,13 +224,15 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
   // This effect runs after the banner has been committed, so the origin is right
   // before the player can touch anything. `hint` and `solved` are the two things
   // that mount a banner above the board.
-  // `generating` is in here for the same reason `hint` and `solved` are: it
-  // changes what the row above the board renders. That row keeps its height by
-  // design, so the board should not actually move — this is the cheap insurance
-  // that says so, and the place the next thing added above the board belongs.
+  // `generating` and `lives.left` are in here for the same reason, one step
+  // weaker: they change what the row above the board *renders* rather than
+  // whether it exists. That row keeps its height by design — the hearts live
+  // inside it precisely so losing one cannot move the board — so this is the
+  // cheap insurance that says so, and the place the next thing added above the
+  // board belongs.
   useEffect(() => {
     measure();
-  }, [hint, solved, generating, measure]);
+  }, [hint, solved, generating, lives.left, measure]);
 
   // The latest marks/geometry, readable from inside gesture callbacks that were
   // created once and would otherwise close over a stale render.
@@ -319,15 +345,39 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
 
         onPanResponderRelease: () => {
           if (isStroke.current) {
+            // A stroke is not a tap, and must not become half of a double one:
+            // tap, drag, tap should be two separate taps.
+            previousTap.current = { cell: -1, at: 0 };
             endStroke();
           } else {
-            // Never travelled: it was a tap, so run the full mark cycle. Taps
-            // land here now rather than on a per-cell Touchable, because the
-            // board owns the touch from the moment it starts.
+            // Never travelled: it was a tap. Taps land here rather than on a
+            // per-cell Touchable, because the board owns the touch from the
+            // moment it starts — which is also why the double-tap detector has
+            // to live *inside* this responder (plan §14.2). A second
+            // PanResponder or a child Touchable would never see the second tap.
             const tapped = startPoint.current
               ? cellAt(startPoint.current.x, startPoint.current.y)
               : -1;
-            if (tapped >= 0) cycleCell(tapped);
+
+            if (tapped >= 0) {
+              const now = Date.now();
+              const previous = previousTap.current;
+              const isSecond = previous.cell === tapped && now - previous.at <= DOUBLE_TAP_MS;
+
+              if (isSecond) {
+                // Consume it, so a third tap starts over rather than reading as
+                // a second double-tap.
+                previousTap.current = { cell: -1, at: 0 };
+                placeMushroom(tapped);
+              } else {
+                // **Not deferred.** The X goes in now and the second tap
+                // upgrades the cell if it arrives. Waiting out the window here
+                // would put a ~300 ms delay on the most common gesture in the
+                // game.
+                previousTap.current = { cell: tapped, at: now };
+                tapCell(tapped);
+              }
+            }
           }
           finish();
         },
@@ -344,7 +394,7 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
         onShouldBlockNativeResponder: () => true,
       }),
     // Built once: every value it touches is read through a ref.
-    [beginStroke, endStroke, paintCells, measure]
+    [beginStroke, endStroke, paintCells, tapCell, placeMushroom, measure]
   );
 
   // Region boundaries come from the theme's grid colors so the board reads as
@@ -398,8 +448,11 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
             // same fill as region 0 the moment boards reached 10 regions.
             const entry = getRegionColor(region, isDark);
             const mark = marks[index];
-            const conflicting = conflicts.has(index);
-            const mistaken = mistakes.has(index);
+            // A red X: this cell held a mushroom that turned out to be wrong
+            // (plan §14.3). It is an *ordinary* X in every other respect — a tap
+            // clears it, a stroke erases it — the colour is only the record of
+            // what it cost.
+            const mistaken = mark === MARKS.X && mistakeCells.has(index);
 
             // X is a thinking aid, so it sits quieter than a mushroom — but it
             // still has to be visible on its own fill, so it is the same
@@ -421,11 +474,20 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
                 // also the seam the browser tests address cells through.
                 accessibilityLabel={`Row ${row + 1}, column ${col + 1}, ${entry.name} region, ${
                   MARK_LABELS[mark] || 'empty'
-                }${conflicting ? ', conflict' : ''}${
-                  showMistakes && mistaken ? ', mistake' : ''
-                }${hintCells.has(index) ? ', hint' : ''}`}
-                accessibilityHint="Taps cycle empty, ruled out, mushroom"
-                onAccessibilityTap={() => cycleCell(index)}
+                }${mistaken ? ', wrong guess' : ''}${hintCells.has(index) ? ', hint' : ''}`}
+                // **A screen reader cannot express a double tap** (plan §14.2),
+                // so activating a cell does the tap and placing a mushroom is a
+                // named alternative action rather than a repeat. The hint is
+                // where it is announced: it is per-cell text that reaches both
+                // VoiceOver and TalkBack, and unlike accessibilityState it is not
+                // dropped on the way to the web.
+                accessibilityHint="Activates to rule out or clear. Use the place mushroom action to commit one."
+                accessibilityActions={ACCESSIBILITY_ACTIONS}
+                onAccessibilityTap={() => tapCell(index)}
+                onAccessibilityAction={({ nativeEvent }) => {
+                  if (nativeEvent.actionName === 'placeMushroom') placeMushroom(index);
+                  else tapCell(index);
+                }}
                 // No borders here: every line on this board is drawn once, by
                 // the FungikuGridLines overlay below. Per-cell borders drew each
                 // interior boundary twice and mitered at every corner.
@@ -439,27 +501,8 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
                   justifyContent: 'center',
                 }}
               >
-                {/* Conflict is signalled by a ring *and* a color change, so it
-                    survives a colorblind reader and a dark theme alike. The ring
-                    color is contrast-checked against every fill in the palette
-                    (see symbolSets.js). */}
-                {conflicting && (
-                  <View
-                    style={[
-                      styles.conflictRing,
-                      {
-                        width: cell - ringInset,
-                        height: cell - ringInset,
-                        borderRadius: (cell - ringInset) / 2,
-                        borderWidth: ringWidth,
-                        borderColor: entry.conflictInk,
-                      },
-                    ]}
-                  />
-                )}
-
-                {/* A hint points with a dashed inset outline — a third channel,
-                    so it can sit on a cell that is also conflicting or mistaken
+                {/* A hint points with a dashed inset outline — a separate channel
+                    from the glyph, so it can sit on a cell that is also flagged
                     without either signal being lost. */}
                 {hintCells.has(index) && (
                   <View
@@ -477,31 +520,19 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
                     // mushroom can be affected.
                     style={{ transform: [{ scale: popValues[index] }] }}
                   >
-                    <MaterialCommunityIcons
-                      name="mushroom"
-                      size={glyph}
-                      color={conflicting ? entry.conflictInk : entry.ink}
-                    />
+                    <MaterialCommunityIcons name="mushroom" size={glyph} color={entry.ink} />
                   </Animated.View>
-                )}
-
-                {/* Mistake badge: legal so far, but not where the solution has it
-                    (plan §11.1). A corner glyph rather than a ring, so it reads
-                    as a different kind of wrong from a conflict. */}
-                {showMistakes && mistaken && (
-                  <MaterialCommunityIcons
-                    name="alert"
-                    size={badge}
-                    color={entry.conflictInk}
-                    style={styles.mistakeBadge}
-                  />
                 )}
 
                 {mark === MARKS.X && (
                   <MaterialCommunityIcons
                     name="close"
                     size={Math.round(glyph * 0.8)}
-                    color={inkFaded}
+                    // `conflictInk` is the palette's contrast-checked "this is
+                    // wrong" ink, checked against every fill (symbolSets.js). The
+                    // conflict ring it was built for is gone; flagging a wrong
+                    // guess is the job it does now.
+                    color={mistaken ? entry.conflictInk : inkFaded}
                   />
                 )}
               </View>
@@ -531,21 +562,12 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
   },
-  conflictRing: {
-    position: 'absolute',
-    // borderWidth is set per board size — see `ringWidth`.
-  },
   hintOutline: {
     position: 'absolute',
     borderWidth: 2,
     borderStyle: 'dashed',
     borderRadius: 3,
     opacity: 0.9,
-  },
-  mistakeBadge: {
-    position: 'absolute',
-    top: 1,
-    right: 1,
   },
 });
 

--- a/SudokuApp/games/fungiku/FungikuBoard.js
+++ b/SudokuApp/games/fungiku/FungikuBoard.js
@@ -48,11 +48,27 @@ const ACCESSIBILITY_ACTIONS = [
 ];
 
 /**
- * How far the finger must travel before a touch becomes a stroke instead of a
- * tap. Small enough that the cell you started on is still under your finger, big
- * enough that a slightly shaky tap does not paint.
+ * When a touch stops being a tap and becomes a stroke.
+ *
+ * **The test is "did the finger reach another cell", not "did it move N pixels".**
+ * It used to be a flat 6px, and that was survivable while a tap only ever cycled
+ * a mark: a shaky tap that tipped over the threshold became a one-cell stroke
+ * and painted the very same ✕ the tap would have, so nobody could tell.
+ *
+ * The double-tap (plan §14.2) ended that. A wobble past 6px on *either* half of
+ * the pair turns that half into a stroke, which resets the double-tap and leaves
+ * the player with a ✕ they have to tap again — or, if it was the second half
+ * starting on a ✕, an *erase* stroke that wipes the cell. The mushroom simply
+ * does not go in, and it fails differently depending on which tap wobbled. That
+ * is the "tapping is very unpredictable" the operator hit on device, and 6px of
+ * travel is well within what a finger does on glass while holding still.
+ *
+ * Leaving the starting cell is the honest test, because it is exactly what a
+ * sweep does and what a tap does not. `MAX_TAP_TRAVEL` is only the backstop for
+ * a finger that leaves the board altogether, where there is no new cell to
+ * compare against.
  */
-const DRAG_THRESHOLD = 6;
+const MAX_TAP_TRAVEL = 28;
 
 /**
  * How long after a tap a second tap on the same cell still counts as a
@@ -306,15 +322,21 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
 
         onPanResponderMove: (event, gesture) => {
           if (!isStroke.current) {
-            // Still ambiguous: a tap is a touch that never travels this far.
-            if (Math.hypot(gesture.dx, gesture.dy) <= DRAG_THRESHOLD) return;
-
-            isStroke.current = true;
-            setPressedCell(-1);
-
             const first = startPoint.current
               ? cellAt(startPoint.current.x, startPoint.current.y)
               : -1;
+            const under = cellAt(event.nativeEvent.pageX, event.nativeEvent.pageY);
+
+            // Still a tap while the finger is over the cell it started on. Only
+            // reaching a *different* cell makes this a sweep — the backstop
+            // catches a finger that has left the board, where `under` is -1 and
+            // there is no cell to compare with.
+            const reachedAnother = under >= 0 && under !== first;
+            const leftTheBoard = under < 0 && Math.hypot(gesture.dx, gesture.dy) > MAX_TAP_TRAVEL;
+            if (!reachedAnother && !leftTheBoard) return;
+
+            isStroke.current = true;
+            setPressedCell(-1);
 
             // The first cell decides the whole stroke: starting on an X erases,
             // starting anywhere else paints. Fixing the mode up front means

--- a/SudokuApp/games/fungiku/FungikuBoard.js
+++ b/SudokuApp/games/fungiku/FungikuBoard.js
@@ -92,6 +92,7 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
     regions,
     marks,
     mistakeCells,
+    lastMistake,
     lives,
     hint,
     tapCell,
@@ -184,6 +185,39 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
     () => Array.from({ length: size * size }, () => new Animated.Value(1)),
     [size]
   );
+  // A wrong guess shakes its cell (plan §14.3). **One value per cell**, for the
+  // same reason the pop has one: a single shared value re-pointed at "the cell
+  // that just went wrong" is re-pointed by a state update but reset immediately,
+  // so for a frame it is still attached to the previous cell. Per-cell values
+  // remove the class of bug rather than patching the ordering.
+  const shakeValues = useMemo(
+    () => Array.from({ length: size * size }, () => new Animated.Value(0)),
+    [size]
+  );
+
+  useEffect(() => {
+    if (!lastMistake) return;
+    const value = shakeValues[lastMistake.cell];
+    if (!value) return;
+
+    // Stop anything still running before restarting, and drive with the JS
+    // driver because this value is `setValue`d — mixing setValue with the native
+    // driver is what stranded the win animation's scales (plan §2).
+    value.stopAnimation();
+    value.setValue(0);
+    Animated.sequence([
+      Animated.timing(value, { toValue: 1, duration: 50, useNativeDriver: false }),
+      Animated.timing(value, { toValue: -1, duration: 70, useNativeDriver: false }),
+      Animated.timing(value, { toValue: 0.6, duration: 60, useNativeDriver: false }),
+      Animated.timing(value, { toValue: 0, duration: 60, useNativeDriver: false }),
+    ]).start(() => {
+      // Whatever interrupts it, the cell must not be left off-centre.
+      value.setValue(0);
+    });
+    // `seq` is in the deps on purpose: two wrong guesses in the *same* cell are
+    // two events, and without it the second would not re-fire.
+  }, [lastMistake, shakeValues]);
+
   const previousMarks = useRef(marks);
 
   useEffect(() => {
@@ -547,15 +581,33 @@ const FungikuBoard = ({ isDark, theme, onTouchActiveChange }) => {
                 )}
 
                 {mark === MARKS.X && (
-                  <MaterialCommunityIcons
-                    name="close"
-                    size={Math.round(glyph * 0.8)}
-                    // `conflictInk` is the palette's contrast-checked "this is
-                    // wrong" ink, checked against every fill (symbolSets.js). The
-                    // conflict ring it was built for is gone; flagging a wrong
-                    // guess is the job it does now.
-                    color={mistaken ? entry.conflictInk : inkFaded}
-                  />
+                  <Animated.View
+                    // The shake is the moment-of-impact half of "that was
+                    // wrong"; the red is the half that stays. Only the cell that
+                    // just went wrong is ever away from 0.
+                    style={{
+                      transform: [
+                        {
+                          translateX: shakeValues[index].interpolate({
+                            inputRange: [-1, 0, 1],
+                            outputRange: [-5, 0, 5],
+                          }),
+                        },
+                      ],
+                    }}
+                  >
+                    <MaterialCommunityIcons
+                      name={mistaken ? 'close-thick' : 'close'}
+                      size={Math.round(glyph * 0.8)}
+                      // `conflictInk` is the palette's contrast-checked "this is
+                      // wrong" ink, checked against every fill (symbolSets.js).
+                      // The conflict ring it was built for is gone; flagging a
+                      // wrong guess is the job it does now. A wrong guess also
+                      // gets the *heavier* glyph, so the flag survives a
+                      // colourblind reader rather than resting on red alone.
+                      color={mistaken ? entry.conflictInk : inkFaded}
+                    />
+                  </Animated.View>
                 )}
               </View>
             );

--- a/SudokuApp/games/fungiku/FungikuContext.js
+++ b/SudokuApp/games/fungiku/FungikuContext.js
@@ -262,6 +262,17 @@ export const FungikuProvider = ({ children }) => {
   );
 
   const clearMarks = useCallback(() => dispatch({ type: FUNGIKU_ACTIONS.CLEAR_MARKS }), [dispatch]);
+
+  /**
+   * Start the same board over after the last life is spent (plan §14.3).
+   *
+   * Driven by the player pressing "Try again", not by the reducer wiping the
+   * board the moment the third mistake lands — see the note on PLACE_MUSHROOM.
+   */
+  const restartBoard = useCallback(
+    () => dispatch({ type: FUNGIKU_ACTIONS.RESTART_BOARD }),
+    [dispatch]
+  );
   const undo = useCallback(() => dispatch({ type: FUNGIKU_ACTIONS.UNDO }), [dispatch]);
   const redo = useCallback(() => dispatch({ type: FUNGIKU_ACTIONS.REDO }), [dispatch]);
 
@@ -295,6 +306,7 @@ export const FungikuProvider = ({ children }) => {
       changeSize,
       changeSeed,
       clearMarks,
+      restartBoard,
       undo,
       redo,
     }),
@@ -323,6 +335,7 @@ export const FungikuProvider = ({ children }) => {
       changeSize,
       changeSeed,
       clearMarks,
+      restartBoard,
       undo,
       redo,
     ]

--- a/SudokuApp/games/fungiku/FungikuContext.js
+++ b/SudokuApp/games/fungiku/FungikuContext.js
@@ -10,9 +10,9 @@ import {
   fungikuReducer,
   selectCanRedo,
   selectCanUndo,
-  selectConflicts,
   selectIsSolved,
-  selectMistakes,
+  selectLives,
+  selectMistakeCells,
   selectMushroomCount,
   selectRevealCell,
   selectRuleOutCells,
@@ -24,9 +24,11 @@ import {
  * GameContext. The two games share no state, no storage key and no reducer;
  * they only share the persistence hook and the theme.
  *
- * Derived values (conflicts, the mushroom count, the win flag) are memoized
- * from `marks` here rather than kept in the reducer, so undo can never leave a
- * stale highlight behind.
+ * Derived values (the mushroom count, the win flag) are memoized from `marks`
+ * here rather than kept in the reducer, so undo can never leave a stale
+ * highlight behind. `lives` and `mistakeCells` are the exceptions and are real
+ * state: what a board has cost you is not a function of what is on it now
+ * (plan §14.3 — undo retracts the mark but never refunds the life).
  */
 const FungikuContext = createContext();
 
@@ -71,7 +73,6 @@ export const FungikuProvider = ({ children }) => {
     FUNGIKU_PERSISTENCE
   );
 
-  const conflicts = useMemo(() => selectConflicts(state), [state.marks, state.regions, state.size]);
   const mushroomCount = useMemo(() => selectMushroomCount(state), [state.marks]);
   const solved = useMemo(() => selectIsSolved(state), [state.marks, state.regions, state.size]);
 
@@ -89,20 +90,31 @@ export const FungikuProvider = ({ children }) => {
     [state.marks, state.regions, state.size]
   );
 
-  // Correctness feedback (plan §11.1). Computed whether or not the switch is on:
-  // the hint cascade needs to know about mistakes even when the player has not
-  // asked to see them. Only the *rendering* is gated on `showMistakes`.
-  const mistakes = useMemo(
-    () => selectMistakes(state),
-    [state.marks, state.solution, state.size]
-  );
+  // The red X marks: cells where a mushroom was placed and turned out to be
+  // wrong (plan §14.3). A stored record rather than a derived one — see the note
+  // above the reducer's selectors.
+  const mistakeCells = useMemo(() => selectMistakeCells(state), [state.mistakeCells]);
+
+  // Lives left on this board, and the full complement the heart row draws.
+  const lives = useMemo(() => selectLives(state), [state.lives]);
   const canReveal = useMemo(
     () => selectRevealCell(state) >= 0,
     [state.marks, state.regions, state.solution, state.size]
   );
 
-  const cycleCell = useCallback(
-    (cell) => dispatch({ type: FUNGIKU_ACTIONS.CYCLE_CELL, payload: { cell } }),
+  // --- the input model (plan §14.2) ----------------------------------------
+  // A tap rules a cell out, or clears a filled one. It is dispatched the moment
+  // the finger lifts — it never waits to see whether a second tap is coming, so
+  // the most common mark in the game is never delayed by the double-tap window.
+  const tapCell = useCallback(
+    (cell) => dispatch({ type: FUNGIKU_ACTIONS.TAP_CELL, payload: { cell } }),
+    [dispatch]
+  );
+
+  // The second tap: commit a mushroom. An attempt, not a mark — the reducer
+  // judges it against the solution and a wrong one costs a life (plan §14.3).
+  const placeMushroom = useCallback(
+    (cell) => dispatch({ type: FUNGIKU_ACTIONS.PLACE_MUSHROOM, payload: { cell } }),
     [dispatch]
   );
 
@@ -122,11 +134,7 @@ export const FungikuProvider = ({ children }) => {
   /** One tap: mark everything the placed mushrooms forbid (plan §2). */
   const ruleOut = useCallback(() => dispatch({ type: FUNGIKU_ACTIONS.RULE_OUT }), [dispatch]);
 
-  // --- feedback and hints (plan §11) ---------------------------------------
-  const toggleMistakes = useCallback(
-    () => dispatch({ type: FUNGIKU_ACTIONS.TOGGLE_MISTAKES }),
-    [dispatch]
-  );
+  // --- hints (plan §11.2) --------------------------------------------------
   const requestHint = useCallback(
     () => dispatch({ type: FUNGIKU_ACTIONS.REQUEST_HINT }),
     [dispatch]
@@ -178,11 +186,12 @@ export const FungikuProvider = ({ children }) => {
             type: FUNGIKU_ACTIONS.NEW_PUZZLE,
             // The feedback switch is a preference and carries over; the hint
             // count is per-puzzle and resets.
+            // Nothing carries over from the board being left behind: a new
+            // board is a full three lives, no red marks and no hints spent.
             payload: buildPuzzleState({
               difficulty: identity.difficulty,
               size: identity.size,
               seed,
-              showMistakes: state.showMistakes,
             }),
           });
         } catch (error) {
@@ -216,7 +225,7 @@ export const FungikuProvider = ({ children }) => {
         }, 0);
       });
     },
-    [dispatch, state.difficulty, state.seed, state.showMistakes]
+    [dispatch, state.difficulty, state.seed]
   );
 
   /**
@@ -259,7 +268,6 @@ export const FungikuProvider = ({ children }) => {
   const value = useMemo(
     () => ({
       ...state,
-      conflicts,
       mushroomCount,
       solved,
       hasMarks,
@@ -268,15 +276,16 @@ export const FungikuProvider = ({ children }) => {
       minSize: MIN_SIZE,
       maxSize: MAX_SIZE,
       generating,
-      cycleCell,
+      tapCell,
+      placeMushroom,
       beginStroke,
       paintCells,
       endStroke,
       ruleOut,
       ruleOutCount,
-      mistakes,
+      mistakeCells,
+      lives,
       canReveal,
-      toggleMistakes,
       requestHint,
       revealMushroom,
       dismissHint,
@@ -291,20 +300,20 @@ export const FungikuProvider = ({ children }) => {
     }),
     [
       state,
-      conflicts,
       mushroomCount,
       solved,
       hasMarks,
       generating,
-      cycleCell,
+      tapCell,
+      placeMushroom,
       beginStroke,
       paintCells,
       endStroke,
       ruleOut,
       ruleOutCount,
-      mistakes,
+      mistakeCells,
+      lives,
       canReveal,
-      toggleMistakes,
       requestHint,
       revealMushroom,
       dismissHint,

--- a/SudokuApp/games/fungiku/FungikuOutOfLivesModal.js
+++ b/SudokuApp/games/fungiku/FungikuOutOfLivesModal.js
@@ -1,0 +1,182 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+
+/**
+ * "You are out of lives, and the board is starting over" (docs/fungiku-plan.md
+ * §14.3).
+ *
+ * **Why this exists at all.** The first version of Step 10 restarted the board in
+ * the same breath as the third mistake, with a line of text in the counter row to
+ * explain it. The operator's report from device was that the board simply emptied
+ * and there was no way to tell what had just happened — which is fair: the one
+ * moment in the game where the player *loses* something was also the one moment
+ * with the least to look at.
+ *
+ * So the restart is now something the player presses. The reducer leaves the
+ * board at `lives === 0` holding the mark that killed it, this modal says what
+ * happened over the top of it, and only then are the marks cleared. The fatal
+ * red ✕ is still visible behind the dialog on purpose — "you got this cell wrong"
+ * is the last useful thing the lost board has to say.
+ *
+ * Deliberately built to `FungikuMenuModal`'s shape (same overlay, box, fade) so
+ * the two dialogs in this game read as the same app.
+ */
+const FungikuOutOfLivesModal = ({ visible, theme, lives, onRestart }) => {
+  const fade = useRef(new Animated.Value(0)).current;
+
+  // The hearts land one after another rather than all at once, so the row reads
+  // as "these are what you spent" instead of as decoration.
+  const heartsAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(fade, {
+      toValue: visible ? 1 : 0,
+      duration: visible ? 260 : 160,
+      useNativeDriver: true,
+    }).start();
+
+    // Driven, never `setValue`d while a native-driver animation owns it — the
+    // rule the win animation was fixed by (plan §2).
+    Animated.timing(heartsAnim, {
+      toValue: visible ? 1 : 0,
+      duration: visible ? 420 : 0,
+      delay: visible ? 140 : 0,
+      useNativeDriver: true,
+    }).start();
+  }, [visible, fade, heartsAnim]);
+
+  const titleColor = theme.colors.title;
+  const surface = theme.colors.numberPad.background;
+  const border = theme.colors.numberPad.border;
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onRestart}>
+      <Animated.View style={[styles.overlay, { opacity: fade }]}>
+        <View style={[styles.box, { backgroundColor: surface, borderColor: border }]}>
+          <View style={styles.hearts}>
+            {Array.from({ length: lives }, (_, i) => (
+              <Animated.View
+                key={i}
+                style={{
+                  transform: [
+                    {
+                      scale: heartsAnim.interpolate({
+                        inputRange: [0, 1],
+                        outputRange: [1.25, 1],
+                      }),
+                    },
+                  ],
+                  opacity: heartsAnim.interpolate({ inputRange: [0, 1], outputRange: [1, 0.55] }),
+                }}
+              >
+                <MaterialCommunityIcons
+                  name="heart-broken"
+                  size={26}
+                  color={OUT_OF_LIVES}
+                  style={styles.heart}
+                />
+              </Animated.View>
+            ))}
+          </View>
+
+          <Text style={[styles.title, { color: titleColor }]}>Out of lives</Text>
+
+          <Text style={[styles.body, { color: titleColor }]}>
+            That was your last one. Three wrong mushrooms and the board starts over.
+          </Text>
+
+          <Text style={[styles.body, styles.reassurance, { color: titleColor }]}>
+            It is the <Text style={styles.bold}>same puzzle</Text> — same board, same answer. Your
+            marks are cleared and you get three fresh lives.
+          </Text>
+
+          <TouchableOpacity
+            style={[styles.button, { borderColor: titleColor }]}
+            onPress={onRestart}
+            accessibilityRole="button"
+            accessibilityLabel="Start this board over with three fresh lives"
+          >
+            <MaterialCommunityIcons name="restart" size={18} color={titleColor} />
+            <Text style={[styles.buttonText, { color: titleColor }]}>Try again</Text>
+          </TouchableOpacity>
+        </View>
+      </Animated.View>
+    </Modal>
+  );
+};
+
+// The same red the hearts in the counter row use, so a spent life and this
+// dialog are visibly the same idea.
+const OUT_OF_LIVES = '#d1495b';
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.35)',
+    // Sits **low**, over the controls, rather than centred like the difficulty
+    // menu. Centred it covered the bottom rows of the board, which defeats the
+    // reason the board is still there — the fatal red ✕ is the last useful thing
+    // the lost board has to say, and a dialog explaining the loss should not be
+    // what hides it.
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    paddingBottom: 32,
+    zIndex: 100,
+  },
+  box: {
+    width: 280,
+    borderRadius: 12,
+    borderWidth: 1,
+    paddingHorizontal: 20,
+    paddingTop: 22,
+    paddingBottom: 18,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+    elevation: 6,
+  },
+  hearts: {
+    flexDirection: 'row',
+    marginBottom: 10,
+  },
+  heart: {
+    marginHorizontal: 3,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 10,
+  },
+  body: {
+    fontSize: 13,
+    lineHeight: 18,
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  reassurance: {
+    opacity: 0.8,
+    marginBottom: 16,
+  },
+  bold: {
+    fontWeight: '700',
+  },
+  button: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+  },
+  buttonText: {
+    fontSize: 15,
+    fontWeight: '700',
+    marginLeft: 6,
+  },
+});
+
+export default FungikuOutOfLivesModal;

--- a/SudokuApp/games/fungiku/FungikuScreen.js
+++ b/SudokuApp/games/fungiku/FungikuScreen.js
@@ -21,6 +21,11 @@ import { FungikuProvider, useFungikuContext } from './FungikuContext';
 // so winning looks like Fungiku rather than a generic green success box.
 const FUNGIKU_ACCENT = '#a0522d';
 
+// Lives are drawn in their own colour rather than the theme's title ink, so
+// "you have three of these and they run out" reads at a glance and does not look
+// like more chrome. Spent hearts fall back to the theme, hollow.
+const FUNGIKU_LIFE = '#d1495b';
+
 /**
  * Fungiku's screen — a peer of the Sudoku screen, reached from the hub
  * (docs/fungiku-plan.md §6), and as of Step 4 an actually playable game.
@@ -42,7 +47,6 @@ const FungikuScreenContent = ({ onExitToHub }) => {
     seed,
     mushroomCount,
     solved,
-    conflicts,
     hasMarks,
     canUndo,
     canRedo,
@@ -55,9 +59,8 @@ const FungikuScreenContent = ({ onExitToHub }) => {
     nextPuzzle,
     ruleOut,
     ruleOutCount,
-    showMistakes,
-    toggleMistakes,
-    mistakes,
+    lives,
+    outOfLives,
     hint,
     hintsUsed,
     requestHint,
@@ -107,15 +110,26 @@ const FungikuScreenContent = ({ onExitToHub }) => {
   };
 
   // The status line follows the state of play instead of always explaining the
-  // tap cycle. (Named `statusText`, not `hint` — `hint` is the hint object from
+  // input model. (Named `statusText`, not `hint` — `hint` is the hint object from
   // context, and shadowing it here silently broke the build once.)
+  //
+  // It no longer counts conflicts. Since plan §14.3 a wrong mushroom never
+  // survives placement, so every mushroom on the board sits at a solution cell —
+  // and two solution cells cannot share a row, column or region, or touch. There
+  // is no such thing as two mushrooms breaking a rule any more, so a line
+  // reporting it would be a promise the game can never keep.
+  //
+  // Running out of lives takes the top slot below "Generating…": the board just
+  // emptied itself, and that needs saying before anything else. It lives here
+  // rather than in a banner of its own because a banner mounting above the board
+  // moves the board — see FungikuBoard's re-measure effect.
   const statusText = generating
     ? 'Generating…'
-    : solved
-      ? 'One per row, column and color — none touching'
-      : conflicts.size > 0
-        ? `${conflicts.size} mushroom${conflicts.size === 1 ? '' : 's'} breaking a rule`
-        : 'Tap to cycle · drag to sweep ✕';
+    : outOfLives
+      ? 'Out of lives — same board, fresh start'
+      : solved
+        ? 'One per row, column and color — none touching'
+        : 'Tap to rule out · double-tap to place · drag to sweep ✕';
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
@@ -184,11 +198,36 @@ const FungikuScreenContent = ({ onExitToHub }) => {
             {mushroomCount}/{size}
           </Text>
 
+          {/* Lives (plan §14.3). Deliberately *inside* this row rather than in
+              a strip of its own: a view that mounts above the board moves the
+              board, which invalidates the origin every touch is resolved
+              against. Hearts that fill and empty in an always-mounted row of
+              fixed height cannot move anything. */}
+          <View
+            style={styles.lives}
+            accessible
+            accessibilityLabel={`${lives.left} of ${lives.of} lives left`}
+            // A lost life is worth announcing — it is the one thing on this
+            // screen that happens *to* the player rather than because of a tap
+            // they meant to make.
+            accessibilityLiveRegion="polite"
+          >
+            {Array.from({ length: lives.of }, (_, i) => (
+              <MaterialCommunityIcons
+                key={i}
+                name={i < lives.left ? 'heart' : 'heart-outline'}
+                size={15}
+                color={i < lives.left ? FUNGIKU_LIFE : titleColor}
+                style={styles.life}
+              />
+            ))}
+          </View>
+
           <Text
             style={[styles.counterHint, { color: titleColor }]}
             // Announced, because a player who cannot see the spinner still needs
             // to know why the board stopped responding.
-            accessibilityLiveRegion={generating ? 'polite' : 'none'}
+            accessibilityLiveRegion={generating || outOfLives ? 'polite' : 'none'}
           >
             {statusText}
           </Text>
@@ -297,9 +336,11 @@ const FungikuScreenContent = ({ onExitToHub }) => {
           </TouchableOpacity>
         </View>
 
-        {/* Hint (plan §11.2) and the correctness-feedback switch (§11.1). Both
-            are opt-in by nature: a hint is asked for, and mistakes are only shown
-            to a player who wants them shown. */}
+        {/* Hint (plan §11.2). The "Show mistakes" switch that used to sit beside
+            it is **gone, not hidden** (plan §14.3): correctness feedback stopped
+            being a preference the moment a wrong guess started costing a life.
+            What made always-on feedback corrosive was that guessing was free, and
+            it no longer is. */}
         <View style={styles.controlRow}>
           <TouchableOpacity
             onPress={requestHint}
@@ -317,30 +358,6 @@ const FungikuScreenContent = ({ onExitToHub }) => {
             <MaterialCommunityIcons name="lightbulb-on-outline" size={18} color={titleColor} />
             <Text style={[styles.buttonText, { color: titleColor }]}>
               {hintsUsed > 0 ? `Hint (${hintsUsed})` : 'Hint'}
-            </Text>
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            onPress={toggleMistakes}
-            style={[
-              styles.wideButton,
-              { borderColor: border },
-              showMistakes && { backgroundColor: titleColor, borderColor: titleColor },
-            ]}
-            accessibilityRole="switch"
-            accessibilityState={{ checked: showMistakes }}
-            // The state is named in the label because accessibilityState.checked
-            // does not reach aria-checked on web.
-            accessibilityLabel={`Show mistakes, ${showMistakes ? 'on' : 'off'}`}
-            accessibilityHint="Flags mushrooms that break no rule but are in the wrong cell"
-          >
-            <MaterialCommunityIcons
-              name={showMistakes ? 'checkbox-marked' : 'checkbox-blank-outline'}
-              size={18}
-              color={showMistakes ? surface : titleColor}
-            />
-            <Text style={[styles.buttonText, { color: showMistakes ? surface : titleColor }]}>
-              Mistakes{showMistakes && mistakes.size > 0 ? ` (${mistakes.size})` : ''}
             </Text>
           </TouchableOpacity>
         </View>
@@ -478,6 +495,14 @@ const styles = StyleSheet.create({
     fontSize: 11,
     opacity: 0.7,
     flexShrink: 1,
+  },
+  lives: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginRight: 10,
+  },
+  life: {
+    marginLeft: 1,
   },
   controlRow: {
     flexDirection: 'row',

--- a/SudokuApp/games/fungiku/FungikuScreen.js
+++ b/SudokuApp/games/fungiku/FungikuScreen.js
@@ -11,6 +11,7 @@ import {
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import ScreenHeader from '../../components/ScreenHeader';
 import useAppTheme from '../../hooks/useAppTheme';
+import useBoardSize from '../../hooks/useBoardSize';
 import FungikuBoard from './FungikuBoard';
 import FungikuMenuModal from './FungikuMenuModal';
 import FungikuWinBanner from './FungikuWinBanner';
@@ -36,6 +37,15 @@ const FUNGIKU_LIFE = '#d1495b';
  */
 const FungikuScreenContent = ({ onExitToHub }) => {
   const { theme, isDark } = useAppTheme();
+
+  // The counter row is width-matched to the board rather than left to size
+  // itself from its contents. **This is load-bearing, not cosmetic.** The row
+  // sits in a ScrollView whose content container centres its children, so a row
+  // wider than the screen widens the content container — and every centred
+  // sibling, the board included, gets pushed right and clipped. Adding the
+  // hearts was enough to do exactly that on a phone: the last column ended up
+  // off-screen and untappable.
+  const boardWidth = useBoardSize();
 
   // True while a finger is down on the board, which freezes scrolling so a
   // vertical sweep paints instead of scrolling the page.
@@ -129,7 +139,7 @@ const FungikuScreenContent = ({ onExitToHub }) => {
       ? 'Out of lives — same board, fresh start'
       : solved
         ? 'One per row, column and color — none touching'
-        : 'Tap to rule out · double-tap to place · drag to sweep ✕';
+        : 'Tap to rule out · double-tap to place';
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
@@ -185,46 +195,62 @@ const FungikuScreenContent = ({ onExitToHub }) => {
             against — the bug behind the hint banner's re-measure effect. This row
             is always mounted and keeps its height, so the board never moves and
             there is no origin to invalidate. */}
-        <View style={[styles.counterRow, { backgroundColor: surface, borderColor: border }]}>
-          {generating ? (
-            <ActivityIndicator size="small" color={titleColor} />
-          ) : (
-            <MaterialCommunityIcons name="mushroom" size={20} color={titleColor} />
-          )}
-          <Text
-            style={[styles.counterText, { color: titleColor }]}
-            accessibilityLabel={`${mushroomCount} of ${size} mushrooms placed`}
-          >
-            {mushroomCount}/{size}
-          </Text>
+        <View
+          style={[
+            styles.counterRow,
+            { backgroundColor: surface, borderColor: border, width: boardWidth },
+          ]}
+        >
+          {/* Two lines, both always present, so the box height is constant and
+              the board below it never moves. The status line is the part that
+              grows with what the game has to say, and it gets its own line
+              rather than competing with the counter for horizontal room. */}
+          <View style={styles.counterTop}>
+            <View style={styles.counterCount}>
+              {generating ? (
+                <ActivityIndicator size="small" color={titleColor} />
+              ) : (
+                <MaterialCommunityIcons name="mushroom" size={20} color={titleColor} />
+              )}
+              <Text
+                style={[styles.counterText, { color: titleColor }]}
+                accessibilityLabel={`${mushroomCount} of ${size} mushrooms placed`}
+              >
+                {mushroomCount}/{size}
+              </Text>
+            </View>
 
-          {/* Lives (plan §14.3). Deliberately *inside* this row rather than in
-              a strip of its own: a view that mounts above the board moves the
-              board, which invalidates the origin every touch is resolved
-              against. Hearts that fill and empty in an always-mounted row of
-              fixed height cannot move anything. */}
-          <View
-            style={styles.lives}
-            accessible
-            accessibilityLabel={`${lives.left} of ${lives.of} lives left`}
-            // A lost life is worth announcing — it is the one thing on this
-            // screen that happens *to* the player rather than because of a tap
-            // they meant to make.
-            accessibilityLiveRegion="polite"
-          >
-            {Array.from({ length: lives.of }, (_, i) => (
-              <MaterialCommunityIcons
-                key={i}
-                name={i < lives.left ? 'heart' : 'heart-outline'}
-                size={15}
-                color={i < lives.left ? FUNGIKU_LIFE : titleColor}
-                style={styles.life}
-              />
-            ))}
+            {/* Lives (plan §14.3). Deliberately *inside* this box rather than in
+                a strip of its own: a view that mounts above the board moves the
+                board, which invalidates the origin every touch is resolved
+                against. Hearts that fill and empty in an always-mounted box of
+                fixed height cannot move anything. */}
+            <View
+              style={styles.lives}
+              accessible
+              accessibilityLabel={`${lives.left} of ${lives.of} lives left`}
+              // A lost life is worth announcing — it is the one thing on this
+              // screen that happens *to* the player rather than because of a tap
+              // they meant to make.
+              accessibilityLiveRegion="polite"
+            >
+              {Array.from({ length: lives.of }, (_, i) => (
+                <MaterialCommunityIcons
+                  key={i}
+                  name={i < lives.left ? 'heart' : 'heart-outline'}
+                  size={15}
+                  color={i < lives.left ? FUNGIKU_LIFE : titleColor}
+                  style={styles.life}
+                />
+              ))}
+            </View>
           </View>
 
           <Text
             style={[styles.counterHint, { color: titleColor }]}
+            // One line, clipped rather than wrapped: a second line would change
+            // the box height and move the board.
+            numberOfLines={1}
             // Announced, because a player who cannot see the spinner still needs
             // to know why the board stopped responding.
             accessibilityLiveRegion={generating || outOfLives ? 'polite' : 'none'}
@@ -448,19 +474,25 @@ const styles = StyleSheet.create({
     paddingBottom: 24,
   },
   counterRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
     borderWidth: 1,
     borderRadius: 10,
     paddingVertical: 6,
     paddingHorizontal: 12,
     marginBottom: 12,
   },
+  counterTop: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  counterCount: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
   counterText: {
     fontSize: 18,
     fontWeight: '700',
     marginLeft: 6,
-    marginRight: 10,
   },
   hintBanner: {
     flexDirection: 'row',
@@ -494,12 +526,11 @@ const styles = StyleSheet.create({
   counterHint: {
     fontSize: 11,
     opacity: 0.7,
-    flexShrink: 1,
+    marginTop: 2,
   },
   lives: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginRight: 10,
   },
   life: {
     marginLeft: 1,

--- a/SudokuApp/games/fungiku/FungikuScreen.js
+++ b/SudokuApp/games/fungiku/FungikuScreen.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import {
+  Animated,
   View,
   Text,
   StyleSheet,
@@ -14,6 +15,7 @@ import useAppTheme from '../../hooks/useAppTheme';
 import useBoardSize from '../../hooks/useBoardSize';
 import FungikuBoard from './FungikuBoard';
 import FungikuMenuModal from './FungikuMenuModal';
+import FungikuOutOfLivesModal from './FungikuOutOfLivesModal';
 import FungikuWinBanner from './FungikuWinBanner';
 import { difficultyLabel } from './difficulty';
 import { FungikuProvider, useFungikuContext } from './FungikuContext';
@@ -70,7 +72,8 @@ const FungikuScreenContent = ({ onExitToHub }) => {
     ruleOut,
     ruleOutCount,
     lives,
-    outOfLives,
+    lastMistake,
+    restartBoard,
     hint,
     hintsUsed,
     requestHint,
@@ -103,6 +106,35 @@ const FungikuScreenContent = ({ onExitToHub }) => {
     if (!hasMarks) setMenuVisible(true);
   }, [hasMarks]);
 
+  // The heart that just emptied gets a beat of its own. Losing a life is the one
+  // thing on this screen that happens *to* the player, and before this it was a
+  // silent swap of one icon for another — easy to miss entirely, which is what
+  // the operator reported.
+  //
+  // One value per heart, never one shared value pointed at "the heart that just
+  // went" — the same rule the board's pop and shake follow (plan §2).
+  const heartBeats = useRef(
+    Array.from({ length: lives.of }, () => new Animated.Value(1))
+  ).current;
+  const previousLives = useRef(lives.left);
+
+  useEffect(() => {
+    const before = previousLives.current;
+    previousLives.current = lives.left;
+    // Only a life *lost*. Gaining them back is the restart, which has a modal.
+    if (lives.left >= before) return;
+
+    const value = heartBeats[lives.left];
+    if (!value) return;
+
+    value.stopAnimation();
+    value.setValue(1);
+    Animated.sequence([
+      Animated.timing(value, { toValue: 1.6, duration: 120, useNativeDriver: false }),
+      Animated.timing(value, { toValue: 1, duration: 220, useNativeDriver: false }),
+    ]).start(() => value.setValue(1));
+  }, [lives.left, heartBeats]);
+
   const closeMenu = () => setMenuVisible(false);
 
   // Every path out of the menu starts a board, so every one of them closes it.
@@ -129,14 +161,20 @@ const FungikuScreenContent = ({ onExitToHub }) => {
   // is no such thing as two mushrooms breaking a rule any more, so a line
   // reporting it would be a promise the game can never keep.
   //
-  // Running out of lives takes the top slot below "Generating…": the board just
-  // emptied itself, and that needs saying before anything else. It lives here
-  // rather than in a banner of its own because a banner mounting above the board
-  // moves the board — see FungikuBoard's re-measure effect.
+  // A wrong guess takes the top slot below "Generating…". It is the one thing
+  // that happens *to* the player, and it needs saying in words as well as in the
+  // shake and the heart — three channels, because the operator's report was that
+  // it was not obvious a life had gone at all. It lives here rather than in a
+  // banner of its own because a banner mounting above the board moves the board
+  // (see FungikuBoard's re-measure effect); this row is always mounted and its
+  // height is fixed.
+  //
+  // Running out of lives is *not* here: it gets the modal, because a board about
+  // to be wiped deserves more than a line of small print.
   const statusText = generating
     ? 'Generating…'
-    : outOfLives
-      ? 'Out of lives — same board, fresh start'
+    : lastMistake
+      ? 'Wrong — no mushroom there. That cost you a life.'
       : solved
         ? 'One per row, column and color — none touching'
         : 'Tap to rule out · double-tap to place';
@@ -168,6 +206,17 @@ const FungikuScreenContent = ({ onExitToHub }) => {
         onPickSize={pickSize}
         onPickSeed={pickSeed}
         onClose={closeMenu}
+      />
+
+      {/* Driven by `lives === 0`, which the reducer treats as "a restart is
+          pending" rather than as a state the board is left sitting in. Because
+          `lives` is persisted, quitting to the hub with the dialog up and coming
+          back lands on it again instead of stranding a board with no lives. */}
+      <FungikuOutOfLivesModal
+        visible={lives.left === 0}
+        theme={theme}
+        lives={lives.of}
+        onRestart={restartBoard}
       />
 
       {/* Two halves of one fix for "a vertical drag scrolls instead of painting"
@@ -235,13 +284,14 @@ const FungikuScreenContent = ({ onExitToHub }) => {
               accessibilityLiveRegion="polite"
             >
               {Array.from({ length: lives.of }, (_, i) => (
-                <MaterialCommunityIcons
-                  key={i}
-                  name={i < lives.left ? 'heart' : 'heart-outline'}
-                  size={15}
-                  color={i < lives.left ? FUNGIKU_LIFE : titleColor}
-                  style={styles.life}
-                />
+                <Animated.View key={i} style={{ transform: [{ scale: heartBeats[i] }] }}>
+                  <MaterialCommunityIcons
+                    name={i < lives.left ? 'heart' : 'heart-outline'}
+                    size={15}
+                    color={i < lives.left ? FUNGIKU_LIFE : titleColor}
+                    style={styles.life}
+                  />
+                </Animated.View>
               ))}
             </View>
           </View>
@@ -253,7 +303,7 @@ const FungikuScreenContent = ({ onExitToHub }) => {
             numberOfLines={1}
             // Announced, because a player who cannot see the spinner still needs
             // to know why the board stopped responding.
-            accessibilityLiveRegion={generating || outOfLives ? 'polite' : 'none'}
+            accessibilityLiveRegion={generating || lastMistake ? 'polite' : 'none'}
           >
             {statusText}
           </Text>

--- a/SudokuApp/games/fungiku/__tests__/engine.test.js
+++ b/SudokuApp/games/fungiku/__tests__/engine.test.js
@@ -3,7 +3,6 @@ import {
   MAX_SIZE,
   MIN_SIZE,
   SIZES,
-  nextMark,
   createRng,
   generate,
   findSolutions,
@@ -85,18 +84,6 @@ const marksFromSolution = (puzzle) => {
   });
   return marks;
 };
-
-describe('nextMark', () => {
-  it('cycles empty -> X -> mushroom -> empty (plan §2)', () => {
-    expect(nextMark(MARKS.EMPTY)).toBe(MARKS.X);
-    expect(nextMark(MARKS.X)).toBe(MARKS.MUSHROOM);
-    expect(nextMark(MARKS.MUSHROOM)).toBe(MARKS.EMPTY);
-  });
-
-  it('treats an unknown mark as empty so the first tap gives X', () => {
-    expect(nextMark(undefined)).toBe(MARKS.X);
-  });
-});
 
 describe('createRng', () => {
   it('is deterministic for a given seed', () => {

--- a/SudokuApp/games/fungiku/__tests__/reducer.test.js
+++ b/SudokuApp/games/fungiku/__tests__/reducer.test.js
@@ -302,6 +302,24 @@ describe('a wrong mushroom', () => {
     expect(doubleTap(once, wrong).lives).toBe(MAX_LIVES - 2);
   });
 
+  it('reports itself, so the cell can shake and the counter can say what it cost', () => {
+    const state = doubleTap(initial, wrong);
+    expect(state.lastMistake).toEqual({ cell: wrong, seq: 1 });
+  });
+
+  it('reports a *new* event when the same cell goes wrong twice', () => {
+    // Without the sequence number the second mistake would be an unchanged
+    // object, and the shake would not re-fire.
+    const twice = doubleTap(doubleTap(initial, wrong), wrong);
+    expect(twice.lastMistake.seq).toBe(2);
+  });
+
+  it('stops being reported as soon as the player does something else', () => {
+    const state = doubleTap(initial, wrong);
+    expect(tap(state, 12).lastMistake).toBeNull();
+    expect(undo(state).lastMistake).toBeNull();
+  });
+
   it('does not charge for a correct placement', () => {
     expect(doubleTap(initial, solutionCellOf(initial, 0)).lives).toBe(MAX_LIVES);
   });
@@ -333,6 +351,7 @@ describe('a wrong mushroom', () => {
 
 describe('running out of lives', () => {
   const initial = buildPuzzleState({ size: 5, seed: 1 });
+  const restart = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.RESTART_BOARD });
 
   /** Spend `n` lives on wrong guesses in distinct rows. */
   const spend = (state, n) =>
@@ -341,9 +360,37 @@ describe('running out of lives', () => {
       state
     );
 
+  /**
+   * The board is **not** wiped by the third mistake. It waits at zero lives,
+   * still showing the mark that killed it, until the player acknowledges the
+   * modal. Wiping in the same breath was the first version, and on device it
+   * read as the board emptying for no visible reason.
+   */
+  it('leaves the losing board on screen at zero lives', () => {
+    const lost = spend(initial, MAX_LIVES);
+
+    expect(lost.lives).toBe(0);
+    expect(lost.marks.some((mark) => mark !== MARKS.EMPTY)).toBe(true);
+    expect(selectMistakeCells(lost).size).toBeGreaterThan(0);
+  });
+
+  it('freezes the board while the restart is pending', () => {
+    const lost = spend(initial, MAX_LIVES);
+
+    // The modal is over the board, but the reducer does not rely on that.
+    expect(place(lost, solutionCellOf(initial, 0))).toBe(lost);
+    expect(doubleTap(lost, solutionCellOf(initial, 0)).marks).toEqual(
+      tap(lost, solutionCellOf(initial, 0)).marks
+    );
+  });
+
+  it('reports the mistake that ended it, so the shake and the message have something to fire on', () => {
+    const lost = spend(initial, MAX_LIVES);
+    expect(lost.lastMistake).toMatchObject({ cell: expect.any(Number) });
+  });
+
   it('restarts the same board — same seed, same regions, same solution', () => {
-    const played = doubleTap(spend(initial, MAX_LIVES - 1), solutionCellOf(initial, 4));
-    const restarted = spend(played, 1);
+    const restarted = restart(spend(initial, MAX_LIVES));
 
     expect(restarted.seed).toBe(initial.seed);
     expect(restarted.size).toBe(initial.size);
@@ -352,31 +399,40 @@ describe('running out of lives', () => {
   });
 
   it('clears the marks and hands the lives back', () => {
-    const restarted = spend(initial, MAX_LIVES);
+    const restarted = restart(spend(initial, MAX_LIVES));
 
     expect(restarted.marks.every((mark) => mark === MARKS.EMPTY)).toBe(true);
     expect(restarted.lives).toBe(MAX_LIVES);
     expect(restarted.mistakeCells).toEqual([]);
-  });
-
-  it('says so, once, until the player does something next', () => {
-    const restarted = spend(initial, MAX_LIVES);
-    expect(restarted.outOfLives).toBe(true);
-
-    expect(tap(restarted, 0).outOfLives).toBe(false);
+    expect(restarted.lastMistake).toBeNull();
   });
 
   it('leaves nothing to undo back into — the restart is not a move', () => {
-    const restarted = spend(initial, MAX_LIVES);
+    const restarted = restart(spend(initial, MAX_LIVES));
 
     expect(selectCanUndo(restarted)).toBe(false);
     expect(selectCanRedo(restarted)).toBe(false);
     expect(undo(restarted)).toBe(restarted);
   });
 
-  it('never leaves the board sitting at zero lives', () => {
-    // Zero lives is the trigger, not a state the player is left in.
-    expect(spend(initial, MAX_LIVES).lives).toBeGreaterThan(0);
+  /**
+   * `lives === 0` *is* "a restart is pending" — that is what the modal is driven
+   * by. Because lives are persisted, a player who quits to the hub mid-dialog and
+   * comes back must land back on it rather than on a board with no lives and no
+   * way to start it over.
+   */
+  it('survives a round trip through storage as a pending restart', () => {
+    const lost = spend(initial, MAX_LIVES);
+    const reopened = buildPuzzleState({
+      size: lost.size,
+      seed: lost.seed,
+      marks: lost.marks,
+      lives: lost.lives,
+      mistakeCells: lost.mistakeCells,
+    });
+
+    expect(reopened.lives).toBe(0);
+    expect(restart(reopened).lives).toBe(MAX_LIVES);
   });
 });
 
@@ -912,7 +968,8 @@ describe('hints', () => {
       mistakeCells: [],
       hintsUsed: 0,
       hint: null,
-      outOfLives: false,
+      lastMistake: null,
+      mistakeSeq: 0,
       strokeOpen: false,
       upgradableCell: -1,
     };

--- a/SudokuApp/games/fungiku/__tests__/reducer.test.js
+++ b/SudokuApp/games/fungiku/__tests__/reducer.test.js
@@ -2,32 +2,48 @@ import {
   DEFAULT_SEED,
   FUNGIKU_ACTIONS,
   HINT_KINDS,
+  MAX_LIVES,
   PAINT_MODES,
   buildPuzzleState,
   createInitialFungikuState,
   fungikuReducer,
   selectCanRedo,
   selectCanUndo,
-  selectConflicts,
   selectIsSolved,
-  selectMistakes,
+  selectLives,
+  selectMistakeCells,
   selectMushroomCount,
   selectRevealCell,
   selectRuleOutCells,
   resolvePuzzleIdentity,
 } from '../reducer';
-import { MARKS, MIN_SIZE, createEmptyMarks } from '../engine';
+import { MARKS, MIN_SIZE, createEmptyMarks, findConflicts } from '../engine';
 import { DEFAULT_DIFFICULTY, sizesForDifficulty } from '../difficulty';
 
-const cycle = (state, cell) =>
-  fungikuReducer(state, { type: FUNGIKU_ACTIONS.CYCLE_CELL, payload: { cell } });
+/** One tap: rule a blank cell out, or clear a filled one (plan §14.2). */
+const tap = (state, cell) =>
+  fungikuReducer(state, { type: FUNGIKU_ACTIONS.TAP_CELL, payload: { cell } });
 
-/** Tap a cell twice: empty -> X -> mushroom. */
-const placeMushroom = (state, cell) => cycle(cycle(state, cell), cell);
+/** The second half of a double-tap on its own — also the accessibility path. */
+const place = (state, cell) =>
+  fungikuReducer(state, { type: FUNGIKU_ACTIONS.PLACE_MUSHROOM, payload: { cell } });
+
+/** A real double-tap, as the board dispatches it: a tap, then the upgrade. */
+const doubleTap = (state, cell) => place(tap(state, cell), cell);
+
+const undo = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.UNDO });
+const redo = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.REDO });
+
+/** Where the solution has row `row`'s mushroom. */
+const solutionCellOf = (state, row) => row * state.size + state.solution[row];
+
+/** A cell in `row` that is *not* the solution's — a guaranteed wrong guess. */
+const wrongCellOf = (state, row) =>
+  row * state.size + (state.solution[row] === 0 ? 1 : 0);
 
 /** Place the puzzle's own solution, so the board is legally complete. */
 const solve = (state) =>
-  state.solution.reduce((acc, col, row) => placeMushroom(acc, row * state.size + col), state);
+  state.solution.reduce((acc, col, row) => doubleTap(acc, row * state.size + col), state);
 
 describe('buildPuzzleState', () => {
   it('starts an empty board of the right shape', () => {
@@ -58,10 +74,12 @@ describe('buildPuzzleState', () => {
   });
 
   it('adopts restored marks that match the board', () => {
+    const base = buildPuzzleState({ size: 5, seed: 1 });
     const marks = createEmptyMarks(5);
-    marks[7] = MARKS.MUSHROOM;
+    marks[solutionCellOf(base, 1)] = MARKS.MUSHROOM;
 
-    expect(buildPuzzleState({ size: 5, seed: 1, marks }).marks[7]).toBe(MARKS.MUSHROOM);
+    const restored = buildPuzzleState({ size: 5, seed: 1, marks });
+    expect(restored.marks[solutionCellOf(base, 1)]).toBe(MARKS.MUSHROOM);
   });
 
   it('discards restored marks of the wrong length rather than rendering them', () => {
@@ -74,42 +92,291 @@ describe('buildPuzzleState', () => {
   it('rejects a board smaller than the engine supports', () => {
     expect(() => buildPuzzleState({ size: 4, seed: 1 })).toThrow(/size/i);
   });
+
+  it('starts with a full complement of lives and no red marks', () => {
+    const state = buildPuzzleState({ size: 5, seed: 1 });
+
+    expect(state.lives).toBe(MAX_LIVES);
+    expect(state.mistakeCells).toEqual([]);
+    expect(selectLives(state)).toEqual({ left: MAX_LIVES, of: MAX_LIVES });
+  });
+
+  it('carries a restored life count and its red marks back onto the board', () => {
+    const base = buildPuzzleState({ size: 5, seed: 1 });
+    const wrong = wrongCellOf(base, 0);
+    const marks = createEmptyMarks(5);
+    marks[wrong] = MARKS.X;
+
+    const restored = buildPuzzleState({
+      size: 5,
+      seed: 1,
+      marks,
+      lives: 1,
+      mistakeCells: [wrong],
+    });
+
+    expect(restored.lives).toBe(1);
+    expect([...selectMistakeCells(restored)]).toEqual([wrong]);
+  });
+
+  it('clamps a corrupt life count rather than drawing a heart row it cannot', () => {
+    expect(buildPuzzleState({ size: 5, seed: 1, lives: 99 }).lives).toBe(MAX_LIVES);
+    expect(buildPuzzleState({ size: 5, seed: 1, lives: -4 }).lives).toBe(0);
+    expect(buildPuzzleState({ size: 5, seed: 1, lives: 'lots' }).lives).toBe(MAX_LIVES);
+  });
+
+  it('drops restored mistake records that are not on the board', () => {
+    const state = buildPuzzleState({ size: 5, seed: 1, mistakeCells: [3, -1, 999, 'x'] });
+
+    // 3 holds no X, and the rest are not cells at all.
+    expect(state.mistakeCells).toEqual([]);
+  });
+
+  /**
+   * The invariant the whole step rests on, applied on the way in. A v1/v2 save
+   * can hold mushrooms guessed when guessing was free.
+   */
+  describe('a mushroom restored from an older save', () => {
+    const base = buildPuzzleState({ size: 5, seed: 1 });
+
+    const restoreWith = (cells) => {
+      const marks = createEmptyMarks(5);
+      cells.forEach((cell) => {
+        marks[cell] = MARKS.MUSHROOM;
+      });
+      return buildPuzzleState({ size: 5, seed: 1, marks });
+    };
+
+    it('survives when it is where the solution has it', () => {
+      const cell = solutionCellOf(base, 2);
+      const restored = restoreWith([cell]);
+
+      expect(restored.marks[cell]).toBe(MARKS.MUSHROOM);
+      expect(restored.mistakeCells).toEqual([]);
+    });
+
+    it('becomes a red X when it is not', () => {
+      const cell = wrongCellOf(base, 2);
+      const restored = restoreWith([cell]);
+
+      expect(restored.marks[cell]).toBe(MARKS.X);
+      expect([...selectMistakeCells(restored)]).toEqual([cell]);
+    });
+
+    it('costs nothing — those guesses were made when guessing was free', () => {
+      expect(restoreWith([wrongCellOf(base, 0), wrongCellOf(base, 1)]).lives).toBe(MAX_LIVES);
+    });
+
+    it('leaves no board that a mushroom conflict could exist on', () => {
+      // Two mushrooms in one row is the shape a v2 save could hold and the new
+      // rules cannot produce. Both are wrong, so both convert.
+      const restored = restoreWith([0, 3]);
+
+      expect(findConflicts(restored.marks, restored.regions, restored.size).size).toBe(0);
+    });
+  });
 });
 
-describe('cycling marks', () => {
+/**
+ * The input model (plan §14.2): tap rules out, double-tap commits a mushroom.
+ * The three-state cycle it replaced is gone from the engine entirely.
+ */
+describe('tapping a cell', () => {
   const initial = buildPuzzleState({ size: 5, seed: 1 });
 
-  it('cycles empty -> X -> mushroom -> empty', () => {
-    const afterOne = cycle(initial, 0);
-    expect(afterOne.marks[0]).toBe(MARKS.X);
+  it('rules an empty cell out', () => {
+    expect(tap(initial, 0).marks[0]).toBe(MARKS.X);
+  });
 
-    const afterTwo = cycle(afterOne, 0);
-    expect(afterTwo.marks[0]).toBe(MARKS.MUSHROOM);
+  it('clears a cell that is ruled out', () => {
+    expect(tap(tap(initial, 0), 0).marks[0]).toBe(MARKS.EMPTY);
+  });
 
-    const afterThree = cycle(afterTwo, 0);
-    expect(afterThree.marks[0]).toBe(MARKS.EMPTY);
+  it('clears a cell holding a mushroom — which is what keeps every state reachable', () => {
+    const cell = solutionCellOf(initial, 0);
+    const placed = doubleTap(initial, cell);
+    expect(placed.marks[cell]).toBe(MARKS.MUSHROOM);
+
+    expect(tap(placed, cell).marks[cell]).toBe(MARKS.EMPTY);
   });
 
   it('does not mutate the previous state', () => {
-    const next = cycle(initial, 3);
+    const next = tap(initial, 3);
 
     expect(initial.marks[3]).toBe(MARKS.EMPTY);
     expect(next.marks[3]).toBe(MARKS.X);
   });
 
   it('ignores taps outside the board', () => {
-    expect(cycle(initial, -1)).toBe(initial);
-    expect(cycle(initial, 25)).toBe(initial);
-    expect(cycle(initial, 1.5)).toBe(initial);
+    expect(tap(initial, -1)).toBe(initial);
+    expect(tap(initial, 25)).toBe(initial);
+    expect(tap(initial, 1.5)).toBe(initial);
+    expect(place(initial, 25)).toBe(initial);
+  });
+});
+
+describe('double-tapping to place a mushroom', () => {
+  const initial = buildPuzzleState({ size: 5, seed: 1 });
+
+  it('places one when the cell is where the solution has it', () => {
+    const cell = solutionCellOf(initial, 0);
+    const state = doubleTap(initial, cell);
+
+    expect(state.marks[cell]).toBe(MARKS.MUSHROOM);
+    expect(state.lives).toBe(MAX_LIVES);
+    expect(state.mistakeCells).toEqual([]);
   });
 
-  it('allows a conflicting placement and reports the conflict', () => {
-    // Two mushrooms in row 0 break one-per-row.
-    const state = placeMushroom(placeMushroom(initial, 0), 3);
+  it('is one undo entry, not two — undo never strands the first tap’s ✕', () => {
+    const cell = solutionCellOf(initial, 0);
+    const state = doubleTap(initial, cell);
 
-    expect(state.marks[0]).toBe(MARKS.MUSHROOM);
-    expect(state.marks[3]).toBe(MARKS.MUSHROOM);
-    expect([...selectConflicts(state)].sort((a, b) => a - b)).toEqual([0, 3]);
+    expect(state.undoStack).toHaveLength(1);
+    expect(undo(state).marks).toEqual(initial.marks);
+  });
+
+  it('upgrades a cell the first tap had just cleared, still as one entry', () => {
+    // Double-tapping a ruled-out cell: tap clears it, the second tap commits.
+    const cell = solutionCellOf(initial, 0);
+    const ruledOut = tap(initial, cell);
+    const state = doubleTap(ruledOut, cell);
+
+    expect(state.marks[cell]).toBe(MARKS.MUSHROOM);
+    expect(state.undoStack).toHaveLength(ruledOut.undoStack.length + 1);
+    expect(undo(state).marks).toEqual(ruledOut.marks);
+  });
+
+  it('leaves no dead undo entry when it lands back on the mushroom already there', () => {
+    // Double-tapping a placed mushroom clears it and puts it straight back, so
+    // the board is unchanged — and an undo entry that undoes nothing would be a
+    // dead press of the Undo button.
+    const cell = solutionCellOf(initial, 0);
+    const placed = doubleTap(initial, cell);
+    const again = doubleTap(placed, cell);
+
+    expect(again.marks).toEqual(placed.marks);
+    expect(again.undoStack).toHaveLength(placed.undoStack.length);
+  });
+
+  it('stands alone when no tap preceded it (the accessibility action)', () => {
+    const cell = solutionCellOf(initial, 0);
+    const state = place(initial, cell);
+
+    expect(state.marks[cell]).toBe(MARKS.MUSHROOM);
+    expect(state.undoStack).toHaveLength(1);
+    expect(undo(state).marks).toEqual(initial.marks);
+  });
+
+  it('does not let the upgrade window cross to another cell', () => {
+    const first = solutionCellOf(initial, 0);
+    const second = solutionCellOf(initial, 1);
+
+    // Tap one cell, then double-tap a different one: two separate actions.
+    const state = doubleTap(tap(initial, first), second);
+
+    expect(state.marks[first]).toBe(MARKS.X);
+    expect(state.marks[second]).toBe(MARKS.MUSHROOM);
+    expect(state.undoStack).toHaveLength(2);
+  });
+});
+
+/** Plan §14.3 — the cost of getting it wrong. */
+describe('a wrong mushroom', () => {
+  const initial = buildPuzzleState({ size: 5, seed: 1 });
+  const wrong = wrongCellOf(initial, 0);
+
+  it('never reaches the board: it is flagged immediately and left as a red ✕', () => {
+    const state = doubleTap(initial, wrong);
+
+    expect(state.marks[wrong]).toBe(MARKS.X);
+    expect(selectMushroomCount(state)).toBe(0);
+    expect([...selectMistakeCells(state)]).toEqual([wrong]);
+  });
+
+  it('costs exactly one life', () => {
+    expect(doubleTap(initial, wrong).lives).toBe(MAX_LIVES - 1);
+  });
+
+  it('costs another life every time, even in the same cell', () => {
+    const once = doubleTap(initial, wrong);
+    expect(doubleTap(once, wrong).lives).toBe(MAX_LIVES - 2);
+  });
+
+  it('does not charge for a correct placement', () => {
+    expect(doubleTap(initial, solutionCellOf(initial, 0)).lives).toBe(MAX_LIVES);
+  });
+
+  it('leaves a ✕ a later tap can clear, like any other', () => {
+    const state = tap(doubleTap(initial, wrong), wrong);
+
+    expect(state.marks[wrong]).toBe(MARKS.EMPTY);
+    // The record goes with the mark it was describing.
+    expect(selectMistakeCells(state).size).toBe(0);
+  });
+
+  it('is retracted by undo — but the life is not refunded', () => {
+    // "You don't get lives with info." The mistake already told the player
+    // something true about the board; taking the mark back cannot take that back.
+    const state = doubleTap(initial, wrong);
+    const back = undo(state);
+
+    expect(back.marks).toEqual(initial.marks);
+    expect(back.lives).toBe(MAX_LIVES - 1);
+    expect(selectMistakeCells(back).size).toBe(0);
+  });
+
+  it('does not get its life back through redo either', () => {
+    const state = redo(undo(doubleTap(initial, wrong)));
+    expect(state.lives).toBe(MAX_LIVES - 1);
+  });
+});
+
+describe('running out of lives', () => {
+  const initial = buildPuzzleState({ size: 5, seed: 1 });
+
+  /** Spend `n` lives on wrong guesses in distinct rows. */
+  const spend = (state, n) =>
+    Array.from({ length: n }).reduce(
+      (acc, _, i) => doubleTap(acc, wrongCellOf(acc, i)),
+      state
+    );
+
+  it('restarts the same board — same seed, same regions, same solution', () => {
+    const played = doubleTap(spend(initial, MAX_LIVES - 1), solutionCellOf(initial, 4));
+    const restarted = spend(played, 1);
+
+    expect(restarted.seed).toBe(initial.seed);
+    expect(restarted.size).toBe(initial.size);
+    expect(restarted.regions).toEqual(initial.regions);
+    expect(restarted.solution).toEqual(initial.solution);
+  });
+
+  it('clears the marks and hands the lives back', () => {
+    const restarted = spend(initial, MAX_LIVES);
+
+    expect(restarted.marks.every((mark) => mark === MARKS.EMPTY)).toBe(true);
+    expect(restarted.lives).toBe(MAX_LIVES);
+    expect(restarted.mistakeCells).toEqual([]);
+  });
+
+  it('says so, once, until the player does something next', () => {
+    const restarted = spend(initial, MAX_LIVES);
+    expect(restarted.outOfLives).toBe(true);
+
+    expect(tap(restarted, 0).outOfLives).toBe(false);
+  });
+
+  it('leaves nothing to undo back into — the restart is not a move', () => {
+    const restarted = spend(initial, MAX_LIVES);
+
+    expect(selectCanUndo(restarted)).toBe(false);
+    expect(selectCanRedo(restarted)).toBe(false);
+    expect(undo(restarted)).toBe(restarted);
+  });
+
+  it('never leaves the board sitting at zero lives', () => {
+    // Zero lives is the trigger, not a state the player is left in.
+    expect(spend(initial, MAX_LIVES).lives).toBeGreaterThan(0);
   });
 });
 
@@ -117,10 +384,10 @@ describe('the mushroom counter', () => {
   const initial = buildPuzzleState({ size: 5, seed: 1 });
 
   it('counts only mushrooms, never X marks', () => {
-    const withXs = cycle(cycle(initial, 1), 2); // two cells left on X
+    const withXs = tap(tap(initial, 1), 2);
     expect(selectMushroomCount(withXs)).toBe(0);
 
-    const withOne = placeMushroom(withXs, 10);
+    const withOne = doubleTap(withXs, solutionCellOf(initial, 2));
     expect(selectMushroomCount(withOne)).toBe(1);
   });
 });
@@ -136,17 +403,19 @@ describe('win detection', () => {
     const state = solve(initial);
 
     expect(selectMushroomCount(state)).toBe(5);
-    expect(selectConflicts(state).size).toBe(0);
     expect(selectIsSolved(state)).toBe(true);
+  });
+
+  it('is won with a full complement of lives, because only correct guesses land', () => {
+    expect(solve(initial).lives).toBe(MAX_LIVES);
   });
 
   it('is still won with X marks scattered around (X is only an aid)', () => {
     let state = solve(initial);
     const solutionCells = new Set(state.solution.map((col, row) => row * state.size + col));
 
-    // Put an X on every cell that isn't holding a mushroom.
     state.marks.forEach((_, cell) => {
-      if (!solutionCells.has(cell)) state = cycle(state, cell);
+      if (!solutionCells.has(cell)) state = tap(state, cell);
     });
 
     expect(state.marks.filter((mark) => mark === MARKS.X)).toHaveLength(20);
@@ -154,35 +423,56 @@ describe('win detection', () => {
   });
 
   it('is not won by a board full of X marks and no mushrooms', () => {
-    const state = initial.marks.reduce((acc, _, cell) => cycle(acc, cell), initial);
+    const state = initial.marks.reduce((acc, _, cell) => tap(acc, cell), initial);
 
     expect(state.marks.every((mark) => mark === MARKS.X)).toBe(true);
     expect(selectIsSolved(state)).toBe(false);
   });
 
-  it('is not won by N mushrooms placed illegally', () => {
-    // Fill row 0 and row 2 badly: right count, wrong placement.
-    let state = initial;
-    for (let col = 0; col < 5; col++) {
-      state = placeMushroom(state, col);
-    }
+  it('cannot be reached by double-tapping every cell — the wrong ones never land', () => {
+    // Under the old cycle this filled the board with mushrooms. Now each wrong
+    // guess converts, and the third one restarts the board.
+    const state = initial.marks.reduce((acc, _, cell) => doubleTap(acc, cell), initial);
 
-    expect(selectMushroomCount(state)).toBe(5);
     expect(selectIsSolved(state)).toBe(false);
+    expect(state.marks.filter((m) => m === MARKS.MUSHROOM).length).toBeLessThan(5);
   });
 
   it('stops being won as soon as a mushroom is removed', () => {
     const solved = solve(initial);
     const firstMushroom = solved.marks.findIndex((mark) => mark === MARKS.MUSHROOM);
 
-    expect(selectIsSolved(cycle(solved, firstMushroom))).toBe(false);
+    expect(selectIsSolved(tap(solved, firstMushroom))).toBe(false);
+  });
+});
+
+/**
+ * The consequence §14.3 calls out: with every placed mushroom at a solution cell,
+ * and solution cells never sharing a row, column or region or touching, two
+ * mushrooms on the board can no longer conflict. That is why the conflict
+ * rendering and `selectConflicts` are gone.
+ */
+describe('conflicts, now unreachable by construction', () => {
+  const initial = buildPuzzleState({ size: 5, seed: 1 });
+  const conflictsOn = (state) => findConflicts(state.marks, state.regions, state.size);
+
+  it('cannot be produced by two placements in the same row', () => {
+    // The old test for this placed two mushrooms in row 0 and asserted both were
+    // flagged. Now the wrong one never becomes a mushroom at all.
+    const state = doubleTap(doubleTap(initial, solutionCellOf(initial, 0)), wrongCellOf(initial, 0));
+
+    expect(state.marks.filter((m) => m === MARKS.MUSHROOM)).toHaveLength(1);
+    expect(conflictsOn(state).size).toBe(0);
+  });
+
+  it('cannot be produced by any sequence of double-taps', () => {
+    const state = initial.marks.reduce((acc, _, cell) => doubleTap(acc, cell), initial);
+    expect(conflictsOn(state).size).toBe(0);
   });
 });
 
 describe('undo and redo', () => {
   const initial = buildPuzzleState({ size: 5, seed: 1 });
-  const undo = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.UNDO });
-  const redo = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.REDO });
 
   it('does nothing on an empty history', () => {
     expect(selectCanUndo(initial)).toBe(false);
@@ -192,39 +482,30 @@ describe('undo and redo', () => {
   });
 
   it('walks back and forward through taps', () => {
-    const placed = placeMushroom(initial, 4);
-    expect(placed.marks[4]).toBe(MARKS.MUSHROOM);
+    const cell = solutionCellOf(initial, 0);
+    const placed = doubleTap(tap(initial, cell), cell);
+    expect(placed.marks[cell]).toBe(MARKS.MUSHROOM);
 
     const back = undo(placed);
-    expect(back.marks[4]).toBe(MARKS.X);
+    expect(back.marks[cell]).toBe(MARKS.X);
     expect(selectCanRedo(back)).toBe(true);
 
     const backAgain = undo(back);
-    expect(backAgain.marks[4]).toBe(MARKS.EMPTY);
+    expect(backAgain.marks[cell]).toBe(MARKS.EMPTY);
     expect(selectCanUndo(backAgain)).toBe(false);
 
-    expect(redo(redo(backAgain)).marks[4]).toBe(MARKS.MUSHROOM);
+    expect(redo(redo(backAgain)).marks[cell]).toBe(MARKS.MUSHROOM);
   });
 
   it('drops the redo stack once a new tap lands', () => {
-    const back = undo(placeMushroom(initial, 4));
+    const back = undo(doubleTap(initial, solutionCellOf(initial, 0)));
     expect(selectCanRedo(back)).toBe(true);
 
-    expect(selectCanRedo(cycle(back, 9))).toBe(false);
-  });
-
-  it('keeps derived conflicts in step with an undo', () => {
-    const conflicting = placeMushroom(placeMushroom(initial, 0), 3);
-    expect(selectConflicts(conflicting).size).toBe(2);
-
-    // Undo takes cell 3 back to X, so nothing conflicts any more.
-    const back = undo(conflicting);
-    expect(selectConflicts(back).size).toBe(0);
+    expect(selectCanRedo(tap(back, 9))).toBe(false);
   });
 
   it('undoes a win back to an unsolved board', () => {
-    const solved = solve(initial);
-    expect(selectIsSolved(undo(solved))).toBe(false);
+    expect(selectIsSolved(undo(solve(initial)))).toBe(false);
   });
 });
 
@@ -233,23 +514,30 @@ describe('clearing the board', () => {
   const clear = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.CLEAR_MARKS });
 
   it('empties every mark in one undoable step', () => {
-    const played = placeMushroom(cycle(initial, 1), 7);
+    const played = doubleTap(tap(initial, 1), solutionCellOf(initial, 1));
     const cleared = clear(played);
 
     expect(cleared.marks.every((mark) => mark === MARKS.EMPTY)).toBe(true);
-
-    const back = fungikuReducer(cleared, { type: FUNGIKU_ACTIONS.UNDO });
-    expect(back.marks).toEqual(played.marks);
+    expect(undo(cleared).marks).toEqual(played.marks);
   });
 
   it('is a no-op on an already empty board', () => {
     expect(clear(initial)).toBe(initial);
   });
+
+  it('takes the red marks with it but not the lives spent earning them', () => {
+    const played = doubleTap(initial, wrongCellOf(initial, 0));
+    const cleared = clear(played);
+
+    expect(cleared.mistakeCells).toEqual([]);
+    expect(cleared.lives).toBe(MAX_LIVES - 1);
+  });
 });
 
 describe('starting another puzzle', () => {
   it('replaces the board and forgets the history', () => {
-    const played = placeMushroom(buildPuzzleState({ size: 5, seed: 1 }), 0);
+    const base = buildPuzzleState({ size: 5, seed: 1 });
+    const played = doubleTap(base, solutionCellOf(base, 0));
 
     const next = fungikuReducer(played, {
       type: FUNGIKU_ACTIONS.NEW_PUZZLE,
@@ -264,18 +552,34 @@ describe('starting another puzzle', () => {
     expect(selectCanRedo(next)).toBe(false);
   });
 
+  it('hands back a full complement of lives', () => {
+    const base = buildPuzzleState({ size: 5, seed: 1 });
+    const played = doubleTap(base, wrongCellOf(base, 0));
+    expect(played.lives).toBe(MAX_LIVES - 1);
+
+    const next = fungikuReducer(played, {
+      type: FUNGIKU_ACTIONS.NEW_PUZZLE,
+      payload: buildPuzzleState({ size: 6, seed: 2 }),
+    });
+
+    expect(next.lives).toBe(MAX_LIVES);
+    expect(next.mistakeCells).toEqual([]);
+  });
+
   it('restores a saved board through the same path', () => {
+    const target = buildPuzzleState({ size: 5, seed: 9 });
     const marks = createEmptyMarks(5);
-    marks[12] = MARKS.MUSHROOM;
+    marks[solutionCellOf(target, 2)] = MARKS.MUSHROOM;
 
     const restored = fungikuReducer(createInitialFungikuState(), {
       type: FUNGIKU_ACTIONS.RESTORE_SAVED_GAME,
-      payload: buildPuzzleState({ size: 5, seed: 9, marks }),
+      payload: buildPuzzleState({ size: 5, seed: 9, marks, lives: 2 }),
     });
 
     expect(restored.seed).toBe(9);
-    expect(restored.marks[12]).toBe(MARKS.MUSHROOM);
     expect(selectMushroomCount(restored)).toBe(1);
+    // A round trip through the hub must not refund a mistake.
+    expect(restored.lives).toBe(2);
   });
 });
 
@@ -348,14 +652,15 @@ describe('difficulty on built state', () => {
   });
 
   it('reopens a restored board at its saved size, not at whatever the rung would pick', () => {
+    const target = buildPuzzleState({ difficulty: 'easy', size: 6, seed: 1 });
     const marks = createEmptyMarks(6);
-    marks[3] = MARKS.MUSHROOM;
+    marks[solutionCellOf(target, 0)] = MARKS.MUSHROOM;
 
     const restored = buildPuzzleState({ difficulty: 'easy', size: 6, seed: 1, marks });
 
     expect(restored.size).toBe(6);
     expect(restored.difficulty).toBe('easy');
-    expect(restored.marks[3]).toBe(MARKS.MUSHROOM);
+    expect(restored.marks[solutionCellOf(target, 0)]).toBe(MARKS.MUSHROOM);
   });
 });
 
@@ -372,7 +677,6 @@ describe('drag strokes', () => {
   const end = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.END_STROKE });
   const paint = (state, cells, mode = PAINT_MODES.X) =>
     fungikuReducer(state, { type: FUNGIKU_ACTIONS.PAINT_CELLS, payload: { cells, mode } });
-  const undoOne = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.UNDO });
 
   /** A whole stroke, the way the gesture drives it. */
   const stroke = (state, batches, mode = PAINT_MODES.X) =>
@@ -388,7 +692,7 @@ describe('drag strokes', () => {
     const state = stroke(initial, [[0], [1, 2], [3, 4]]);
 
     expect(state.undoStack).toHaveLength(1);
-    expect(undoOne(state).marks).toEqual(initial.marks);
+    expect(undo(state).marks).toEqual(initial.marks);
   });
 
   it('erases back to empty when the stroke is an erase', () => {
@@ -401,19 +705,31 @@ describe('drag strokes', () => {
 
   it('never overwrites a mushroom', () => {
     // Losing a deduced placement to a stray swipe is the worst failure here.
-    const withMushroom = placeMushroom(initial, 2);
+    const cell = solutionCellOf(initial, 0);
+    const withMushroom = doubleTap(initial, cell);
     const swept = stroke(withMushroom, [[0, 1, 2, 3, 4]]);
 
-    expect(swept.marks[2]).toBe(MARKS.MUSHROOM);
-    expect(swept.marks[1]).toBe(MARKS.X);
-    expect(swept.marks[3]).toBe(MARKS.X);
+    expect(swept.marks[cell]).toBe(MARKS.MUSHROOM);
+    expect(swept.marks.filter((m) => m === MARKS.X)).toHaveLength(4);
   });
 
   it('does not overwrite a mushroom on an erase stroke either', () => {
-    const withMushroom = placeMushroom(initial, 2);
-    const swept = stroke(withMushroom, [[0, 1, 2, 3, 4]], PAINT_MODES.ERASE);
+    const cell = solutionCellOf(initial, 0);
+    const swept = stroke(doubleTap(initial, cell), [[0, 1, 2, 3, 4]], PAINT_MODES.ERASE);
 
-    expect(swept.marks[2]).toBe(MARKS.MUSHROOM);
+    expect(swept.marks[cell]).toBe(MARKS.MUSHROOM);
+  });
+
+  it('takes the red off an X it erases, without refunding the life', () => {
+    const wrong = wrongCellOf(initial, 0);
+    const played = doubleTap(initial, wrong);
+    expect(selectMistakeCells(played).size).toBe(1);
+
+    const swept = stroke(played, [[wrong]], PAINT_MODES.ERASE);
+
+    expect(swept.marks[wrong]).toBe(MARKS.EMPTY);
+    expect(selectMistakeCells(swept).size).toBe(0);
+    expect(swept.lives).toBe(MAX_LIVES - 1);
   });
 
   it('is a no-op when the stroke changes nothing, leaving no undo entry', () => {
@@ -432,7 +748,7 @@ describe('drag strokes', () => {
 
     expect(swept.marks.slice(0, 3)).toEqual([MARKS.X, MARKS.X, MARKS.X]);
     expect(swept.undoStack).toHaveLength(2);
-    expect(undoOne(swept).marks).toEqual(seeded.marks);
+    expect(undo(swept).marks).toEqual(seeded.marks);
   });
 
   it('ignores cells outside the board', () => {
@@ -464,12 +780,16 @@ describe('drag strokes', () => {
     expect(selectIsSolved(swept)).toBe(false);
     expect(selectMushroomCount(swept)).toBe(0);
   });
+
+  it('never costs a life — there is no such thing as a wrong ✕', () => {
+    const all = Array.from({ length: 25 }, (_, i) => i);
+    expect(stroke(initial, [all]).lives).toBe(MAX_LIVES);
+  });
 });
 
 describe('the rule-out button', () => {
   const base = buildPuzzleState({ size: 5, seed: 1 });
   const ruleOut = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.RULE_OUT });
-  const undo = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.UNDO });
 
   it('does nothing on an empty board', () => {
     // Nothing is placed, so nothing is forbidden yet.
@@ -478,19 +798,17 @@ describe('the rule-out button', () => {
   });
 
   it('marks the row, column, region and neighbours of a placed mushroom', () => {
-    const cell = 12; // row 2, col 2
-    const placed = placeMushroom(base, cell);
-    const after = ruleOut(placed);
+    const row = 2;
+    const cell = solutionCellOf(base, row);
+    const col = base.solution[row];
+    const after = ruleOut(doubleTap(base, cell));
 
     expect(after.marks[cell]).toBe(MARKS.MUSHROOM);
 
     for (let i = 0; i < 5; i++) {
-      if (i !== 2) {
-        expect(after.marks[2 * 5 + i]).toBe(MARKS.X);
-        expect(after.marks[i * 5 + 2]).toBe(MARKS.X);
-      }
+      if (i !== col) expect(after.marks[row * 5 + i]).toBe(MARKS.X);
+      if (i !== row) expect(after.marks[i * 5 + col]).toBe(MARKS.X);
     }
-    [6, 7, 8, 11, 13, 16, 17, 18].forEach((n) => expect(after.marks[n]).toBe(MARKS.X));
 
     const region = base.regions[cell];
     base.regions.forEach((r, i) => {
@@ -499,121 +817,53 @@ describe('the rule-out button', () => {
   });
 
   it('accounts for every placed mushroom at once, not just the last', () => {
-    const two = placeMushroom(placeMushroom(base, 0), 12);
+    const two = doubleTap(doubleTap(base, solutionCellOf(base, 0)), solutionCellOf(base, 2));
     const after = ruleOut(two);
 
-    // Row 0 belongs to the mushroom at 0; row 2 to the one at 12.
-    expect(after.marks[1]).toBe(MARKS.X);
-    expect(after.marks[14]).toBe(MARKS.X);
+    const blanks = after.marks.filter((m) => m === MARKS.EMPTY).length;
+    expect(selectRuleOutCells(two).size).toBeGreaterThan(0);
+    expect(blanks).toBeLessThan(base.marks.length);
   });
 
   it('is one undoable action however many cells it fills', () => {
-    const placed = placeMushroom(base, 12);
+    const placed = doubleTap(base, solutionCellOf(base, 2));
     const after = ruleOut(placed);
 
     expect(after.undoStack).toHaveLength(placed.undoStack.length + 1);
     expect(undo(after).marks).toEqual(placed.marks);
   });
 
-  it('never disturbs a mushroom, including a conflicting one', () => {
-    // Two mushrooms in row 0 conflict; each rules the other's cell out, and
-    // neither may be overwritten — the player is mid-deduction.
-    const conflicting = placeMushroom(placeMushroom(base, 0), 3);
-    const after = ruleOut(conflicting);
-
-    expect(after.marks[0]).toBe(MARKS.MUSHROOM);
-    expect(after.marks[3]).toBe(MARKS.MUSHROOM);
-  });
-
   it('only fills blanks, leaving existing marks alone', () => {
-    const placed = placeMushroom(base, 12);
-    const after = ruleOut(placed);
-    const again = ruleOut(after);
+    const after = ruleOut(doubleTap(base, solutionCellOf(base, 2)));
 
     // Second tap has nothing left to do, so it is a no-op with no undo entry.
-    expect(again).toBe(after);
+    expect(ruleOut(after)).toBe(after);
     expect(selectRuleOutCells(after).size).toBe(0);
   });
 
-  it('reports how many cells it would fill, for the button label', () => {
-    const placed = placeMushroom(base, 12);
-
-    expect(selectRuleOutCells(placed).size).toBeGreaterThan(0);
-    expect(selectRuleOutCells(placed).has(12)).toBe(false);
-  });
-
-  it('leaves its X marks behind when the mushroom is cycled away', () => {
+  it('leaves its X marks behind when the mushroom is tapped away', () => {
     // Deliberate: they become ordinary X marks the moment they land. Retracting
     // them would need per-mark provenance, which is ambiguous as soon as two
     // mushrooms rule out the same cell. Undo is how you take the assist back.
-    const after = ruleOut(placeMushroom(base, 12));
-    const cycledAway = cycle(after, 12);
+    const cell = solutionCellOf(base, 2);
+    const after = ruleOut(doubleTap(base, cell));
+    const tappedAway = tap(after, cell);
 
-    expect(cycledAway.marks[12]).toBe(MARKS.EMPTY);
-    expect(cycledAway.marks.filter((m) => m === MARKS.X).length).toBeGreaterThan(0);
+    expect(tappedAway.marks[cell]).toBe(MARKS.EMPTY);
+    expect(tappedAway.marks.filter((m) => m === MARKS.X).length).toBeGreaterThan(0);
   });
 
   it('cannot win a board on its own', () => {
-    expect(selectIsSolved(ruleOut(placeMushroom(base, 12)))).toBe(false);
-  });
-});
-
-describe('correctness feedback', () => {
-  const base = buildPuzzleState({ size: 5, seed: 1 });
-  const solutionCell = (row) => row * base.size + base.solution[row];
-
-  it('is off by default', () => {
-    expect(base.showMistakes).toBe(false);
+    expect(selectIsSolved(ruleOut(doubleTap(base, solutionCellOf(base, 2))))).toBe(false);
   });
 
-  it('flags a mushroom that breaks no rule but is in the wrong cell', () => {
-    // Pick a cell in row 0 that is not the solution's.
-    const wrong = base.solution[0] === 0 ? 1 : 0;
-    const state = placeMushroom(base, wrong);
-
-    expect(selectConflicts(state).size).toBe(0); // legal so far
-    expect([...selectMistakes(state)]).toEqual([wrong]);
-  });
-
-  it('does not flag a correct mushroom', () => {
-    expect(selectMistakes(placeMushroom(base, solutionCell(0))).size).toBe(0);
-  });
-
-  it('never flags an X mark, however many there are', () => {
-    // X is a thinking aid with no bearing on the win, so there is no wrong X.
-    const allX = base.marks.reduce((acc, _, cell) => cycle(acc, cell), base);
-
-    expect(allX.marks.every((m) => m === MARKS.X)).toBe(true);
-    expect(selectMistakes(allX).size).toBe(0);
-  });
-
-  it('never flags a complete legal board, because there cannot be one that is wrong', () => {
-    // Uniqueness: N mushrooms with no conflicts *is* the solution.
-    const solved = solve(base);
-
-    expect(selectIsSolved(solved)).toBe(true);
-    expect(selectMistakes(solved).size).toBe(0);
-  });
-
-  it('is a preference the switch toggles, independent of the flags themselves', () => {
-    const wrong = base.solution[0] === 0 ? 1 : 0;
-    const placed = placeMushroom(base, wrong);
-    const on = fungikuReducer(placed, { type: FUNGIKU_ACTIONS.TOGGLE_MISTAKES });
-
-    expect(on.showMistakes).toBe(true);
-    // The selector reports mistakes either way — only rendering is gated.
-    expect(selectMistakes(on).size).toBe(1);
-    expect(fungikuReducer(on, { type: FUNGIKU_ACTIONS.TOGGLE_MISTAKES }).showMistakes).toBe(false);
-  });
-
-  it('carries the preference across a new puzzle', () => {
-    expect(buildPuzzleState({ size: 6, seed: 2, showMistakes: true }).showMistakes).toBe(true);
+  it('costs no lives', () => {
+    expect(ruleOut(doubleTap(base, solutionCellOf(base, 2))).lives).toBe(MAX_LIVES);
   });
 });
 
 describe('hints', () => {
   const base = buildPuzzleState({ size: 5, seed: 1 });
-  const solutionCell = (row) => row * base.size + base.solution[row];
   const hintFor = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.REQUEST_HINT });
   const reveal = (state) => fungikuReducer(state, { type: FUNGIKU_ACTIONS.REVEAL_MUSHROOM });
 
@@ -622,26 +872,26 @@ describe('hints', () => {
     expect(base.hintsUsed).toBe(0);
   });
 
-  it('reports a mistake before anything else, because a wrong mushroom corrupts every deduction after it', () => {
-    const wrong = base.solution[0] === 0 ? 1 : 0;
-    const state = hintFor(placeMushroom(base, wrong));
+  it('has no "one of your mushrooms is wrong" rung left to reach', () => {
+    // The rung is gone because the board it described cannot exist: a wrong
+    // mushroom is converted the instant it is placed.
+    const guessed = doubleTap(base, wrongCellOf(base, 0));
 
-    expect(state.hint.kind).toBe(HINT_KINDS.MISTAKE);
-    expect(state.hint.cells).toEqual([wrong]);
-    expect(state.hintsUsed).toBe(1);
+    expect(Object.values(HINT_KINDS)).not.toContain('mistake');
+    expect(hintFor(guessed).hint.kind).not.toBe('mistake');
   });
 
   it('nudges at a group without naming the cell', () => {
     // Four of five rows solved leaves the fifth forced.
     let state = base;
-    for (let row = 0; row < 4; row++) state = placeMushroom(state, solutionCell(row));
+    for (let row = 0; row < 4; row++) state = doubleTap(state, solutionCellOf(state, row));
 
     const hinted = hintFor(state);
     expect(hinted.hint.kind).toBe(HINT_KINDS.NUDGE);
     // The highlight is the whole group, not the single forced cell — that is
     // what makes it a nudge rather than a reveal.
     expect(hinted.hint.cells.length).toBeGreaterThan(1);
-    expect(hinted.hint.cells).toContain(solutionCell(4));
+    expect(hinted.hint.cells).toContain(solutionCellOf(base, 4));
     expect(hinted.hint.message).toMatch(/only one cell/i);
   });
 
@@ -658,10 +908,13 @@ describe('hints', () => {
       marks: createEmptyMarks(5),
       undoStack: [],
       redoStack: [],
-      showMistakes: false,
+      lives: MAX_LIVES,
+      mistakeCells: [],
       hintsUsed: 0,
       hint: null,
+      outOfLives: false,
       strokeOpen: false,
+      upgradableCell: -1,
     };
 
     const hinted = hintFor(bands);
@@ -678,52 +931,49 @@ describe('hints', () => {
 
     expect(revealed.hint.kind).toBe(HINT_KINDS.REVEAL);
     expect(revealed.marks[cell]).toBe(MARKS.MUSHROOM);
-    expect(selectMistakes(revealed).size).toBe(0); // it revealed a *correct* one
     expect(revealed.hintsUsed).toBe(1);
   });
 
-  it('never reveals a mushroom that would conflict', () => {
-    // Reveal repeatedly and check the board stays legal throughout.
+  it('never costs a life, however many it places', () => {
     let state = base;
-    for (let i = 0; i < 5; i++) {
-      state = reveal(state);
-      expect(selectConflicts(state).size).toBe(0);
-    }
+    for (let i = 0; i < 5; i++) state = reveal(state);
+
     expect(selectIsSolved(state)).toBe(true);
+    expect(state.lives).toBe(MAX_LIVES);
   });
 
-  it('has nothing safe to reveal when a wrong mushroom blocks every solution cell', () => {
-    // Fill the whole board with mushrooms: every solution cell is occupied or
-    // conflicted, so there is no safe reveal and the cascade reports mistakes.
-    const everywhere = base.marks.reduce((acc, _, cell) => placeMushroom(acc, cell), base);
+  it('has nothing left to reveal once the board is solved', () => {
+    const solved = solve(base);
 
-    expect(selectRevealCell(everywhere)).toBe(-1);
-    expect(reveal(everywhere)).toBe(everywhere);
-    expect(hintFor(everywhere).hint.kind).toBe(HINT_KINDS.MISTAKE);
+    expect(selectRevealCell(solved)).toBe(-1);
+    expect(reveal(solved)).toBe(solved);
   });
 
   it('is one undoable action', () => {
-    const revealed = reveal(base);
-    const back = fungikuReducer(revealed, { type: FUNGIKU_ACTIONS.UNDO });
-
-    expect(back.marks).toEqual(base.marks);
+    expect(undo(reveal(base)).marks).toEqual(base.marks);
   });
 
   it('goes stale the moment the board changes', () => {
     const hinted = hintFor(base);
     expect(hinted.hint).not.toBeNull();
 
-    expect(cycle(hinted, 0).hint).toBeNull();
+    expect(tap(hinted, 0).hint).toBeNull();
 
     // Only an action that *actually changes the board* clears it. A no-op
     // action leaves the advice alone, because it is still advice about the board
     // in front of you — so these use a board where each action does something.
-    const played = hintFor(placeMushroom(base, solutionCell(0)));
+    const played = hintFor(doubleTap(base, solutionCellOf(base, 0)));
     expect(fungikuReducer(played, { type: FUNGIKU_ACTIONS.RULE_OUT }).hint).toBeNull();
-    expect(fungikuReducer(played, { type: FUNGIKU_ACTIONS.UNDO }).hint).toBeNull();
+    expect(undo(played).hint).toBeNull();
 
     // ...and a no-op undo on a board with no history keeps it.
-    expect(fungikuReducer(hintFor(base), { type: FUNGIKU_ACTIONS.UNDO }).hint).not.toBeNull();
+    expect(undo(hintFor(base)).hint).not.toBeNull();
+  });
+
+  it('is cleared by a placement, right or wrong', () => {
+    expect(hintFor(base).hint).not.toBeNull();
+    expect(doubleTap(hintFor(base), solutionCellOf(base, 0)).hint).toBeNull();
+    expect(doubleTap(hintFor(base), wrongCellOf(base, 0)).hint).toBeNull();
   });
 
   it('can be dismissed', () => {
@@ -732,13 +982,10 @@ describe('hints', () => {
   });
 
   it('keeps its count across a hint that follows', () => {
-    const once = reveal(base);
-    expect(reveal(once).hintsUsed).toBe(2);
+    expect(reveal(reveal(base)).hintsUsed).toBe(2);
   });
 
-  it('resets the count for a new puzzle but not the preference', () => {
-    const fresh = buildPuzzleState({ size: 5, seed: 2, showMistakes: true, hintsUsed: 0 });
-    expect(fresh.hintsUsed).toBe(0);
-    expect(fresh.showMistakes).toBe(true);
+  it('resets the count for a new puzzle', () => {
+    expect(buildPuzzleState({ size: 5, seed: 2, hintsUsed: 0 }).hintsUsed).toBe(0);
   });
 });

--- a/SudokuApp/games/fungiku/__tests__/saveMigration.test.js
+++ b/SudokuApp/games/fungiku/__tests__/saveMigration.test.js
@@ -1,5 +1,6 @@
 import { FUNGIKU_STORAGE_VERSION, migrateFungikuSave } from '../saveMigration';
 import { MARKS, createEmptyMarks } from '../engine';
+import { MAX_LIVES } from '../reducer';
 
 /** A v1 save exactly as Steps 4-8 wrote one. */
 const v1Save = (overrides = {}) => {
@@ -44,10 +45,7 @@ describe('migrating a v1 save', () => {
   });
 
   it('carries the other v1 fields forward untouched', () => {
-    const migrated = migrateFungikuSave(v1Save());
-
-    expect(migrated.showMistakes).toBe(true);
-    expect(migrated.hintsUsed).toBe(2);
+    expect(migrateFungikuSave(v1Save()).hintsUsed).toBe(2);
   });
 
   it('maps every size a v1 save could hold onto a real rung', () => {
@@ -75,16 +73,92 @@ describe('migrating a v1 save', () => {
   });
 });
 
+/**
+ * v2 → v3 (Step 10, plan §14.3): the "Show mistakes" preference is deleted and a
+ * board now carries what it has cost.
+ */
+describe('migrating a v2 save', () => {
+  const v2Save = (overrides = {}) => {
+    const { showMistakes, ...rest } = v1Save();
+    return { ...rest, _v: 2, difficulty: 'easy', showMistakes, ...overrides };
+  };
+
+  it('drops the correctness-feedback preference rather than translating it', () => {
+    // There is nothing to translate it *to*: feedback stopped being a preference
+    // and became a rule of the game.
+    expect(migrateFungikuSave(v2Save({ showMistakes: true }))).not.toHaveProperty('showMistakes');
+    expect(migrateFungikuSave(v2Save({ showMistakes: false }))).not.toHaveProperty('showMistakes');
+  });
+
+  it('hands the board a full complement of lives', () => {
+    // The save has no record of what its guesses would have cost, and inventing
+    // a debt for a player who simply updated the app would be worse than level.
+    expect(migrateFungikuSave(v2Save()).lives).toBe(MAX_LIVES);
+    expect(migrateFungikuSave(v2Save()).mistakeCells).toEqual([]);
+  });
+
+  it('does not wipe or alter the board — still the whole point', () => {
+    const saved = v2Save();
+    const migrated = migrateFungikuSave(saved);
+
+    expect(migrated._v).toBe(FUNGIKU_STORAGE_VERSION);
+    expect(migrated.size).toBe(6);
+    expect(migrated.seed).toBe(7);
+    expect(migrated.marks).toEqual(saved.marks);
+    expect(migrated.difficulty).toBe('easy');
+    expect(migrated.hintsUsed).toBe(2);
+  });
+});
+
+describe('a v1 save brought all the way forward', () => {
+  it('picks up both bumps in one pass', () => {
+    const migrated = migrateFungikuSave(v1Save());
+
+    expect(migrated._v).toBe(FUNGIKU_STORAGE_VERSION);
+    expect(migrated.difficulty).toBe('easy');
+    expect(migrated.lives).toBe(MAX_LIVES);
+    expect(migrated).not.toHaveProperty('showMistakes');
+  });
+});
+
 describe('a current save', () => {
+  const v3Save = (overrides = {}) => {
+    const { showMistakes, ...rest } = v1Save();
+    return {
+      ...rest,
+      _v: FUNGIKU_STORAGE_VERSION,
+      difficulty: 'easy',
+      lives: 2,
+      mistakeCells: [4],
+      ...overrides,
+    };
+  };
+
   it('passes through unchanged', () => {
-    const saved = { ...v1Save(), _v: FUNGIKU_STORAGE_VERSION, difficulty: 'easy' };
+    const saved = v3Save();
     expect(migrateFungikuSave(saved)).toEqual(saved);
   });
 
+  it('keeps the lives it was saved with — a round trip is not a refund', () => {
+    expect(migrateFungikuSave(v3Save({ lives: 1 })).lives).toBe(1);
+    expect(migrateFungikuSave(v3Save({ lives: 0 })).lives).toBe(0);
+  });
+
   it('has a corrupt difficulty repaired from its size rather than being discarded', () => {
-    const saved = { ...v1Save(), _v: FUNGIKU_STORAGE_VERSION, difficulty: 'legendary' };
+    const saved = v3Save({ difficulty: 'legendary' });
     expect(migrateFungikuSave(saved).difficulty).toBe('easy');
     expect(migrateFungikuSave(saved).marks).toEqual(saved.marks);
+  });
+
+  it('has a corrupt life count repaired rather than drawing a heart row it cannot', () => {
+    expect(migrateFungikuSave(v3Save({ lives: 99 })).lives).toBe(MAX_LIVES);
+    expect(migrateFungikuSave(v3Save({ lives: -1 })).lives).toBe(0);
+    expect(migrateFungikuSave(v3Save({ lives: 'three' })).lives).toBe(MAX_LIVES);
+  });
+
+  it('discards mistake records that are not cell indices', () => {
+    expect(migrateFungikuSave(v3Save({ mistakeCells: 'nope' })).mistakeCells).toEqual([]);
+    expect(migrateFungikuSave(v3Save({ mistakeCells: [1, 'x', 2.5] })).mistakeCells).toEqual([1]);
   });
 });
 

--- a/SudokuApp/games/fungiku/engine.js
+++ b/SudokuApp/games/fungiku/engine.js
@@ -20,17 +20,15 @@
 
 // Marks a cell can hold. X is a player aid only and never affects win
 // detection (plan §2, §9).
+//
+// There is deliberately **no tap cycle here any more.** Steps 4-9 had one
+// (`nextMark`: empty -> X -> mushroom -> empty); plan §14.2 replaced it with
+// tap = X, double-tap = mushroom, and a mushroom is no longer a mark the player
+// can simply set — placing one is an *attempt* that the reducer judges against
+// the solution and may cost a life (§14.3). A cycle function would be a second,
+// silent way to place one that skips that judgement, so it is gone rather than
+// left unused.
 export const MARKS = { EMPTY: 'empty', X: 'x', MUSHROOM: 'mushroom' };
-
-// Tap order: empty -> X -> mushroom -> empty (plan §2).
-const MARK_CYCLE = [MARKS.EMPTY, MARKS.X, MARKS.MUSHROOM];
-
-/** The next mark in the tap cycle. */
-export function nextMark(mark) {
-  const i = MARK_CYCLE.indexOf(mark);
-  // Unknown/absent mark is treated as empty, so the first tap yields X.
-  return MARK_CYCLE[((i < 0 ? 0 : i) + 1) % MARK_CYCLE.length];
-}
 
 /**
  * Smallest solvable board. N=4 is impossible: one mushroom per column with a

--- a/SudokuApp/games/fungiku/reducer.js
+++ b/SudokuApp/games/fungiku/reducer.js
@@ -54,6 +54,10 @@ export const FUNGIKU_ACTIONS = {
   PLACE_MUSHROOM: 'FUNGIKU_PLACE_MUSHROOM',
 
   CLEAR_MARKS: 'FUNGIKU_CLEAR_MARKS',
+
+  // Acknowledging the out-of-lives modal. The restart is deliberately *not*
+  // automatic — see the note on PLACE_MUSHROOM.
+  RESTART_BOARD: 'FUNGIKU_RESTART_BOARD',
   UNDO: 'FUNGIKU_UNDO',
   REDO: 'FUNGIKU_REDO',
   RESTORE_SAVED_GAME: 'FUNGIKU_RESTORE_SAVED_GAME',
@@ -257,10 +261,16 @@ export const buildPuzzleState = ({
     // Transient advice, never persisted: it goes stale the moment the board
     // changes, so every board-changing action clears it.
     hint: null,
-    // Transient: set to true by the restart that follows the last life being
-    // spent, so the status line can say what just happened. Cleared by the next
-    // thing the player does.
-    outOfLives: false,
+    // Transient: the wrong guess the player just made, so the board can shake
+    // the cell and the counter row can say what it cost. Cleared by the next
+    // thing the player does; never persisted.
+    lastMistake: null,
+    // Monotonic within a session, and deliberately **not** cleared alongside
+    // `lastMistake`: it is what makes two wrong guesses in the same cell two
+    // distinct events. A counter that reset with the transient would hand out
+    // seq 1 twice, and an animation keyed on it would not re-fire the second
+    // time. Never persisted — it means nothing across a reload.
+    mistakeSeq: 0,
     // Transient: true between BEGIN_STROKE and the stroke's first effective
     // paint, which is the paint that records the single undo entry. Never
     // persisted (see ./storage.js).
@@ -295,7 +305,7 @@ const pushHistory = (state, marks, extra) => ({
   // Advice about a board you have since changed is worse than no advice.
   hint: null,
   // Both transients belong to one gesture and do not survive the next action.
-  outOfLives: false,
+  lastMistake: null,
   upgradableCell: -1,
   ...extra,
 });
@@ -320,7 +330,7 @@ const amendHistory = (state, marks, extra) => {
     undoStack: unchanged ? state.undoStack.slice(0, -1) : state.undoStack,
     mistakeCells: pruneMistakeCells(state.mistakeCells, marks),
     hint: null,
-    outOfLives: false,
+    lastMistake: null,
     upgradableCell: -1,
     ...extra,
   };
@@ -381,6 +391,10 @@ export function fungikuReducer(state, action) {
         return state;
       }
 
+      // Out of lives already: the board is waiting to be restarted and the
+      // modal is over it. Nothing on the board should respond until it is.
+      if (state.lives === 0) return state;
+
       const correct = isSolutionCell(cell, state.solution, state.size);
       const marks = state.marks.slice();
       marks[cell] = correct ? MARKS.MUSHROOM : MARKS.X;
@@ -396,25 +410,27 @@ export function fungikuReducer(state, action) {
       // be remembered as a mistake, so a later tap clears it like any other
       // (plan §14.3 ships it clearable and flags it for an on-device answer).
       const lives = Math.max(0, state.lives - 1);
+      const seq = (state.mistakeSeq || 0) + 1;
+      const spent = record(state, marks, {
+        lives,
+        mistakeSeq: seq,
+        lastMistake: { cell, seq },
+      });
 
-      // Out of lives: the **same** board starts over — same seed, same regions,
-      // marks cleared, lives back. A fresh board would punish twice, taking away
-      // the deduction the player has already done along with the lives.
-      if (lives === 0) {
-        return {
-          ...state,
-          marks: createEmptyMarks(state.size),
-          mistakeCells: [],
-          lives: MAX_LIVES,
-          undoStack: [],
-          redoStack: [],
-          hint: null,
-          outOfLives: true,
-          upgradableCell: -1,
-        };
-      }
-
-      const spent = record(state, marks, { lives });
+      // **The board is not wiped here, even on the last life.** It ends up at
+      // `lives === 0` holding the mark that killed it, and RESTART_BOARD does the
+      // clearing once the player has acknowledged the modal.
+      //
+      // Wiping in the same breath as the third mistake was the first version,
+      // and the operator's report on it was that the board simply emptied with
+      // no idea what had happened. Losing is worth a beat: the fatal red ✕ stays
+      // on screen, the hearts are visibly empty, and the restart is something
+      // the player presses.
+      //
+      // `lives === 0` is therefore exactly "a restart is pending", which is what
+      // the modal is driven by — and because `lives` is persisted, quitting to
+      // the hub mid-modal and coming back lands back on it rather than stranding
+      // a board with no lives and no way to start it over.
       return {
         ...spent,
         mistakeCells: spent.mistakeCells.includes(cell)
@@ -422,6 +438,24 @@ export function fungikuReducer(state, action) {
           : [...spent.mistakeCells, cell],
       };
     }
+
+    /**
+     * Start the **same** board over: same seed, same regions, marks cleared,
+     * lives back (plan §14.3). A fresh board would punish twice, taking away the
+     * deduction the player has already done along with the lives.
+     */
+    case FUNGIKU_ACTIONS.RESTART_BOARD:
+      return {
+        ...state,
+        marks: createEmptyMarks(state.size),
+        mistakeCells: [],
+        lives: MAX_LIVES,
+        undoStack: [],
+        redoStack: [],
+        hint: null,
+        lastMistake: null,
+        upgradableCell: -1,
+      };
 
     case FUNGIKU_ACTIONS.RULE_OUT: {
       const ruled = selectRuleOutCells(state);
@@ -568,7 +602,7 @@ export function fungikuReducer(state, action) {
         redoStack: [...state.redoStack, state.marks],
         mistakeCells: pruneMistakeCells(state.mistakeCells, marks),
         hint: null,
-        outOfLives: false,
+        lastMistake: null,
         upgradableCell: -1,
       };
     }
@@ -583,7 +617,7 @@ export function fungikuReducer(state, action) {
         redoStack: state.redoStack.slice(0, -1),
         mistakeCells: pruneMistakeCells(state.mistakeCells, marks),
         hint: null,
-        outOfLives: false,
+        lastMistake: null,
         upgradableCell: -1,
       };
     }

--- a/SudokuApp/games/fungiku/reducer.js
+++ b/SudokuApp/games/fungiku/reducer.js
@@ -6,13 +6,22 @@
  * place a row/column/region/adjacency check exists.
  *
  * What lives in state: the puzzle identity (`difficulty` + `size` + `seed`), the
- * puzzle data rebuilt from it (`regions`, `solution`), and the player's `marks`.
- * Conflicts, the mushroom count and the win condition are **derived** from
- * `marks` by the selectors at the bottom rather than stored — storing them would
- * let undo rewind marks and leave stale highlights behind.
+ * puzzle data rebuilt from it (`regions`, `solution`), the player's `marks`, and
+ * what those marks have cost — `lives` and `mistakeCells`. The mushroom count
+ * and the win condition are **derived** from `marks` by the selectors at the
+ * bottom rather than stored: storing them would let undo rewind marks and leave
+ * stale highlights behind.
  *
- * Only the identity plus `marks` is ever persisted (see ./storage.js);
- * generation is deterministic, so regions and the solution are rebuilt.
+ * **The invariant this module maintains, since plan §14.3:** every mushroom on
+ * the board is at a solution cell. A wrong one is converted to a red X the
+ * instant it is placed, and marks arriving from an older save are put through the
+ * same rule on the way in. A great deal follows from it — most visibly that two
+ * mushrooms can no longer conflict, which is why there is no `selectConflicts`
+ * any more. See the note above the selectors.
+ *
+ * Persisted: the identity, `marks`, `lives`, `mistakeCells` and `hintsUsed` (see
+ * ./storage.js). Generation is deterministic, so regions and the solution are
+ * rebuilt rather than stored.
  */
 import {
   MARKS,
@@ -24,7 +33,6 @@ import {
   findForcedDeduction,
   generate,
   isSolved,
-  nextMark,
 } from './engine';
 import {
   DEFAULT_DIFFICULTY,
@@ -36,7 +44,15 @@ import {
 
 export const FUNGIKU_ACTIONS = {
   NEW_PUZZLE: 'FUNGIKU_NEW_PUZZLE',
-  CYCLE_CELL: 'FUNGIKU_CYCLE_CELL',
+
+  // The two halves of the input model (plan §14.2), which replaced the
+  // three-state tap cycle:
+  //   TAP_CELL       — empty becomes X; anything filled becomes empty.
+  //   PLACE_MUSHROOM — the second tap of a double-tap. An *attempt*: the reducer
+  //                    judges it against the solution and it may cost a life.
+  TAP_CELL: 'FUNGIKU_TAP_CELL',
+  PLACE_MUSHROOM: 'FUNGIKU_PLACE_MUSHROOM',
+
   CLEAR_MARKS: 'FUNGIKU_CLEAR_MARKS',
   UNDO: 'FUNGIKU_UNDO',
   REDO: 'FUNGIKU_REDO',
@@ -53,20 +69,32 @@ export const FUNGIKU_ACTIONS = {
   // forbid. An action the player asks for, not a mode that acts behind them.
   RULE_OUT: 'FUNGIKU_RULE_OUT',
 
-  // Feedback and hints (plan §11).
-  TOGGLE_MISTAKES: 'FUNGIKU_TOGGLE_MISTAKES',
+  // Feedback and hints (plan §11, §14.3).
   REQUEST_HINT: 'FUNGIKU_REQUEST_HINT',
   REVEAL_MUSHROOM: 'FUNGIKU_REVEAL_MUSHROOM',
   DISMISS_HINT: 'FUNGIKU_DISMISS_HINT',
 };
 
-/** What a hint turned out to be able to offer (plan §11.2). */
+/**
+ * What a hint turned out to be able to offer (plan §11.2).
+ *
+ * Rung 1 — "one of your mushrooms is in the wrong place" — is **gone**, not
+ * unused: since §14.3 a wrong mushroom never survives placement, so there can
+ * never be one on the board to point at.
+ */
 export const HINT_KINDS = {
-  MISTAKE: 'mistake',
   NUDGE: 'nudge',
   REVEAL: 'reveal',
   STUCK: 'stuck',
 };
+
+/**
+ * Lives per board (plan §14.3). **Three at every size**, not scaled per
+ * difficulty — the operator's answer. A bigger board is more work, not more
+ * forgiving, and a per-size table would be a second difficulty concept sitting
+ * next to `difficulty.js`.
+ */
+export const MAX_LIVES = 3;
 
 /** What a drag stroke does to the cells it crosses. */
 export const PAINT_MODES = { X: 'x', ERASE: 'erase' };
@@ -112,23 +140,97 @@ export const resolvePuzzleIdentity = ({ difficulty, size, seed }) => {
   return { difficulty: named ? difficulty : difficultyForSize(size), size };
 };
 
+/** Is this flat cell index where the solution has a mushroom? */
+const isSolutionCell = (cell, solution, size) => solution[Math.floor(cell / size)] === cell % size;
+
+/**
+ * Keep only the mistake records whose X is still on the board.
+ *
+ * Undo, an erase stroke and a plain tap can all take a red X away, and a record
+ * that outlives its mark would come back to haunt the *next* X the player puts
+ * in that cell — showing it red for a mistake they have already taken back.
+ *
+ * Returns the array it was given when nothing changed, so a state update can be
+ * skipped by identity the way the rest of this module does.
+ */
+const pruneMistakeCells = (cells, marks) => {
+  const kept = cells.filter((cell) => marks[cell] === MARKS.X);
+  return kept.length === cells.length ? cells : kept;
+};
+
+/**
+ * The invariant this whole step rests on: **every mushroom on the board sits at
+ * a solution cell** (plan §14.3). Placement enforces it going forward — a wrong
+ * mushroom is converted to a red X the instant it is placed — and this enforces
+ * it on the way *in*, for marks that arrive from somewhere else.
+ *
+ * Today that means one thing: a save written before this step (v1/v2), whose
+ * board may hold mushrooms the player had guessed and not yet been told about.
+ * The migration cannot do this — `saveMigration.js` is pure and deliberately
+ * knows nothing about solutions — so it happens here, where the puzzle has just
+ * been generated and the answer is in hand.
+ *
+ * **No lives are charged.** Those guesses were made under rules where they were
+ * free, and billing for them retroactively on first launch after an update would
+ * be indefensible. What they get is the feedback the new rules would have given:
+ * the mushroom becomes an ordinary X, flagged red.
+ *
+ * Leaving them instead was the alternative, and it is worse: it would leave the
+ * board in a state the rest of the game now assumes cannot exist (two mushrooms
+ * that conflict), which is exactly how "unreachable" code turns out to be
+ * reachable.
+ */
+const enforcePlacedMushroomsAreCorrect = (marks, mistakeCells, solution, size) => {
+  const wrong = [];
+
+  marks.forEach((mark, cell) => {
+    if (mark === MARKS.MUSHROOM && !isSolutionCell(cell, solution, size)) wrong.push(cell);
+  });
+
+  if (wrong.length === 0) return { marks, mistakeCells };
+
+  const next = marks.slice();
+  wrong.forEach((cell) => {
+    next[cell] = MARKS.X;
+  });
+
+  return { marks: next, mistakeCells: [...new Set([...mistakeCells, ...wrong])] };
+};
+
 /**
  * Build a fresh state for a puzzle identity. Calls `generate`, which throws for
  * an unsupported size — callers do this outside the reducer so a generation
  * failure never happens mid-dispatch.
  *
- * @param {{difficulty?: string, size?: number, seed?: number, marks?: string[]}} opts
+ * @param {{difficulty?: string, size?: number, seed?: number, marks?: string[],
+ *   lives?: number, mistakeCells?: number[], hintsUsed?: number}} opts
  */
 export const buildPuzzleState = ({
   difficulty,
   size,
   seed = DEFAULT_SEED,
   marks,
-  showMistakes = false,
+  lives = MAX_LIVES,
+  mistakeCells,
   hintsUsed = 0,
 } = {}) => {
   const identity = resolvePuzzleIdentity({ difficulty, size, seed });
   const puzzle = generate({ size: identity.size, seed });
+
+  // A restored `marks` array is only trusted if it matches this board's shape.
+  const restored =
+    Array.isArray(marks) && marks.length === puzzle.size * puzzle.size
+      ? marks.slice()
+      : createEmptyMarks(puzzle.size);
+
+  const checked = enforcePlacedMushroomsAreCorrect(
+    restored,
+    (Array.isArray(mistakeCells) ? mistakeCells : []).filter(
+      (cell) => Number.isInteger(cell) && cell >= 0 && cell < restored.length
+    ),
+    puzzle.solution,
+    puzzle.size
+  );
 
   return {
     // What the player picked, and what it resolved to. Both are persisted: the
@@ -139,26 +241,33 @@ export const buildPuzzleState = ({
     seed: puzzle.seed,
     regions: puzzle.regions,
     solution: puzzle.solution,
-    // A restored `marks` array is only trusted if it matches this board's shape.
-    marks:
-      Array.isArray(marks) && marks.length === puzzle.size * puzzle.size
-        ? marks.slice()
-        : createEmptyMarks(puzzle.size),
+    marks: checked.marks,
     undoStack: [],
     redoStack: [],
-    // Opt-in correctness feedback (plan §11.1). Off by default: left on it turns
-    // a deduction puzzle into trial-and-error. A preference, so it carries across
-    // puzzles; §8 #7 asks whether it should default on for younger players.
-    showMistakes: !!showMistakes,
-    // Per-puzzle, so the ladder step can price hints later (plan §11.2).
+    // Lives left on *this* board (plan §14.3). Per-puzzle, and persisted: leaving
+    // for the hub and coming back must not refund a mistake.
+    lives: Number.isFinite(lives) ? Math.max(0, Math.min(MAX_LIVES, lives)) : MAX_LIVES,
+    // Cells holding an X that is there because a mushroom was placed on them and
+    // was wrong — the red X of §14.3. It cannot be derived: an ordinary X sitting
+    // on a solution cell is a perfectly legal thing for a player to mark, and
+    // colouring *those* red would hand over the answer.
+    mistakeCells: pruneMistakeCells(checked.mistakeCells, checked.marks),
+    // Per-puzzle, so the wallet step can price hints later (plan §11.2, §14.4).
     hintsUsed: Number.isFinite(hintsUsed) ? hintsUsed : 0,
     // Transient advice, never persisted: it goes stale the moment the board
     // changes, so every board-changing action clears it.
     hint: null,
+    // Transient: set to true by the restart that follows the last life being
+    // spent, so the status line can say what just happened. Cleared by the next
+    // thing the player does.
+    outOfLives: false,
     // Transient: true between BEGIN_STROKE and the stroke's first effective
     // paint, which is the paint that records the single undo entry. Never
     // persisted (see ./storage.js).
     strokeOpen: false,
+    // Transient: the cell whose undo entry a double-tap's second half is still
+    // allowed to amend. See TAP_CELL / PLACE_MUSHROOM.
+    upgradableCell: -1,
   };
 };
 
@@ -177,14 +286,45 @@ export const createInitialFungikuState = () =>
  * and it means a single cell tap and a full "clear board" undo through exactly
  * the same code path. The stacks are deliberately not persisted.
  */
-const pushHistory = (state, marks) => ({
+const pushHistory = (state, marks, extra) => ({
   ...state,
   marks,
   undoStack: [...state.undoStack, state.marks],
   redoStack: [],
+  mistakeCells: pruneMistakeCells(state.mistakeCells, marks),
   // Advice about a board you have since changed is worse than no advice.
   hint: null,
+  // Both transients belong to one gesture and do not survive the next action.
+  outOfLives: false,
+  upgradableCell: -1,
+  ...extra,
 });
+
+/**
+ * Rewrite the marks **without** adding an undo entry — the second half of a
+ * double-tap, whose first half already pushed one (see PLACE_MUSHROOM).
+ *
+ * The one wrinkle: double-tapping a cell that already held a correct mushroom
+ * clears it and puts it straight back, so the amended board is identical to the
+ * snapshot the first tap pushed. Left alone that would leave an undo entry that
+ * undoes nothing — one dead press of the Undo button. Dropping it here is
+ * cheaper than explaining it later.
+ */
+const amendHistory = (state, marks, extra) => {
+  const previous = state.undoStack[state.undoStack.length - 1];
+  const unchanged = previous.length === marks.length && previous.every((m, i) => m === marks[i]);
+
+  return {
+    ...state,
+    marks,
+    undoStack: unchanged ? state.undoStack.slice(0, -1) : state.undoStack,
+    mistakeCells: pruneMistakeCells(state.mistakeCells, marks),
+    hint: null,
+    outOfLives: false,
+    upgradableCell: -1,
+    ...extra,
+  };
+};
 
 export function fungikuReducer(state, action) {
   switch (action.type) {
@@ -193,17 +333,94 @@ export function fungikuReducer(state, action) {
       // The payload is already a complete built state (see buildPuzzleState).
       return { ...state, ...action.payload };
 
-    case FUNGIKU_ACTIONS.CYCLE_CELL: {
+    /**
+     * A single tap (plan §14.2): an empty cell is ruled out, a filled one is
+     * cleared — whichever mark filled it.
+     *
+     * Clearing on a filled cell is what keeps every state reachable now that the
+     * cycle is gone, and it is the reason this action can be dispatched the
+     * instant the finger lifts: it never has to wait to find out whether a second
+     * tap is coming. The X — by far the most common mark in the game — is on
+     * screen immediately, and the second tap *upgrades* the result instead.
+     */
+    case FUNGIKU_ACTIONS.TAP_CELL: {
       const { cell } = action.payload;
       if (!Number.isInteger(cell) || cell < 0 || cell >= state.marks.length) {
         return state;
       }
 
-      // A conflicting placement is allowed on purpose (plan §2): conflicts are
-      // shown, never blocked — spotting and fixing them is the puzzle.
       const marks = state.marks.slice();
-      marks[cell] = nextMark(marks[cell]);
-      return pushHistory(state, marks);
+      marks[cell] = marks[cell] === MARKS.EMPTY ? MARKS.X : MARKS.EMPTY;
+
+      // Arm the upgrade. If a second tap on this same cell arrives next, it
+      // amends this entry rather than stacking a second one on top.
+      return pushHistory(state, marks, { upgradableCell: cell });
+    }
+
+    /**
+     * The second tap of a double-tap: commit a mushroom (plan §14.2, §14.3).
+     *
+     * Two things are load-bearing here.
+     *
+     * **It is one undo entry, not two.** The first tap has already pushed an
+     * entry and left `upgradableCell` pointing at this cell, so this half writes
+     * the marks *without* pushing again. Undo therefore lands on the board as it
+     * was before the double-tap began — not on the intermediate X that the player
+     * never asked for. It is the same trick BEGIN_STROKE/PAINT_CELLS uses to make
+     * a whole drag one action; the difference is only that the entry here is
+     * pushed by the first event rather than armed by it.
+     *
+     * **A wrong mushroom does not survive.** It is judged against the solution
+     * immediately: right, and it stays; wrong, and it becomes a red X and costs a
+     * life. That is what makes "every mushroom on the board is a solution cell"
+     * an invariant rather than a hope — see `enforcePlacedMushroomsAreCorrect`.
+     */
+    case FUNGIKU_ACTIONS.PLACE_MUSHROOM: {
+      const { cell } = action.payload;
+      if (!Number.isInteger(cell) || cell < 0 || cell >= state.marks.length) {
+        return state;
+      }
+
+      const correct = isSolutionCell(cell, state.solution, state.size);
+      const marks = state.marks.slice();
+      marks[cell] = correct ? MARKS.MUSHROOM : MARKS.X;
+
+      // Amending the first tap's entry, or standing alone? Standing alone is the
+      // accessibility action's path, and any path where the taps did not pair up.
+      const amends = state.upgradableCell === cell && state.undoStack.length > 0;
+      const record = amends ? amendHistory : pushHistory;
+
+      if (correct) return record(state, marks);
+
+      // Wrong. The mark is a red X from here on: an *ordinary* X that happens to
+      // be remembered as a mistake, so a later tap clears it like any other
+      // (plan §14.3 ships it clearable and flags it for an on-device answer).
+      const lives = Math.max(0, state.lives - 1);
+
+      // Out of lives: the **same** board starts over — same seed, same regions,
+      // marks cleared, lives back. A fresh board would punish twice, taking away
+      // the deduction the player has already done along with the lives.
+      if (lives === 0) {
+        return {
+          ...state,
+          marks: createEmptyMarks(state.size),
+          mistakeCells: [],
+          lives: MAX_LIVES,
+          undoStack: [],
+          redoStack: [],
+          hint: null,
+          outOfLives: true,
+          upgradableCell: -1,
+        };
+      }
+
+      const spent = record(state, marks, { lives });
+      return {
+        ...spent,
+        mistakeCells: spent.mistakeCells.includes(cell)
+          ? spent.mistakeCells
+          : [...spent.mistakeCells, cell],
+      };
     }
 
     case FUNGIKU_ACTIONS.RULE_OUT: {
@@ -223,40 +440,23 @@ export function fungikuReducer(state, action) {
       return pushHistory(state, marks);
     }
 
-    case FUNGIKU_ACTIONS.TOGGLE_MISTAKES:
-      return { ...state, showMistakes: !state.showMistakes };
-
     case FUNGIKU_ACTIONS.DISMISS_HINT:
       return state.hint ? { ...state, hint: null } : state;
 
     /**
      * One hint, as weak as will still help (plan §11.2). The cascade matters:
      *
-     * 1. A wrong mushroom on the board corrupts every deduction that follows, so
-     *    saying "row 3 is forced" would be confidently wrong. Mistakes first.
-     * 2. Otherwise nudge: name the row, column or region where something is
-     *    forced, *without* saying which cell. That is the hint that teaches.
-     * 3. Nothing forced from here — **say so** rather than quietly revealing.
+     * 1. Nudge: name the row, column or region where something is forced,
+     *    *without* saying which cell. That is the hint that teaches.
+     * 2. Nothing forced from here — **say so** rather than quietly revealing.
      *    The reveal is a second, deliberate tap.
+     *
+     * There used to be a rung above both of these — "one of your mushrooms is in
+     * the wrong place" — and it is gone rather than dormant. Since §14.3 a wrong
+     * mushroom is converted the instant it is placed, so there has never been one
+     * on the board for that rung to find.
      */
     case FUNGIKU_ACTIONS.REQUEST_HINT: {
-      const mistakes = selectMistakes(state);
-      if (mistakes.size > 0) {
-        const cell = Math.min(...mistakes);
-        return {
-          ...state,
-          hintsUsed: state.hintsUsed + 1,
-          hint: {
-            kind: HINT_KINDS.MISTAKE,
-            cells: [cell],
-            message:
-              mistakes.size === 1
-                ? 'This mushroom is in the wrong place.'
-                : `${mistakes.size} of your mushrooms are in the wrong place — here is one.`,
-          },
-        };
-      }
-
       const forced = findForcedDeduction(state.marks, state.regions, state.size);
       if (forced) {
         return {
@@ -335,7 +535,13 @@ export function fungikuReducer(state, action) {
 
       return state.strokeOpen
         ? { ...pushHistory(state, marks), strokeOpen: false }
-        : { ...state, marks };
+        : {
+            ...state,
+            marks,
+            // A stroke can erase a red X like any other, so the record has to
+            // follow the marks even on the paints that add no undo entry.
+            mistakeCells: pruneMistakeCells(state.mistakeCells, marks),
+          };
     }
 
     case FUNGIKU_ACTIONS.CLEAR_MARKS: {
@@ -345,25 +551,40 @@ export function fungikuReducer(state, action) {
       return pushHistory(state, createEmptyMarks(state.size));
     }
 
+    /**
+     * Undo retracts the mark. It does **not** refund a life (plan §14.3) —
+     * *"you don't get lives with info."* The wrong guess already told the player
+     * something true about the board, and taking the mark back cannot take the
+     * knowledge back, so the life stays spent. `lives` is simply not part of what
+     * the history stacks hold: they are mark snapshots and nothing else.
+     */
     case FUNGIKU_ACTIONS.UNDO: {
       if (state.undoStack.length === 0) return state;
+      const marks = state.undoStack[state.undoStack.length - 1];
       return {
         ...state,
-        marks: state.undoStack[state.undoStack.length - 1],
+        marks,
         undoStack: state.undoStack.slice(0, -1),
         redoStack: [...state.redoStack, state.marks],
+        mistakeCells: pruneMistakeCells(state.mistakeCells, marks),
         hint: null,
+        outOfLives: false,
+        upgradableCell: -1,
       };
     }
 
     case FUNGIKU_ACTIONS.REDO: {
       if (state.redoStack.length === 0) return state;
+      const marks = state.redoStack[state.redoStack.length - 1];
       return {
         ...state,
-        marks: state.redoStack[state.redoStack.length - 1],
+        marks,
         undoStack: [...state.undoStack, state.marks],
         redoStack: state.redoStack.slice(0, -1),
+        mistakeCells: pruneMistakeCells(state.mistakeCells, marks),
         hint: null,
+        outOfLives: false,
+        upgradableCell: -1,
       };
     }
 
@@ -373,9 +594,20 @@ export function fungikuReducer(state, action) {
 }
 
 // --- Selectors: everything derived, so nothing can go stale -----------------
-
-/** Flat indices of mushrooms breaking a rule (plan §2). */
-export const selectConflicts = (state) => findConflicts(state.marks, state.regions, state.size);
+//
+// **There is no `selectConflicts` here any more, and that is a decision, not an
+// omission** (plan §14.3, and see the module header). Every mushroom that
+// survives on the board sits at a solution cell, and two solution cells never
+// share a row, column or region and never touch — so two placed mushrooms cannot
+// conflict. `findConflicts` stays in the engine, where generation, `isSolved`
+// and the reveal-safety check below still need it; what is gone is the player-
+// facing half that could no longer ever fire.
+//
+// `selectMistakes` went the same way, for the same reason: it reported wrong
+// mushrooms *sitting on the board*, and none can. The red-X record that replaced
+// it is `state.mistakeCells`, which is stored rather than derived — an ordinary X
+// on a solution cell is a legal thing to mark, so "is this X a mistake?" is not a
+// question the board can answer by looking at it.
 
 /** Mushrooms placed — the left half of the `🍄 X/N` counter. */
 export const selectMushroomCount = (state) => countMushrooms(state.marks);
@@ -407,39 +639,26 @@ export const selectRuleOutCells = (state) => {
 export const selectCanUndo = (state) => state.undoStack.length > 0;
 export const selectCanRedo = (state) => state.redoStack.length > 0;
 
-/**
- * Mushrooms that break no rule *yet* but are not where the puzzle's single
- * solution has them (plan §11.1). Derived, never stored, so undo cannot leave a
- * stale flag behind.
- *
- * **Mushrooms only.** X marks are a thinking aid with no bearing on the win, so
- * there is no such thing as a wrong X — flagging one would be telling the player
- * how to think.
- *
- * Note what this can never report: because the puzzle has exactly one solution,
- * N mushrooms placed with no conflicts *is* that solution. There is no
- * complete-but-wrong board, so this is purely a mid-solve aid.
- */
-export const selectMistakes = (state) => {
-  const out = new Set();
+/** Cells showing a red X: an X that is there because a mushroom went wrong. */
+export const selectMistakeCells = (state) => new Set(state.mistakeCells);
 
-  state.marks.forEach((mark, cell) => {
-    if (mark !== MARKS.MUSHROOM) return;
-    const row = Math.floor(cell / state.size);
-    if (state.solution[row] !== cell % state.size) out.add(cell);
-  });
-
-  return out;
-};
+/** Lives left, and the full complement — what the heart row draws. */
+export const selectLives = (state) => ({ left: state.lives, of: MAX_LIVES });
 
 /**
  * Which cell a reveal would fill: a row still missing its mushroom whose solution
  * cell can be placed **without creating a conflict** (plan §11.2 — "a hint that
  * creates a conflict is worse than no hint").
  *
- * Returns -1 when there is nothing safe to reveal, which in practice means a
- * wrongly-placed mushroom is in the way. The hint cascade catches that first and
- * reports the mistake instead.
+ * The conflict trial is now belt and braces rather than a live guard: every
+ * mushroom on the board is a solution cell, so another solution cell can never
+ * clash with one. It is kept because it is what makes the guarantee *local* — the
+ * check lives next to the placement it protects instead of depending on an
+ * invariant established three files away.
+ *
+ * Returns -1 when every row already has its mushroom, i.e. the board is solved
+ * and there is nothing left to reveal. Before §14.3 it could also mean "a wrongly
+ * placed mushroom is in the way"; that case no longer exists.
  */
 export const selectRevealCell = (state) => {
   for (let row = 0; row < state.size; row++) {

--- a/SudokuApp/games/fungiku/saveMigration.js
+++ b/SudokuApp/games/fungiku/saveMigration.js
@@ -16,12 +16,14 @@
  * one — it describes a shape already on real devices.
  */
 import { difficultyForSize, isDifficulty } from './difficulty';
+import { MAX_LIVES } from './reducer';
 
 /**
  * v1 — `{size, seed, marks, showMistakes, hintsUsed}` (Steps 4-8).
  * v2 — v1 plus `difficulty`, the rung the player picked (Step 9).
+ * v3 — `showMistakes` dropped; `lives` and `mistakeCells` added (Step 10).
  */
-export const FUNGIKU_STORAGE_VERSION = 2;
+export const FUNGIKU_STORAGE_VERSION = 3;
 
 /**
  * v1 → v2: name the rung the saved board belongs to.
@@ -37,9 +39,34 @@ const v1ToV2 = (saved) => ({
   difficulty: difficultyForSize(saved.size),
 });
 
+/**
+ * v2 → v3: the correctness-feedback switch is gone, and a board now costs
+ * something to get wrong (plan §14.3).
+ *
+ * `showMistakes` is dropped rather than translated: there is nothing on the far
+ * side to translate it *to*. Correctness feedback stopped being a preference and
+ * became a rule of the game — always on, and priced.
+ *
+ * The board arrives with **a full complement of lives**. It is the only defensible
+ * choice: the marks in this save were made when guessing was free, so there is no
+ * record of what they would have cost, and inventing a debt for a player who
+ * simply updated the app would be worse than starting them level.
+ *
+ * `mistakeCells` starts empty for the same reason — the save carries no record of
+ * which marks were mistakes. Any *mushroom* in it that turns out to be wrong is
+ * still converted to a red X on load, but that happens in `buildPuzzleState`,
+ * which knows the solution; this module is pure and deliberately does not.
+ */
+const v2ToV3 = ({ showMistakes, ...rest }) => ({
+  ...rest,
+  lives: MAX_LIVES,
+  mistakeCells: [],
+});
+
 /** Keyed by the version each function upgrades *from*. */
 const MIGRATIONS = {
   1: v1ToV2,
+  2: v2ToV3,
 };
 
 /**
@@ -69,14 +96,20 @@ export const migrateFungikuSave = (saved) => {
     version += 1;
   }
 
-  // Belt and braces: a hand-edited or corrupt `difficulty` should not reach the
-  // menu as a rung that does not exist.
+  // Belt and braces: a hand-edited or corrupt field should not reach the game as
+  // a rung that does not exist, or as a life count the heart row cannot draw.
   return {
     ...current,
     _v: FUNGIKU_STORAGE_VERSION,
     difficulty: isDifficulty(current.difficulty)
       ? current.difficulty
       : difficultyForSize(current.size),
+    lives: Number.isFinite(current.lives)
+      ? Math.max(0, Math.min(MAX_LIVES, current.lives))
+      : MAX_LIVES,
+    mistakeCells: Array.isArray(current.mistakeCells)
+      ? current.mistakeCells.filter(Number.isInteger)
+      : [],
   };
 };
 

--- a/SudokuApp/games/fungiku/storage.js
+++ b/SudokuApp/games/fungiku/storage.js
@@ -43,7 +43,8 @@ export const loadFungikuState = async () => {
       size: saved.size,
       seed: saved.seed,
       marks: saved.marks,
-      showMistakes: saved.showMistakes,
+      lives: saved.lives,
+      mistakeCells: saved.mistakeCells,
       hintsUsed: saved.hintsUsed,
     });
   } catch (error) {
@@ -66,12 +67,21 @@ export const saveFungikuState = debounce(async (state) => {
         size: state.size,
         seed: state.seed,
         marks: state.marks,
-        // The feedback switch is a preference and the hint count is per-puzzle
-        // history, so both persist. `strokeOpen` and `hint` deliberately do not:
-        // one is gesture bookkeeping, the other is advice that goes stale the
-        // moment the board changes. Nor does anything about the rule-out assist —
-        // it is an action the player taps, not a mode with a remembered setting.
-        showMistakes: !!state.showMistakes,
+        // What the board has cost so far (plan §14.3). Persisted for one reason:
+        // otherwise leaving for the hub and coming back would refund every
+        // mistake, and lives that a round trip through the menu can restore are
+        // not a cost at all.
+        lives: state.lives,
+        // Which X marks are red. Not derivable from the board — an ordinary X on
+        // a solution cell is a perfectly legal thing for a player to have marked,
+        // and colouring those red would give the answer away.
+        mistakeCells: state.mistakeCells,
+        // The hint count is per-puzzle history, so it persists. `strokeOpen`,
+        // `upgradableCell`, `outOfLives` and `hint` deliberately do not: the
+        // first three are one gesture's bookkeeping, the last is advice that goes
+        // stale the moment the board changes. Nor does anything about the
+        // rule-out assist — it is an action the player taps, not a mode with a
+        // remembered setting.
         hintsUsed: state.hintsUsed || 0,
       })
     );

--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -220,20 +220,6 @@ pass**.
    Decided metered, but rule-out saves tedium rather than insight. Worth
    re-checking after a family play session — **and it lands in Step 11**, so this
    is the moment it stops being hypothetical.
-11. **Is a 320 ms double-tap window right for a child?** — the first device pass
-    said tapping was unpredictable; that turned out to be the 6px tap-vs-drag
-    threshold rather than the window, and the second pass with it fixed was
-    "working fine". The window itself is still untuned.
-    Original note: — **new, and a device
-    question.** `DOUBLE_TAP_MS` in `games/fungiku/FungikuBoard.js`. Set longer
-    than a platform double-tap (~250 ms) on purpose: a small finger is slower, and
-    the cost of being generous is one extra tap while the cost of being strict is
-    a mushroom that "won't go in". No browser can answer it — a mouse click and a
-    finger on glass are not the same gesture.
-12. **Should the red ✕ left by a wrong guess be erasable?** — **new.** It ships as
-    an ordinary ✕ (plan §14.3 says so explicitly), consistent with rule-out and
-    hint marks, so a later tap clears it — which also lets a player erase the
-    record of their own mistake. Revisit if it reads wrong in play.
 9. ~~**Does a rung that spans two sizes read as inconsistent?**~~ — **approved on
    device, 2026-07-26.** Easy hands out 5×5 or 6×6 and Hard 8×8 or 9×9, picked
    from the seed, so two Easy games in a row can be different sizes. The operator
@@ -243,6 +229,23 @@ pass**.
 10. ~~**Should the difficulty menu open on arrival?**~~ — **approved on device,
     2026-07-26.** It opens when there is nothing to continue (matching Sudoku) and
     never interrupts a restored or in-progress board. Revisit only if it annoys.
+11. ~~**Does the double-tap work on a device?**~~ — **approved on device,
+    2026-07-28, after two rounds.** The first pass reported tapping as
+    "very unpredictable"; the cause was **not** the double-tap window but the 6px
+    tap-vs-drag threshold, which turned any wobbly tap into a stroke and broke the
+    pairing (see the note above). With that fixed the operator's verdict was
+    "working fine". **`DOUBLE_TAP_MS` (320 ms) is still untuned** — it is set
+    longer than a platform double-tap on purpose, because a small finger is
+    slower. Watch for a mushroom that "won't go in"; no browser can answer it.
+12. **Should the red ✕ left by a wrong guess be erasable?** It ships as an ordinary
+    ✕ (plan §14.3 says so explicitly), consistent with rule-out and hint marks, so
+    a later tap clears it — which also lets a player erase the record of their own
+    mistake. Revisit if it reads wrong in play.
+13. **Is a full wipe the right price for running out of lives?** — **asked and
+    answered once, 2026-07-28: keep it as §14.3 specifies.** Every mark goes, the
+    ✕ deductions included, and the operator chose that over keeping them. The
+    dialog is what makes it survivable — it says the puzzle is the same one before
+    the board clears. Worth re-asking after a child has hit it.
 
 ### Noted in passing, for a later step
 
@@ -487,7 +490,7 @@ pass**.
 | 7 | Feedback & hints — mistake flagging, forced-deduction nudge, reveal, placement pop | merged to `epic/fungiku` (#73, `12f72c3`) |
 | 8 | Bigger boards — `MAX_SIZE = 10`, a tenth region colour tuned for CVD, no-wrap `getRegionColor`, generation announced, legibility at 32px, cost bound in rounds, board lines redrawn as a snapped overlay | merged to `epic/fungiku` (#75, `d4d2018`), operator-tested on device |
 | 9 | Difficulty menu — rungs mapped into `SIZES` by *share*, size-from-seed, menu modal built to Sudoku's, free play + seed behind one constant, real v1→v2 save migration, difficulty in the header rather than a banner, hub badge names the rung | merged to `epic/fungiku` (#77, `02fcdf1`), operator-tested on device |
-| 10 | Lives & mistakes — tap ✕ / double-tap 🍄 replacing the cycle, wrong mushroom flagged immediately as a red ✕ costing one of three lives, zero lives restarts the same board *behind a dialog*, undo never refunds, "Show mistakes" deleted, v2→v3 migration, conflict rendering **removed** | **this step** (#79) — device-tested twice, two rounds of fixes |
+| 10 | Lives & mistakes — tap ✕ / double-tap 🍄 replacing the cycle, wrong mushroom flagged immediately as a red ✕ costing one of three lives and announced on three channels, zero lives leaves the losing board up behind a dialog until the player restarts it, undo never refunds, "Show mistakes" deleted, v2→v3 migration, conflict rendering **removed** | merged to `epic/fungiku` (#79), operator-tested on device |
 
 ## Steps still to come
 

--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -92,129 +92,98 @@ operator to test in Expo Go.**
 
 ---
 
-## Next step: **Step 10 — lives and mistakes**
+## Next step: **Step 11 — earned assists (the wallet)**
 
-Branch: **`feature/fungiku-lives`** off `epic/fungiku`.
-Plan: **§14.2 and §14.3** — read **both, in full**, plus §14's preamble and
-§11.1 (which §14.3 supersedes). This step deletes things earlier steps built
-deliberately. §14.3 explains why each removal is sound; do not re-derive those
-arguments and do not put the deleted behaviors back.
-
-### Why these two are one step
-
-§14.2 is a new input gesture (tap = ✕, double-tap = 🍄) and §14.3 is what a
-mushroom placement now costs. They are the same input surface, and building the
-double-tap without the life cost would ship a mushroom-placing gesture with no
-consequence attached. **Do not split them.**
+Branch: **`feature/fungiku-wallet`** off `epic/fungiku`.
+Plan: **§14.4** — read it in full, plus §11.2 (the hint ladder being priced) and
+§2's "Rule out" (the other thing being metered). This step **inverts** what
+`hintsUsed` is; §14.4 explains why, and the inversion is the whole point rather
+than a refactor to be minimized.
 
 ### Scope — ONLY this
 
-1. **Tap places ✕, double-tap places 🍄** (§14.2), replacing the three-state
-   cycle. Tap on a filled cell (either mark) clears it — that is what keeps every
-   state reachable once the cycle is gone. Drag-to-sweep is unchanged: a stroke
-   still only paints or erases ✕ and still never disturbs a mushroom.
-2. **A wrong mushroom is flagged immediately, leaves a red ✕, and costs a life**
-   (§14.3). **Three lives at every size** — not scaled per difficulty (the
-   operator's answer). At zero lives the **same board** restarts: same seed,
-   marks cleared, lives reset. A fresh board would punish twice and throw away
-   deduction already done.
-3. **Undo does not refund a life** — *"you don't get lives with info."* Undo still
-   retracts the mark.
-4. **Delete the "Show mistakes" toggle**, `TOGGLE_MISTAKES` and the
-   `showMistakes` field (§14.3 answers open question §8 #7 by deletion). This
-   needs a **storage migration to v3** — the plumbing is now in
-   `games/fungiku/saveMigration.js`, so it is one `MIGRATIONS[2]` entry.
-5. **Decide the conflict rendering explicitly, and say which in the PR** — see
-   below. This is a required output of this step, not an optional note.
-6. **Lives visible on screen**, and it should not move the board (see the deps
-   note below).
+1. **A wallet in its own module** — `games/fungiku/wallet.js` (pure) plus its
+   storage. `grant(kind, n)` / `spend(kind)` / `balance(kind)`, persisted under
+   **its own global key**, the same shape as `@AppTheme`. **Not part of the
+   per-puzzle save** — that is the point of the step: a balance that spans
+   puzzles and sessions, where `hintsUsed` is per-puzzle history.
+2. **Hints and Rule out both become metered consumables.** Both buttons: disabled
+   at zero balance, and each shows what it has left. "Auto fill" in §14.4 *is* the
+   existing Rule out button — confirmed with the operator — and it is metered
+   too, not left free.
+3. **Earning, denominated in what already exists**: boards solved, and how
+   cleanly — **lives remaining is now a real number you can read** (`state.lives`,
+   Step 10) and assists unspent. **Draft the rates and say in the PR that they are
+   guesses**, flagged for on-device tuning. color-loop's star thresholds were left
+   the same way and are still on its backlog (§13).
+4. **Gifts and purchases are both just `grant()`.** Build the seam, not the store.
 
 ### Read first
 
-- **§14.2, §14.3** of the plan, and §11.1 for what is being superseded.
-- `SudokuApp/games/fungiku/reducer.js` — `CYCLE_CELL` is the action that becomes
-  two, and `nextMark`/`MARK_CYCLE` in `engine.js` is the cycle being retired.
-- `SudokuApp/games/fungiku/FungikuBoard.js` — the `PanResponder`, the 6px
-  tap-vs-drag threshold, and where a second tap has to be detected.
-- `SudokuApp/games/fungiku/saveMigration.js` — how to add the v2 → v3 step. The
-  file's header states the rule: **add an entry, never edit an existing one.**
-- `SudokuApp/games/fungiku/difficulty.js` — three lives at every size means this
-  file should need **no change at all**; if you are editing it, re-read §14.3.
+- **§14.4** of the plan, and §11.2 for what each hint rung is worth.
+- `SudokuApp/games/fungiku/reducer.js` — `hintsUsed` is incremented in
+  `REQUEST_HINT` and `REVEAL_MUSHROOM`, and **not** by the STUCK branch, which
+  deliberately gives nothing away and charges nothing. That asymmetry is the model
+  for what a spend is.
+- `SudokuApp/games/fungiku/storage.js` and `saveMigration.js` — read them to see
+  what the wallet must **not** become part of. `FUNGIKU_STORAGE_VERSION` is now
+  **3**; a wallet under its own key needs no bump at all, and if you find yourself
+  writing `MIGRATIONS[3]` you have put the wallet in the wrong place.
+- `SudokuApp/utils/appTheme.js` — the existing example of a small global
+  preference with its own key. That is the shape to copy.
+- `SudokuApp/games/fungiku/FungikuScreen.js` — the two buttons that get meters.
 
 ### Behaviors that are easy to get wrong
 
-- **Do not make single taps wait for the double-tap window.** The naive detector
-  delays every ✕ by ~250 ms, and the ✕ is the most common gesture in the game.
-  Place the ✕ **immediately** and *upgrade* the cell if a second tap lands inside
-  the window.
-- **The upgrade must be one undo entry, not two.** Otherwise undo after a
-  double-tap strands a ✕ the player never asked for. `BEGIN_STROKE`/`PAINT_CELLS`
-  already solve exactly this shape for drags — the same trick applies.
-- **The detector belongs inside the existing gesture, not beside it.** The board
-  claims every touch at touch-down to win the ScrollView race (§2). A second
-  `PanResponder` or a child `Touchable` will never see the second tap.
-- **A screen reader cannot express a double tap.** Cells carry
-  `onAccessibilityTap`; placing a mushroom needs an explicit alternative action
-  named in the `accessibilityLabel` (`accessibilityState` does not survive to the
-  web).
-- **This is a device question.** Double-tap timing — and whether a child can
-  produce one reliably — cannot be answered in a browser (§2, "A pattern worth
-  knowing"). Both native bugs the operator has found were invisible on web.
+- **The wallet is not per-puzzle, and `hintsUsed` still is.** Keep both. Deleting
+  `hintsUsed` and reading the wallet instead would lose "how much help did *this
+  board* need", which is exactly what earning has to be computed from.
+- **Spend on the action, not on the tap.** `REQUEST_HINT`'s "nothing is forced"
+  answer is not a hint and must not cost anything — it already declines to count
+  itself. A reveal is a second, deliberate tap and is its own spend.
+- **A balance of zero has to look different from a disabled button.** Rule out is
+  *already* disabled when there is nothing to mark, and Hint when the board is
+  solved. Three reasons a button is dead, and the player needs to be able to tell
+  "you cannot use this here" from "you have run out".
+- **The wallet outlives the board, so granting has to be idempotent per win.**
+  `solved` is derived from marks — undo and redo can cross the win line as many
+  times as the player likes, and each crossing must not pay out again.
+- **Do not make the game unwinnable.** A player at zero assists on a hard board
+  with no way to earn is stuck with no way out. Decide what the floor is — a
+  trickle, a daily grant, a minimum balance — and say which in the PR.
 - **Anything new above the board joins `FungikuBoard`'s re-measure deps**
-  (`[hint, solved, generating, measure]`), or the first tap after it appears
-  lands on the wrong cell. A lives counter is exactly that shape. **Two places
-  now dodge this properly and are the patterns to copy:** the always-mounted
-  counter row (which is where "Generating…" lives) and the header's subtitle,
-  which Step 9 used for the difficulty because its height never changes.
-
-### The decision this step owes the next one
-
-Once a wrong mushroom is converted to a ✕ on placement, every mushroom left on
-the board sits at a solution cell — and two solution cells can never share a row,
-column or region, or touch. **So two placed mushrooms can no longer conflict,
-ever.** That makes several existing paths unreachable by construction:
-
-- the live conflict rendering from Steps 4–5,
-- `selectMistakes`, `showMistakes` / `TOGGLE_MISTAKES`,
-- hint rung 1 (`HINT_KINDS.MISTAKE`),
-- `selectRevealCell`'s -1 branch.
-
-§14.3 calls the loss of the "these two are fighting" read real, and asks you to
-**decide explicitly whether to remove the conflict rendering or leave it dormant,
-and say which in the PR.** Otherwise a later session finds highlighting that
-never fires and assumes it is broken. `findConflicts` itself **stays** — the
-engine needs it for generation, solving and the reveal-safety check.
-
-Note the screen's status line currently reports conflicts
-(`${conflicts.size} mushrooms breaking a rule` in `FungikuScreen`); whichever way
-you decide, that string is part of the decision.
+  (now `[hint, solved, generating, lives.left, measure]`), or the first tap after
+  it appears lands on the wrong cell. If a balance is drawn in the counter row —
+  which is where the hearts and "Generating…" already live, and is the pattern to
+  copy — it must keep that row's height fixed.
 
 ### Out of scope for this step
 
-- **No wallet or metering** — Step 11 (§14.4). `hintsUsed` stays the per-puzzle
-  counter it is.
+- **No store, and no `react-native-iap` / RevenueCat.** Neither runs in Expo Go,
+  so either would break the epic's "visible in Expo Go" rule (§14.4 states this
+  once, with the Kids Category and parental-gate reasons too). Purchases are
+  `grant()` and nothing more.
 - **No art swap** — Step 12.
 - **No board rating / propagator work** (§14.1, §12.1); difficulty stays
   size-only.
-- **No new difficulty work.** The menu landed in Step 9 and lives are not
-  per-difficulty.
+- **No changes to lives.** Three per board at every size, settled in Step 10.
 
 ### Visible in Expo Go when this lands
 
-**A wrong guess costs you something.** You tap to rule a cell out, double-tap to
-commit a mushroom, and a wrong commitment turns red and takes one of your three
-lives — three mistakes and the board you were working on starts over.
+**Help is something you have, not something that is always there.** The Hint and
+Rule out buttons carry a balance, spending one takes it down, and finishing a
+board cleanly earns more.
 
 ### How to verify
 
 `npm test` · `npx expo-doctor` (18/18) · `npx expo export --platform all`, then
 drive the web build (serve `dist/`, Chromium at
-`/opt/pw-browsers/chromium-1194/chrome-linux/chrome` —
-**note the versioned path**, `/opt/pw-browsers/chromium` is a file, not the
-binary; do not run `playwright install`). Prove the migration on a **real** save:
-write a v2 blob into `localStorage['@FungikuGame']`, reload, and confirm the
-board and its marks come back. Then **ask the operator for a device pass** — the
-double-tap is the part a browser cannot answer.
+`/opt/pw-browsers/chromium-1194/chrome-linux/chrome` — **note the versioned
+path**, `/opt/pw-browsers/chromium` is a file, not the binary; do not run
+`playwright install`). Prove the wallet **survives a reload and a puzzle change**,
+which is the whole claim of the step, and prove a win pays out exactly once
+across an undo/redo of the winning move. Then **ask the operator for a device
+pass**.
 
 ## Open questions for the operator (carry these forward)
 
@@ -238,15 +207,29 @@ double-tap is the part a browser cannot answer.
    mushroom*, which solves a cell outright. Right for a family game, or does it
    want capping at a nudge? Related: a reveal is currently only reachable when
    nothing is forced, so a frustrated player cannot skip to the answer — see the
-   first note below.
+   first note below. Step 11 prices it, which is a partial answer: a reveal that
+   costs something is a different question from a reveal that is free.
 7. ~~**Should "Show mistakes" default on for younger players?**~~ — **answered
    by deletion, 2026-07-26** (plan §14.3). Correctness feedback stops being
    optional: a wrong guess is flagged immediately and costs a life, so the toggle
-   goes away in Step 10. The trial-and-error worry that made it opt-in is
-   answered by making guesses expensive rather than by hiding the answer.
+   goes away in Step 10 — **shipped**: the toggle, `TOGGLE_MISTAKES` and
+   `showMistakes` are deleted and the v2→v3 migration drops the saved field. The
+   trial-and-error worry that made it opt-in is answered by making guesses
+   expensive rather than by hiding the answer.
 8. **Should metering Rule out survive contact with a child?** (plan §14.4)
    Decided metered, but rule-out saves tedium rather than insight. Worth
-   re-checking after a family play session.
+   re-checking after a family play session — **and it lands in Step 11**, so this
+   is the moment it stops being hypothetical.
+11. **Is a 320 ms double-tap window right for a child?** — **new, and a device
+    question.** `DOUBLE_TAP_MS` in `games/fungiku/FungikuBoard.js`. Set longer
+    than a platform double-tap (~250 ms) on purpose: a small finger is slower, and
+    the cost of being generous is one extra tap while the cost of being strict is
+    a mushroom that "won't go in". No browser can answer it — a mouse click and a
+    finger on glass are not the same gesture.
+12. **Should the red ✕ left by a wrong guess be erasable?** — **new.** It ships as
+    an ordinary ✕ (plan §14.3 says so explicitly), consistent with rule-out and
+    hint marks, so a later tap clears it — which also lets a player erase the
+    record of their own mistake. Revisit if it reads wrong in play.
 9. ~~**Does a rung that spans two sizes read as inconsistent?**~~ — **approved on
    device, 2026-07-26.** Easy hands out 5×5 or 6×6 and Hard 8×8 or 9×9, picked
    from the seed, so two Easy games in a row can be different sizes. The operator
@@ -259,6 +242,46 @@ double-tap is the part a browser cannot answer.
 
 ### Noted in passing, for a later step
 
+- **The invariant everything since Step 10 rests on: every mushroom on the board
+  is at a solution cell.** A wrong one is converted to a red ✕ the instant it is
+  placed, and marks arriving from an older save go through the same rule in
+  `buildPuzzleState` (`enforcePlacedMushroomsAreCorrect`). **If you ever add a
+  path that puts a mushroom on the board, it must go through that judgement** —
+  a great deal was deleted on the strength of this holding, and the deletions do
+  not announce themselves when it breaks.
+- **The conflict rendering was removed, not left dormant** (the decision Step 10
+  owed, plan §14.3). Two mushrooms on the board are two distinct solution cells,
+  and solution cells never share a row, column or region and never touch — so two
+  placed mushrooms *cannot* conflict. Gone with it: the ring, the status line's
+  conflict count, `selectConflicts`, `selectMistakes`, hint rung 1
+  (`HINT_KINDS.MISTAKE`), and `selectRevealCell`'s "a wrong mushroom is in the
+  way" case. **`findConflicts` stays in the engine** — generation, `isSolved` and
+  the reveal-safety check all still need it. The loss is real: the "these two are
+  fighting" read is gone. It was the direct consequence of immediate feedback, not
+  an oversight.
+- **`conflictInk` outlived the conflict ring it was named for.** It is the
+  palette's contrast-checked "this is wrong" ink, verified against every fill
+  (`utils/symbolSets.js`, and there is a test pinning the contrast floor). It now
+  draws the red ✕. Do not delete it as dead code because its name says conflict.
+- **Lives are not part of the undo history, and that is deliberate.** The stacks
+  hold mark snapshots and nothing else, so undo retracts a mistake's mark and
+  leaves the life spent — *"you don't get lives with info"* (§14.3). If you ever
+  put another cost in state, decide the same question explicitly rather than
+  letting `pushHistory` answer it for you.
+- **The double-tap detector lives inside the board's one `PanResponder`, and the
+  ✕ is never deferred.** The board claims every touch at touch-down to win the
+  ScrollView race, so a second `PanResponder` or a child `Touchable` would never
+  see the second tap. The first tap dispatches `TAP_CELL` immediately and the
+  second *upgrades* the cell via `PLACE_MUSHROOM`; the upgrade amends the first
+  tap's undo entry (`upgradableCell`) instead of pushing a second, so undo after a
+  double-tap never strands a ✕ the player did not ask for.
+- **Custom accessibility actions do not reach the web.** Placing a mushroom is
+  exposed as a named `placeMushroom` action alongside `onAccessibilityTap`,
+  because a screen reader cannot express a double tap — but react-native-web does
+  not map custom actions, so on web a screen-reader user can rule out and clear
+  but cannot commit a mushroom. Native VoiceOver/TalkBack are fine. Worth fixing
+  if web accessibility ever matters; it needs a real alternative affordance, not
+  another prop.
 - **A save is migrated now, not discarded — and the plumbing has one rule.**
   `games/fungiku/saveMigration.js` holds `FUNGIKU_STORAGE_VERSION` and a
   `MIGRATIONS` map keyed by the version each function upgrades *from*. **Add an
@@ -315,9 +338,11 @@ double-tap is the part a browser cannot answer.
 - **A banner mounting above the board invalidates the board's measured origin.**
   `onLayout` does not save you: on web it is backed by a ResizeObserver, which
   watches size and not position, so a board that merely *moves* never fires it.
-  `FungikuBoard` re-measures in an effect keyed on `[hint, solved]` — the two
-  things that mount a banner. **Anything new added above the board must be added
-  to those deps**, or the first tap after it appears lands on the wrong cell.
+  `FungikuBoard` re-measures in an effect keyed on
+  `[hint, solved, generating, lives.left]` — the first two mount a banner, the
+  rest only change what the always-mounted counter row draws and are cheap
+  insurance. **Anything new added above the board must be added to those deps**,
+  or the first tap after it appears lands on the wrong cell.
 
 - **Dragging on the board never scrolls the page.** The board claims every touch
   at touch-down — that is the fix for the operator's device report that a vertical
@@ -329,14 +354,17 @@ double-tap is the part a browser cannot answer.
   and a child Touchable would never see a press. Labels and `onAccessibilityTap`
   are intact; keyboard tabbing to a cell is not. Revisit if web keyboard play
   ever matters.
-- **Rule-out marks are ordinary X marks once placed.** Removing the mushroom that
-  implied them leaves them behind; undo takes the whole fill back instead.
+- **Rule-out marks are ordinary X marks once placed** — and so is the red ✕ a
+  wrong guess leaves (plan §14.3, shipped clearable; §8 #12). Removing the
+  mushroom that implied them leaves them behind; undo takes the whole fill back
+  instead.
   Retracting them per-mushroom would need per-mark provenance, which is ambiguous
   as soon as two mushrooms rule out the same cell.
 - **`accessibilityState.checked` does not reach `aria-checked` on web.** Any
   toggle has to name its state in its `accessibilityLabel` — that is the only
-  place a screen reader or a test can read it reliably. Step 7 adds a
-  "Show Mistakes" switch; it will need the same treatment.
+  place a screen reader or a test can read it reliably. (The "Show Mistakes"
+  switch this was written for is gone as of Step 10; the rule outlives it, and the
+  cell labels are still the seam the browser checks address the board through.)
 
 - **Fungiku's undo history is not persisted** — only `size` + `seed` + `marks`
   are. Leaving for the hub and returning gives you your board back with an empty
@@ -424,12 +452,12 @@ double-tap is the part a browser cannot answer.
 | 7 | Feedback & hints — mistake flagging, forced-deduction nudge, reveal, placement pop | merged to `epic/fungiku` (#73, `12f72c3`) |
 | 8 | Bigger boards — `MAX_SIZE = 10`, a tenth region colour tuned for CVD, no-wrap `getRegionColor`, generation announced, legibility at 32px, cost bound in rounds, board lines redrawn as a snapped overlay | merged to `epic/fungiku` (#75, `d4d2018`), operator-tested on device |
 | 9 | Difficulty menu — rungs mapped into `SIZES` by *share*, size-from-seed, menu modal built to Sudoku's, free play + seed behind one constant, real v1→v2 save migration, difficulty in the header rather than a banner, hub badge names the rung | merged to `epic/fungiku` (#77, `02fcdf1`), operator-tested on device |
+| 10 | Lives & mistakes — tap ✕ / double-tap 🍄 replacing the cycle, wrong mushroom flagged immediately as a red ✕ costing one of three lives, zero lives restarts the same board, undo never refunds, "Show mistakes" deleted, v2→v3 migration, conflict rendering **removed** | **this step** — awaiting operator device test |
 
 ## Steps still to come
 
 | # | Step | Plan |
 |---|------|------|
-| 10 | **Lives & mistakes** — tap ✕ / double-tap 🍄, wrong guess costs a life, three lives then restart | §14.2, §14.3 |
 | 11 | **Earned assists** — a wallet; hints and rule-out metered, earned by solving | §14.4 |
 | 12 | **Art swap** — floating, gated on artwork rather than code | §7 |
 

--- a/docs/fungiku-handoff.md
+++ b/docs/fungiku-handoff.md
@@ -220,7 +220,11 @@ pass**.
    Decided metered, but rule-out saves tedium rather than insight. Worth
    re-checking after a family play session — **and it lands in Step 11**, so this
    is the moment it stops being hypothetical.
-11. **Is a 320 ms double-tap window right for a child?** — **new, and a device
+11. **Is a 320 ms double-tap window right for a child?** — the first device pass
+    said tapping was unpredictable; that turned out to be the 6px tap-vs-drag
+    threshold rather than the window, and the second pass with it fixed was
+    "working fine". The window itself is still untuned.
+    Original note: — **new, and a device
     question.** `DOUBLE_TAP_MS` in `games/fungiku/FungikuBoard.js`. Set longer
     than a platform double-tap (~250 ms) on purpose: a small finger is slower, and
     the cost of being generous is one extra tap while the cost of being strict is
@@ -263,11 +267,42 @@ pass**.
   palette's contrast-checked "this is wrong" ink, verified against every fill
   (`utils/symbolSets.js`, and there is a test pinning the contrast floor). It now
   draws the red ✕. Do not delete it as dead code because its name says conflict.
+- **Losing is a dialog, not a wipe.** The reducer does **not** clear the board on
+  the third mistake: it leaves it at `lives === 0` still holding the mark that
+  killed it, and `RESTART_BOARD` — which the player presses in
+  `FungikuOutOfLivesModal` — does the clearing. The first version wiped in the
+  same breath and the operator's report was that the board just emptied with no
+  idea why. **`lives === 0` therefore means "a restart is pending"**, which is
+  what the modal is driven by; because lives are persisted, quitting to the hub
+  mid-dialog and coming back lands on it again rather than stranding a board with
+  no lives and no way to start it over.
+- **A wrong guess is announced on three channels**, because one was not enough on
+  device: the cell shakes and its ✕ goes red *and* heavier (`close-thick`, so the
+  flag does not rest on colour alone), the heart that just emptied beats, and the
+  counter row says it in words. `lastMistake` carries the event and `mistakeSeq`
+  is a **monotonic** counter that survives the transient being cleared — without
+  it, two wrong guesses in the same cell would hand out the same `seq` and the
+  animation would not re-fire.
 - **Lives are not part of the undo history, and that is deliberate.** The stacks
   hold mark snapshots and nothing else, so undo retracts a mistake's mark and
   leaves the life spent — *"you don't get lives with info"* (§14.3). If you ever
   put another cost in state, decide the same question explicitly rather than
   letting `pushHistory` answer it for you.
+- **Tap-vs-drag is "did the finger reach another cell", not a pixel distance.**
+  It was a flat 6px, which was survivable while a tap only cycled a mark — a
+  shaky tap became a one-cell stroke and painted the same ✕, so it never showed.
+  The double-tap ended that: a wobble past 6px on either half turns that half into
+  a stroke and breaks the pairing, or (when the second half starts on a ✕) into an
+  *erase* stroke that wipes the cell. **That was the operator's "tapping is very
+  unpredictable" on device.** `MAX_TAP_TRAVEL` survives only as a backstop for a
+  finger that has left the board.
+- **Nothing in the counter row may size itself from its contents.** It is
+  width-matched to the board (`useBoardSize`) for a load-bearing reason: it sits
+  in a ScrollView whose content container centres its children, so a row wider
+  than the screen widens the container and pushes every centred sibling — the
+  board included — right, off the edge. Adding the hearts did exactly that and
+  left the last column untappable. The row is two fixed lines; keep it that way,
+  or the board moves.
 - **The double-tap detector lives inside the board's one `PanResponder`, and the
   ✕ is never deferred.** The board claims every touch at touch-down to win the
   ScrollView race, so a second `PanResponder` or a child `Touchable` would never
@@ -452,7 +487,7 @@ pass**.
 | 7 | Feedback & hints — mistake flagging, forced-deduction nudge, reveal, placement pop | merged to `epic/fungiku` (#73, `12f72c3`) |
 | 8 | Bigger boards — `MAX_SIZE = 10`, a tenth region colour tuned for CVD, no-wrap `getRegionColor`, generation announced, legibility at 32px, cost bound in rounds, board lines redrawn as a snapped overlay | merged to `epic/fungiku` (#75, `d4d2018`), operator-tested on device |
 | 9 | Difficulty menu — rungs mapped into `SIZES` by *share*, size-from-seed, menu modal built to Sudoku's, free play + seed behind one constant, real v1→v2 save migration, difficulty in the header rather than a banner, hub badge names the rung | merged to `epic/fungiku` (#77, `02fcdf1`), operator-tested on device |
-| 10 | Lives & mistakes — tap ✕ / double-tap 🍄 replacing the cycle, wrong mushroom flagged immediately as a red ✕ costing one of three lives, zero lives restarts the same board, undo never refunds, "Show mistakes" deleted, v2→v3 migration, conflict rendering **removed** | **this step** — awaiting operator device test |
+| 10 | Lives & mistakes — tap ✕ / double-tap 🍄 replacing the cycle, wrong mushroom flagged immediately as a red ✕ costing one of three lives, zero lives restarts the same board *behind a dialog*, undo never refunds, "Show mistakes" deleted, v2→v3 migration, conflict rendering **removed** | **this step** (#79) — device-tested twice, two rounds of fixes |
 
 ## Steps still to come
 


### PR DESCRIPTION
Plan **§14.2 and §14.3**, together — they are the same input surface, and shipping the double-tap without the life cost would be a mushroom-placing gesture with no consequence attached.

> **Branch name.** This session was pinned to `claude/fungiku-epic-next-rvqr6r`, so it stands in for the `feature/fungiku-lives` the handoff named. The branch was restarted from `epic/fungiku` (its previous tip was `main`'s, already contained in the epic, so nothing was lost). Targets `epic/fungiku` as required.

## The input model (§14.2)

The three-state tap cycle is gone. **Tap** rules an empty cell out and clears a filled one — either mark. **Double-tap** commits a mushroom.

Three things this had to get right:

- **The ✕ is never deferred.** The first tap dispatches `TAP_CELL` the instant the finger lifts; the second *upgrades* the cell. Waiting out the window would put ~300 ms on the most common gesture in the game. Measured at **43 ms** tap→✕ in the browser run below.
- **The upgrade is one undo entry, not two.** The first tap pushes the entry and leaves `upgradableCell` pointing at that cell; `PLACE_MUSHROOM` amends it rather than pushing again, so undo after a double-tap lands on the board as it was *before* the double-tap and never strands a ✕ the player did not ask for. Same shape as `BEGIN_STROKE`/`PAINT_CELLS`.
- **The detector is inside the existing `PanResponder`.** The board claims every touch at touch-down to win the ScrollView race (§2), so a second responder or a child `Touchable` would never see the second tap.

`DOUBLE_TAP_MS` is **320 ms**, deliberately longer than a platform double-tap: a small finger is slower, and a late second tap only costs one extra tap, where a strict window costs a mushroom that "won't go in". **This is a device question, carried as open question #11.**

Drag-to-sweep is unchanged: a stroke still only paints or erases ✕ and still never disturbs a mushroom.

## What a wrong guess costs (§14.3)

A mushroom placed off the solution **never reaches the board**: flagged immediately, left as a red ✕, and one of **three lives** is spent. Three at every size — `difficulty.js` is untouched, as the brief predicted.

At zero lives the **same board** restarts: same seed, same regions, marks cleared, lives back. A fresh board would punish twice and throw away deduction already done.

**Undo retracts the mark and does not refund the life** — *"you don't get lives with info."* The history stacks hold mark snapshots and nothing else, which is what makes that fall out rather than need enforcing.

The red ✕ is an **ordinary** ✕ in every other respect — a tap clears it, a stroke erases it — as §14.3 specifies. That also lets a player erase the record of their own mistake; carried as open question #12.

Lives are drawn as hearts **inside the always-mounted counter row**, the pattern that keeps the board from moving, and `lives.left` joins `FungikuBoard`'s re-measure deps.

## Deletions §14.3 asks for

- **"Show mistakes", `TOGGLE_MISTAKES` and `showMistakes`** — gone. Correctness feedback stopped being a preference the moment guessing stopped being free.
- **Hint rung 1** (`HINT_KINDS.MISTAKE`) and **`selectMistakes`** — gone; there can be no wrong mushroom on the board to point at.
- **`nextMark` / `MARK_CYCLE`** — removed from the engine rather than left unused. A mushroom is no longer a mark you can simply set, and a cycle function would be a second, silent way to place one that skips the judgement.
- **Storage v3.** One new `MIGRATIONS[2]` entry, v1's untouched. It drops `showMistakes` and grants a full complement of lives — the save has no record of what its guesses would have cost, and inventing a debt for a player who just updated the app would be worse than starting them level.

## ⚠️ The decision this step owed: **the conflict rendering is REMOVED**

Not left dormant. Every mushroom that survives placement sits at a solution cell, and solution cells never share a row, column or region and never touch — so **two placed mushrooms cannot conflict**. Gone with it: the ring, `selectConflicts`, and the status line's `N mushrooms breaking a rule`, which the brief flagged as part of the decision. `selectRevealCell`'s -1 now means only "the board is solved".

**`findConflicts` stays in the engine** — generation, `isSolved` and the reveal-safety check all still need it. `conflictInk` also stays and now draws the red ✕; it is the palette's contrast-checked "this is wrong" ink, with a test pinning its contrast floor, so it should not be deleted later for having "conflict" in its name.

**The loss is real and worth naming:** the "these two are fighting" read is gone. It is the direct consequence of immediate feedback, not an oversight.

### One thing the brief did not call for, and why it is here

That argument only holds if *nothing* can put a wrong mushroom on the board — and a v1/v2 save can, since it may hold mushrooms guessed when guessing was free. So `buildPuzzleState` puts restored marks through the same judgement (`enforcePlacedMushroomsAreCorrect`): a wrong mushroom becomes a red ✕, **charging no lives**. The migration cannot do it — `saveMigration.js` is pure and deliberately knows nothing about solutions.

Leaving them was the alternative and is worse: it would leave the board in a state the rest of the game now assumes cannot exist, which is exactly how "unreachable" code turns out to be reachable.

## Verification

- **`npm test` — 347 pass** (316 before), 8 suites.
- **`npx expo-doctor` — 18/18.**
- **`npx expo export --platform all`** — web, iOS and Android all bundle.
- **Web build driven in Chromium**, no page errors:

```
1. tap -> X in 43 ms          Row 1, column 1, ruled out
2. slow tap clears            Row 1, column 1, empty
3. double-tap r1c5 (correct)  mushroom            | 3 of 3 lives left
4. double-tap r2c2 (wrong)    ruled out, wrong guess | 2 of 3 lives left
5. after undo                 empty               | 2 of 3 lives left  <- life stays spent
6. two more wrong guesses     1 of 3 -> restart   | 3 of 3 lives left
   status: "Out of lives — same board, fresh start"; the placed mushroom is gone
```

- **The v2→v3 migration proved on a real save**, not just in unit tests: a v2 blob written into `localStorage['@FungikuGame']` with one correct mushroom, one wrong mushroom, an ordinary ✕ and `showMistakes: true`. After reload the 5×5 board and its marks come back, the correct mushroom survives, the wrong one is a red ✕ (`ruled out, wrong guess`), the plain ✕ is untouched, lives are 3, `hintsUsed` carries — and the rewritten blob is `_v: 3` with `lives`/`mistakeCells` and no `showMistakes`.

## Known gap, carried forward

**Custom accessibility actions do not reach the web.** Placing a mushroom is exposed as a named `placeMushroom` action alongside `onAccessibilityTap`, because a screen reader cannot express a double tap — but react-native-web does not map custom actions, so on web a screen-reader user can rule out and clear but cannot commit a mushroom. Native VoiceOver/TalkBack are fine. Noted in the handoff; fixing it needs a real alternative affordance, not another prop.

## Out of scope, as briefed

No wallet or metering (Step 11, §14.4 — `hintsUsed` stays the per-puzzle counter it is), no art swap, no board rating, no difficulty changes.

---

`docs/fungiku-handoff.md` is rewritten for **Step 11 — earned assists**, with the new open questions (#11 double-tap timing, #12 the erasable red ✕) carried forward.

**Please test in Expo Go before merging** — the double-tap is the part a browser cannot answer, and both native bugs found so far were invisible on web.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyZjWFjz6xaNY3QBAieKWW)_