### PR TITLE
Cube Scramble: replan the epic around solves you write, not solves it computes

### DIFF
--- a/docs/cube-handoff.md
+++ b/docs/cube-handoff.md
@@ -107,82 +107,142 @@ you built, at every stage of the motion, not only at rest.
 
 ---
 
-## Next step: **Step 3 — enter a cube**
+## Next step: **Step 3 — solve mode**
 
-The cube on screen is always a cube this app made up. The operator's goal is a
-workbench for *the cube in their hands*, and every step after this one — the
-solver, CFOP, Roux — is worth nothing until the state being solved is theirs.
+> **Read plan §8.1 before anything else.** The epic was replanned on 2026-08-01
+> and the old Step 3 ("enter a cube") and Step 4 ("a two-phase solver") are gone
+> from the critical path. If you have context that says this step is a solver, it
+> is stale.
+
+The operator has been using the scrambler to drill: **the same scramble, over and
+over**, working out a Roux first block by hand and trying to remember what they
+did. What they need is somewhere to write it down and watch it back. Eventually
+that is several named solves per scramble, each with the orientation the cube was
+held in — this step is the one move that all of it stands on.
+
+**Enter a move, and the cube turns.** That is the whole step.
 
 ### Scope — ONLY this
 
-1. **Paste or type an algorithm.** A text field that takes notation, validates it
-   live, and applies it to the cube. `parseAlg` already accepts the whole set —
-   faces, slices, wides, rotations, curly apostrophes, optional spaces — and
-   already refuses anything it cannot read whole, so this is a screen, not a
-   parser. Show *why* it was rejected: `parseAlg` throws with the offending
-   token in the message.
-2. **Set the colours by hand.** Tap a facelet on the cube, tap a colour, and the
-   sticker changes. This is the half that makes a *scrambled physical cube*
-   enterable, since nobody knows the algorithm that produced the cube on their
-   table.
-3. **Say whether what was entered is a real cube.** A hand-entered facelet state
-   can be impossible — ten green stickers, a flipped edge, a twisted corner, two
-   identical corners. Report it in the UI, and do not let Step 4's solver be
-   handed a state it will search forever for.
+1. **A solve mode.** A button on the cube screen switches the screen from
+   *reading a scramble* to *writing a solve*. The cube starts from the scramble
+   fully applied — that is the cube you would be holding — and the moves you
+   enter go on top of it.
+2. **A move pad.** Twelve keys: `U D L R F B` · `M` · `r` · `l` · `x y z`, with
+   `'` and `2` as modifiers, plus undo and clear. This is the **Roux set**
+   (operator, 2026-08-01): first block is faces plus `M` and `r`, LSE is almost
+   entirely `M` and `U`, and `x`/`y` are how you turn the cube over during
+   inspection. Not the full parser set — `E`, `S` and the other three wides are
+   real notation nobody writes a Roux solve in, and eighteen keys on a phone is a
+   worse pad.
+3. **A text field**, alongside the pad, for typing or pasting a whole algorithm —
+   a CMLL alg, a sequence off a tutorial. The parser already does the work
+   (`parseAlg` takes the full set, spaces optional, curly apostrophes, and
+   refuses anything it cannot read *whole*), so this is a screen, not a parser.
+   Show why something was rejected: `parseAlg` throws with the offending token
+   in the message.
+4. **Each entered move animates**, using Step 2's machinery, and the transport
+   underneath scrubs the solve exactly as it scrubs a scramble.
+
+**The solve is a scratchpad this step** (operator, 2026-08-01) — one solve, held
+in memory, gone when you leave. Saving and naming several is Step 4, and that is
+where the save file's shape gets decided properly rather than in passing.
 
 ### Read first
 
-- `docs/cube-plan.md` §3 (model), §4 (notation), §7 (what is stored), §8
-- `games/cube/moves.js` — `parseAlg`, `tryParseAlg`, `isValidAlg`, `formatAlg`
-- `games/cube/cubeState.js` — `facelets`, `faceletString`, `FACE_READING`; the
-  reading order of D and B is the thing to get right (plan §10)
-- `games/cube/favorites.js` and `storage.js` — what a save is allowed to contain
-- `games/cube/CubeScreen.js` and `CubeScrubber.js` — where new furniture goes on
-  a screen that already fits exactly
+- `docs/cube-plan.md` §4 (notation, and the new note on canonical tokens), §5
+  (the renderer and the transport), §7 (what is stored), §8 and **§8.1–8.2**
+- `games/cube/moves.js` — `parseMove`, `parseAlg`, `tryParseAlg`; note
+  `BASE_MOVES`/`WIDE_MOVES` and that `TOKEN_SOURCE` is the scanner you will want
+  to expose
+- `games/cube/player.js` — `buildPlayback`, and the fact that it starts from
+  `solvedCube()`
+- `games/cube/useScramblePlayer.js` — `playTo`, `animate`, and the effect that
+  resets to the end when the algorithm changes
+- `games/cube/CubeScreen.js`, `CubeScrubber.js`, `CubeFavoritesModal.js` — the
+  screen, the transport, and this feature's modal pattern
+- `games/fungiku/FungikuMenuModal.js` — **the only `TextInput` in the app**, and
+  therefore the house pattern for one
 
 ### Behaviors that are easy to get wrong
 
-- **Storage holds algorithm text, not a cube** (plan §7). A hand-entered facelet
-  state is not algorithm text, so it needs an answer: either store a 54-character
-  facelet string alongside — a *second* shape that `readCubeSave` has to filter
-  and that every later reader has to handle — or do not persist hand-entered
-  states at all and say so. Decide it deliberately and write down which, because
-  it is the first time the save file has had two kinds of thing in it.
-- **The scrubber assumes a scramble** — `useScramblePlayer` builds its states by
-  applying moves to a solved cube. A cube entered by colour has no move list, so
-  the transport has nothing to walk. Decide what the scrubber shows then; a
-  scrubber that silently reads `0 / 0` and does nothing is worse than one that
-  is honestly absent.
-- **Validity is not "54 stickers, nine of each".** Permutation parity, corner
-  twist and edge flip are all separately checkable and all separately violable
-  by a single mis-tapped sticker. Getting this wrong ships a screen that says
-  "looks fine" and a Step 4 solver that never terminates.
+- **`parseMove` normalizes `r` to `Rw`** (plan §4). A Roux notebook that echoes
+  `Rw U Rw'` back at someone who tapped `r` is correcting them in notation their
+  method does not use. Keep the entered text as the source of truth and export a
+  `tokenize` from `moves.js` so the displayed token and the animated move are two
+  arrays built in one pass — not two things hoped to line up. Step 2's token
+  rendering in `CubeScreen` has the same latent problem and can be fixed by the
+  same export.
+- **Appending a move must *animate*, not jump.** `useScramblePlayer`'s effect
+  resets to the end whenever the algorithm changes, which is right for loading a
+  favorite and wrong for adding a move — you would never see the turn. The rule
+  that works: if the new algorithm *extends* the old one and the cube was sitting
+  at the old end, walk forward to the new end (`playTo`) instead of resetting.
+  Worth a pure `extendsAlg(before, after)` in `player.js` so it is testable.
+- **`buildPlayback` starts from a solved cube.** A solve starts from the
+  scrambled one, so it needs a starting cube — `buildPlayback(alg, { from })`.
+  This was flagged as coming in Step 2's handoff and is now due.
+- **Undo has to run the move backwards**, then drop it. Dropping it first and
+  letting the state reset is a jump, and it is the wrong direction of the same
+  bug as the point above. Step 2 already animates backwards for free: it is the
+  same move run from `t = 1` down to 0 on the cube before it.
+- **A whole-cube rotation changes the model, not the camera.** `x`/`y`/`z`
+  already animate correctly and open no seams — but after a `y`, `R` means a
+  different physical face. That is exactly right and exactly what Roux
+  inspection needs; just do not also move the camera, and do not expect the
+  scramble text above to still describe the orientation.
 - **A text field on a screen that does not scroll.** The keyboard covers the
-  bottom half of a phone, and this page is a fixed column by design (plan §2).
-  Editing probably belongs in a modal, like the favorites list does.
-- **Do not let the input clobber the current scramble mid-typing.** The cube
-  should follow a *valid* draft, not every keystroke of an invalid one.
+  bottom half of a phone and this page is a fixed column by design (plan §2).
+  The field probably belongs in a modal, like the favorites list.
+- **The screen is already full.** Step 2's transport came to about 284 points
+  against the 300 the narrowest supported phone has. A pad is another ~120
+  points of vertical, on a page where the stage is the `flex: 1` that absorbs
+  it — so the *cube* is what shrinks. Two rows of six plus a modifier row is the
+  budget that fits; check it, do not assume it.
+- **Do not persist the solve** this step (plan §7). Same reasoning as Step 2's
+  scrub position and speed.
+
+### The modifier question, which is genuinely unsettled
+
+`'` and `2` are **armed** — tap `'`, then `R`, and you get `R'`; the arming
+clears after one move. That is two taps for a move Roux uses constantly, and it
+is the first thing to revisit once the operator has drilled a real solve on it
+(plan §9.8). Two alternatives, neither obviously better:
+
+- **Modify the last move instead** — tap `R`, then `'`, and it becomes `R'`. One
+  fewer tap in the common case, but the cube has already turned `R`, so it has
+  to un-turn and re-turn, and the animation stops meaning "this is the move I
+  just made".
+- **Tap a key repeatedly to cycle** `R` → `R2` → `R'`. No modifier keys at all,
+  and it is what some cube apps do, but the intermediate animations are a cube
+  turning back and forth rather than a solve being written.
+
+Ship the armed modifiers, keep undo one tap away so a mis-entry is cheap, and
+let the operator's first real session decide.
 
 ### Out of scope for this step
 
-Solving, CFOP/Roux phases, other puzzle sizes, random-state scrambles, a timer.
-All of those are later rows in plan §8. The solver is Step 4 and it is the
-customer for this step's output — build for it, do not start it.
+Saving or naming solves, several solves per scramble, an orientation step,
+phase markers, entering a cube by colour, a solver, colour neutrality, a timer.
+Those are plan §8 rows 4–8, and §8.2 says what the first three are. Note what
+you spot for them; do not start them.
 
 ### Visible in Expo Go when this lands
 
-Open Cube Scramble, paste `R U R' U'`, and see that cube. Then set a few stickers
-by hand and see those. Enter something impossible and be told so.
+Open Cube Scramble, tap Solve, tap `R` — the cube turns `R`. Arm `'`, tap `U`
+— it turns `U'`. Tap undo and watch it come back. Type `R U R' U'` in the field
+and watch all four run.
 
 ### How to verify
 
-- `npm test` — the validity check is pure and belongs in a module the node
-  runner can import, tested against known-good and known-impossible states.
-- `npx expo-doctor` (18/18 — the two network-dependent checks may fail behind a
-  proxy; say so rather than reporting 16/18 as a regression) and
+- `npm test` — `tokenize`, `extendsAlg` and `buildPlayback({ from })` are all
+  pure and belong where the node runner can reach them. Pin the round trip: a
+  token entered as `r` comes back as `r` and animates as `Rw`.
+- `npx expo-doctor` (16/18 in a sandbox; see the note above) and
   `npx expo export --platform all`.
-- Drive the web export headlessly at 320×568, 375×667 and 420×860. Step 2's
-  driver is a good starting point: serve `dist` and drive it with
+- Drive the web export headlessly at 320×568, 375×667 and 420×860 — and look at
+  the screenshots, do not only assert on them. Step 2's drivers are a good
+  starting point: serve `dist`, drive it with
   `/opt/pw-browsers/chromium-1194/chrome-linux/chrome`.
 
 ---
@@ -196,15 +256,23 @@ Step 3.
 2. Other puzzles — 2×2, 4×4, pyraminx, skewb?
 3. A timer — in this epic, or a separate feature?
 4. Colour scheme — a setting, or is the standard one enough?
-5. What a "solve" should be for Steps 5–6: the method's own logic, or the
-   shortest algorithm?
+5. ~~Where a solve comes from.~~ **Answered, and it replanned the epic**
+   (operator, 2026-08-01): solves are **written by the operator**, not computed.
+   See plan §8.1.
 6. Drag direction — currently "push the surface under your finger".
 7. ~~Turn speed.~~ **Answered** (operator, 2026-08-01): a speed control, and it
    is in — a chip cycling 1× → 2× → 0.5×, scaling the beat between moves as well
    as the turns, and applying to single steps as much as to playback. It is not
    persisted, for the same reason the view angle is not. If it should survive a
-   relaunch, that is a save-file change and belongs with Step 3's decision about
-   what else the file holds.
+   relaunch, that is a save-file change and belongs with **Step 4's** decision
+   about what else the file holds.
+8. **How a move gets entered** — new, and live. Step 3 ships armed `'` and `2`
+   modifier keys; Roux is prime-heavy, so that is two taps for a very common
+   move. The alternatives are written up under Step 3 above. This wants the
+   operator's first real drilling session, not an opinion.
+9. **Colour neutrality** — raised and deferred by the operator on 2026-08-01
+   ("we're not gonna get into that right now"). Solves assume you pick a top and
+   a left colour and hold it that way.
 
 ### Noted in passing, for a later step
 
@@ -220,9 +288,9 @@ Step 3.
   class of problem avoided rather than dodged, but a device pass is still the
   only evidence that counts for how it *feels*.
 - **`useScramblePlayer` assumes a solved starting cube.** It builds its states by
-  applying moves from `solvedCube()`. Playing a *solve* back (Step 4) starts from
-  a scrambled one, so it will want a starting cube as an argument — a small
-  change, worth making when there is a caller for it rather than now.
+  applying moves from `solvedCube()`. A solve starts from a scrambled one, so it
+  wants a starting cube as an argument. **Step 3 is the caller** — this is no
+  longer "later".
 - **The scrubber row is full.** Five buttons, `n / 20` and the speed chip come to
   about 284 points, and the narrowest phone this app supports has 300. It wraps
   rather than overflows, but a sixth control wants a rethink rather than another

--- a/docs/cube-plan.md
+++ b/docs/cube-plan.md
@@ -3,9 +3,20 @@
 **A 3×3 Rubik's cube you can scramble, keep, and turn over in your hands.** The
 first step ships a random scramble, a cube rendered in 3D that you drag to
 inspect from any angle, and a favorites list. The epic it opens is a *cube
-workbench*: step through a scramble move by move, then step through a **solve**
-— CFOP, Roux, and whatever else the operator wants to teach — with the cube
-showing what each phase does.
+workbench*: step through a scramble move by move, then work out **how you would
+solve it** — in Roux, in CFOP, in whatever the operator is learning — with the
+cube showing what each move does.
+
+> **Replan note (2026-08-01), and it is the important one.** This document used
+> to say the epic ended in a **solver**: a two-phase search in JS that computes a
+> solution, then splits it into CFOP or Roux phases to display. That is not what
+> the operator wants, and the way they have actually been using the tool is what
+> revealed it — running the *same scramble over and over* to drill a Roux solve
+> by hand. What they need is a **notebook**: enter your own moves, watch the cube
+> follow, and keep several attempts at the same scramble side by side. The cube
+> is a place to write down and replay what *you* worked out, not an oracle that
+> tells you the answer. §8 is replanned around that, and the solver drops off the
+> critical path — see §8.1 for what changed and why.
 
 The reference the operator gave is **<https://scramble.cubing.net/>**: a
 scramble, a draggable 3D cube, and nothing else on the page. That restraint is
@@ -162,6 +173,20 @@ whole string** rather than being skipped: a scramble that silently dropped a mov
 would show a cube that is not the cube in the operator's hands, which is the one
 thing this screen must never do.
 
+### A move's canonical token is not always what was typed
+
+`parseMove` normalizes: `r`, `Rw` and `rw` all come back as `{ token: 'Rw', … }`.
+That is right for the *model* — one spelling, one comparison — and wrong for
+anything the operator reads back. Roux is written `r U r'` and `M2`, and a
+notebook that redisplays a solve as `Rw U Rw'` is quietly correcting the person
+using it in the notation their own method does not use.
+
+So from Step 3 on, **the text the operator entered is the text that is kept**,
+and the canonical token stays an implementation detail of the move. The way to
+hold that together is a `tokenize` scan that returns the raw token strings, so a
+displayed token and the move it animates are the same element of two arrays built
+in one pass rather than two things hoped to line up.
+
 ## 5. The renderer — SVG, and why not WebGL
 
 `games/cube/geometry.js` builds the frame; `games/cube/CubeView.js` draws it.
@@ -270,8 +295,9 @@ from the *allowed* faces rather than drawing and retrying — same distribution,
 but it terminates by construction instead of depending on the quality of its
 randomness.
 
-Upgrading to random-state is its own step (§8), and it is the same work that
-gives the epic a solver.
+Upgrading to random-state is its own step (§8, last row), and it is the same
+search a solver needs — which is why the two share a row now that neither is on
+the critical path (§8.1).
 
 ## 7. Favorites and persistence
 
@@ -304,19 +330,58 @@ the operator can open in Expo Go.
 |---|---|---|
 | **1** | Scramble · 3D cube you can drag · favorites · hub tile | **shipped** |
 | **2** | **Play the scramble.** Animated layer turns and a move-by-move scrubber | **shipped** |
-| **3** | **Enter a cube.** Paste or type a scramble, and/or set the colours by hand, so the cube on screen is the cube on the table | next |
-| **4** | **Solve it.** A two-phase solver in JS; play the solution back on the cube | |
-| **5** | **CFOP.** The solve split into cross / F2L / OLL / PLL, each phase named, its pieces highlighted, steppable | |
-| **6** | **Roux.** The same treatment for blocks / CMLL / LSE | |
-| **7** | **Random-state scrambles**, once the solver from Step 4 exists — WCA-legal, and the natural place to add other events | |
+| **3** | **Solve mode.** Enter moves and the cube turns — a move pad and a text field, on the scrambled cube | next |
+| **4** | **Several solves per scramble.** Name them, keep them, switch between them; the notebook the operator asked for | |
+| **5** | **Orientation.** Record how the cube is held before a solve starts — Roux's inspection step, "yellow up, blue left" | |
+| **6** | **Phases.** Mark where first block / second block / CMLL / LSE begin and end inside a solve, and step phase by phase | |
+| **7** | **Enter a cube by hand.** Paste an algorithm, or set the colours facelet by facelet, for a cube that came off a table rather than out of the generator | |
+| **8** | **A solver**, if it is still wanted by then — and random-state scrambles off the back of the same search | |
 
-Steps 5 and 6 are the operator's actual goal ("visualizing how to solve them in
-different methods"). Steps 2–4 are what they stand on: you cannot show a phase
-until you can animate a turn, cannot animate a solve until you can compute one,
-and cannot compute one for the cube in someone's hands until they can enter it.
+Steps 3–6 are the operator's actual goal. Steps 4–6 are increments on Step 3:
+once you can enter moves, keeping several attempts is a list, holding the cube a
+certain way is a prefix of rotations, and naming the phases is a marker between
+two moves. **None of them need a solver**, which is the whole point of the
+replan below.
 
-**Step 7 is deliberately last, not first.** Random-state scrambles need the same
-search Step 4 needs; doing it once, for the solver, gets both.
+### 8.1 Why the solver moved to the end
+
+The old plan had Step 4 compute a solution with a two-phase (Kociemba) search and
+Steps 5–6 chop it into CFOP and Roux phases. It was a coherent plan for a
+different product.
+
+What the operator is doing with the tool is drilling: same scramble, over and
+over, working out a Roux first block by hand and trying to remember what they
+did. A computed solution does not help with that — it is not their solution, it
+does not follow the method's logic (a shortest algorithm ignores what "first
+block" even is), and open question §9.5 was already circling the problem before
+the answer arrived from watching the thing be used.
+
+So the epic becomes a notebook. That is *less* code, not more: no search, no
+pruning tables, no megabyte of dependency, and every step from here is
+recognisably the same shape — moves on a cube that the model and renderer
+already animate. The solver stays in the table because random-state scrambles
+(§6) still want the same search and it would be a good thing to have; it is just
+no longer the thing everything else waits on.
+
+### 8.2 What a solve is
+
+A **solve** is what the operator writes down about one scramble:
+
+- **An orientation** — how you are holding the cube when you start. Roux begins
+  with inspection: find the pairs, pick a top colour and a left colour, and
+  traditionally that is yellow on top and blue on the left. In notation this is a
+  prefix of whole-cube rotations (`x`, `y`, `z`), which the model and renderer
+  already handle and which cost nothing extra to store.
+- **The moves** — the solve itself, in standard notation.
+- **A name**, eventually, so two attempts at the same scramble can be told apart.
+
+Several solves belong to one scramble, because trying it three ways is the
+practice. That is Step 4; Step 3 deliberately ships **one** unsaved solve so
+there is something to try before the save-file shape has to be settled (§7).
+
+**Colour neutrality is explicitly out of scope** (operator, 2026-08-01) — solving
+from any starting colour is a real Roux topic and a real complication, and it is
+not what this epic is for yet.
 
 ## 9. Open questions for the operator
 
@@ -329,13 +394,18 @@ search Step 4 needs; doing it once, for the solver, gets both.
    building one. Is a timer in scope for this epic, or is it a different feature?
 4. **Colour scheme.** Fixed to the standard one now. Worth a setting, or is
    "the scheme on your cube" close enough to universal?
-5. **Where a solve comes from.** Step 4's solver finds *a* short solution, which
-   is not how a human solves. For Steps 5–6 the phases are the point, so the
-   method's own logic (cross first, then pairs) matters more than move count —
-   worth confirming that is the intent before building a solver optimized for
-   the wrong thing.
+5. ~~**Where a solve comes from.**~~ **Answered, and it replanned the epic**
+   (operator, 2026-08-01): solves are **written by the operator**, not computed.
+   The question was whether a solver should optimize for move count or follow the
+   method's own logic; the real answer was that neither is wanted yet. See §8.1.
 6. **Left-handed drag.** The current mapping is "push the surface under your
    finger". Nobody has complained yet because nobody has used it yet.
+7. **Turn speed.** Answered and shipped in Step 2 — a chip cycling 1× → 2× → 0.5×.
+   Not persisted; see §7 and the note under Step 3 in the handoff.
+8. **How a move gets entered.** Step 3 ships a pad with `'` and `2` as modifier
+   keys you arm before the face. Roux is prime-heavy, so that is two taps for a
+   very common move, and it is the first thing to revisit once the operator has
+   drilled a real solve on it. The alternatives are written up in the handoff.
 
 ## 10. Edge cases and things that are easy to get wrong
 
@@ -380,9 +450,10 @@ search Step 4 needs; doing it once, for the solver, gets both.
   `<twisty-player>` element. Dual GPL/MPL; as a library it can be treated as
   MPL, which is file-level copyleft and fine to depend on. It is browser-first
   (Web Workers, WASM), so using it means the WebView route in §5.
-- **Kociemba's two-phase algorithm** is the standard basis for Step 4's solver.
-  There are permissively licensed JS ports; check the licence of whichever is
-  picked, and prefer one small enough to read.
+- **Kociemba's two-phase algorithm** is the standard basis for a solver, which is
+  now the last row of §8 rather than the middle of it (§8.1). There are
+  permissively licensed JS ports; check the licence of whichever is picked, and
+  prefer one small enough to read.
 - Nothing from either is vendored today. Step 1 has no third-party cube code in
   it at all — `react-native-svg` is the only dependency it added.
 


### PR DESCRIPTION
**Docs only — `docs/cube-plan.md` and `docs/cube-handoff.md`. No code changes.**

Refs #82

## Why

The plan had this epic ending in a solver: a two-phase (Kociemba) search that computes a solution, with Steps 5–6 chopping it into CFOP and Roux phases to display. That was a coherent plan for a different product.

How the operator has actually been using the tool is what revealed it — running **the same scramble over and over**, working out a Roux first block by hand and trying to remember what they did. A computed solution does not help with that: it is not their solution, and a shortest algorithm does not know what a "first block" even is. Open question §9.5 had been circling this for two steps; the answer arrived from watching the thing be used rather than from thinking about it harder.

So the epic becomes a **notebook** — enter your own moves, watch the cube follow, keep several attempts at one scramble side by side. That is *less* code, not more: no search, no pruning tables, no megabyte of dependency, and every remaining step is the same shape as the two that shipped — moves on a cube the model and renderer already animate.

## The new step list

| Step | What lands |
|---|---|
| **3** | **Solve mode.** Enter moves and the cube turns — *next* |
| **4** | **Several solves per scramble.** Name them, keep them, switch between them |
| **5** | **Orientation.** Record how the cube is held before a solve starts |
| **6** | **Phases.** Mark where first block / second block / CMLL / LSE begin and end |
| **7** | **Enter a cube by hand.** Paste an algorithm, or set the colours facelet by facelet |
| **8** | **A solver**, if still wanted by then, and random-state scrambles off the same search |

Steps 4–6 are increments on Step 3: keeping several attempts is a list, holding the cube a certain way is a prefix of rotations, naming the phases is a marker between two moves. **None of them need a solver.**

## `docs/cube-plan.md`

- The intro carries the replan note; **§8 is rewritten** around the notebook.
- **New §8.1** records why the solver moved to the last row, and what it is still there for — random-state scrambles want the same search, so the two share a row now that neither is on the critical path.
- **New §8.2** defines what a solve is: an orientation, the moves, and eventually a name. Marks colour neutrality out of scope, per the operator.
- **§4** gains a note that `parseMove` normalizes `r` to `Rw` — right for the model, wrong for a Roux notebook that has to read back what was written. A `tokenize` scan is the way to hold raw and parsed tokens together.
- **§9.5 answered.** §9.7–9.9 added: turn speed (shipped in Step 2), how a move gets entered, colour neutrality deferred.
- §6 and §11's references to "Step 4's solver" follow the new table.

## `docs/cube-handoff.md`

Rewritten for the new **Step 3 — solve mode**, scoped to the narrow thing the operator asked for: enter a move, the cube turns. A pad carrying the **Roux set** (`U D L R F B` · `M` · `r` · `l` · `x y z`) with armed `'` and `2`, a text field beside it for pasting an algorithm, and one unsaved solve.

It leads with a warning to read plan §8.1, because a session arriving with stale context will otherwise think this step is a solver.

Four traps specific to this step are written down:

- **`parseMove` normalizes `r` to `Rw`** — echoing `Rw U Rw'` at someone who tapped `r` corrects them in notation their method does not use. Step 2's token rendering has the same latent problem and the same fix.
- **Appending a move must animate, not jump** — `useScramblePlayer`'s reset effect is right for loading a favorite and wrong for adding a move.
- **`buildPlayback` starts from a solved cube** — a solve starts from the scrambled one. Flagged as coming in Step 2's handoff; now due.
- **Undo has to run the move backwards** then drop it, not the other way round.

Plus the **modifier question, left explicitly unsettled**: armed `'` is two taps for a move Roux uses constantly. Two alternatives are written out with what is wrong with each, and the recommendation is to ship the simple one and let the operator's first real drilling session decide (§9.8).

## Not in this PR

No code. Step 3 itself is the next branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013u837JPyruNcGjMD8xfDyV


---
_Generated by [Claude Code](https://claude.ai/code/session_013u837JPyruNcGjMD8xfDyV)_