### PR TITLE
Cube Scramble Step 7: give the page back to the cube

### DIFF
--- a/SudokuApp/components/ScreenHeader.js
+++ b/SudokuApp/components/ScreenHeader.js
@@ -50,10 +50,10 @@ const ScreenHeader = ({
   const iconSize = dense ? DENSE_ICON_SIZE : ICON_SIZE;
 
   return (
-    <View style={[styles.header, dense && styles.headerDense]}>
-      <View style={[styles.leftSection, dense && styles.leftSectionDense]}>
+    <View style={dense ? styles.headerDense : styles.header}>
+      <View style={dense ? styles.leftSectionDense : styles.leftSection}>
         <TouchableOpacity
-          style={[styles.iconButton, dense && styles.iconButtonDense, { borderColor: titleColor }]}
+          style={[dense ? styles.iconButtonDense : styles.iconButton, { borderColor: titleColor }]}
           onPress={onHomePress}
           accessibilityLabel="Back to games"
           accessibilityRole="button"
@@ -63,11 +63,11 @@ const ScreenHeader = ({
         </TouchableOpacity>
       </View>
 
-      <View style={[styles.centerSection, dense && styles.centerSectionDense]}>
+      <View style={dense ? styles.centerSectionDense : styles.centerSection}>
         {/* One line, by construction, when dense — the whole point of the
             variant is that this row's height is known rather than discovered. */}
         <Text
-          style={[styles.title, dense && styles.titleDense, { color: titleColor }]}
+          style={[dense ? styles.titleDense : styles.title, { color: titleColor }]}
           numberOfLines={dense ? 1 : undefined}
         >
           {title}
@@ -83,11 +83,11 @@ const ScreenHeader = ({
           stays even with no menu button in it. (When dense the title is
           left-aligned against the home button instead, because a row with
           controls on the right has no centre to be optical about.) */}
-      <View style={[styles.rightSection, dense && styles.rightSectionDense]}>
+      <View style={dense ? styles.rightSectionDense : styles.rightSection}>
         {actions}
         {onMenuPress && (
           <TouchableOpacity
-            style={[styles.iconButton, dense && styles.iconButtonDense, { borderColor: titleColor }]}
+            style={[dense ? styles.iconButtonDense : styles.iconButton, { borderColor: titleColor }]}
             onPress={onMenuPress}
             accessibilityLabel="Game menu"
             accessibilityRole="button"
@@ -109,7 +109,25 @@ const styles = StyleSheet.create({
     minHeight: 48,
     marginBottom: 10,
   },
+  // ——— The dense row ————————————————————————————————————————————————
+  //
+  // **These are whole styles, not overrides layered on the ones above, and that
+  // is load-bearing.** Written as `[styles.leftSection, dense && ...]` the
+  // flattened result carries *both* the base `flex: 1` and this variant's
+  // `flexGrow` / `flexShrink` / `flexBasis`, and which of the two wins is not
+  // something the two platforms agree on: react-native-web resolved one way and
+  // Yoga the other, so the header laid out correctly in the browser and, on a
+  // real phone, collapsed the home button to a sliver and pushed the view
+  // controls off the right-hand edge of the screen. There is nothing to disagree
+  // about if only one of them is ever passed.
+  //
+  // The three columns also stop being thirds: the two ends take what they need
+  // and the title takes what is left, which is what lets the right-hand end hold
+  // three controls without squeezing the title into a wrap.
   headerDense: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    width: '100%',
     minHeight: 34,
     marginBottom: 4,
   },
@@ -118,20 +136,16 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
     paddingLeft: 8,
   },
-  // The three columns stop being thirds: the title takes what is left after the
-  // two ends have taken what they need, which is what lets the right-hand end
-  // hold three controls without squeezing the title into a wrap.
-  //
-  // **Spelled out rather than `flex: 0`**, and that is not style. `flex: 0` here
-  // means "size to your content", but react-native-web reads it as
-  // `flex-basis: 0%` with shrink still on — so both ends collapsed to their
-  // padding and their buttons hung off the right edge of the screen. Caught by
-  // the horizontal-overflow check in Step 7's driver, which is the check this
-  // repo has run since Step 1 and the reason it is still worth running.
+  // `flexBasis: 'auto'` with no shrink is "size to your content". Spelled out
+  // rather than written `flex: 0`, which means that in CSS and does *not* mean
+  // it in react-native-web — there it is `flex-basis: 0%` with shrink still on,
+  // which collapses this column to its padding. Both spellings were wrong once,
+  // in different directions, on different platforms.
   leftSectionDense: {
     flexGrow: 0,
     flexShrink: 0,
     flexBasis: 'auto',
+    alignItems: 'flex-start',
     paddingLeft: 4,
   },
   centerSection: {
@@ -139,7 +153,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   centerSectionDense: {
-    flex: 1,
+    flexGrow: 1,
+    flexShrink: 1,
+    flexBasis: 0,
+    minWidth: 0,
     alignItems: 'flex-start',
     paddingLeft: 8,
   },
@@ -162,6 +179,7 @@ const styles = StyleSheet.create({
   },
   titleDense: {
     fontSize: 17,
+    fontWeight: 'bold',
   },
   subtitle: {
     fontSize: 12,
@@ -181,6 +199,7 @@ const styles = StyleSheet.create({
     paddingVertical: 2,
     paddingHorizontal: 6,
     borderRadius: 8,
+    borderWidth: 1,
   },
 });
 

--- a/SudokuApp/components/ScreenHeader.js
+++ b/SudokuApp/components/ScreenHeader.js
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 
 const ICON_SIZE = 24;
+const DENSE_ICON_SIZE = 20;
 
 /**
  * Header for game screens that aren't Sudoku: a home affordance back to the hub
@@ -17,26 +18,60 @@ const ICON_SIZE = 24;
  * (Fungiku uses it for "Easy · 6×6"). Callers should pass it either always or
  * never for a given screen — a subtitle that appears and disappears changes the
  * header's height, which moves everything under it.
+ *
+ * ### `dense`, and `actions` (added for the cube's Step 7)
+ *
+ * **The default header is two lines tall on a modern phone and nobody noticed
+ * for three epics.** The title gets a `flex: 2` centre column — about 186 points
+ * at 393 — and "Cube Scramble" at 24pt bold does not fit in it, so it wraps.
+ * Wrapping is not an error, so no test, no overflow check and no doctor run ever
+ * said a word (`docs/cube-plan.md` §10).
+ *
+ * `dense` is the opt-in fix, and it is opt-in precisely because this component is
+ * shared: **every existing caller keeps exactly the header it has.** It drops the
+ * title to one guaranteed line beside the home button, shrinks the icons, and
+ * comes out around 38 points against 75.
+ *
+ * `actions` is a node for the right-hand end — screen controls that would
+ * otherwise need a row of their own. A row is 40–50 points and on a screen built
+ * around one big square, that is the square's height. The cube puts its view
+ * controls here; see `games/cube/CubeScreen.js` and plan §8.6.
  */
-const ScreenHeader = ({ title, subtitle, theme, onHomePress, onMenuPress }) => {
+const ScreenHeader = ({
+  title,
+  subtitle,
+  theme,
+  onHomePress,
+  onMenuPress,
+  dense = false,
+  actions = null,
+}) => {
   const titleColor = theme?.colors?.title || '#333';
+  const iconSize = dense ? DENSE_ICON_SIZE : ICON_SIZE;
 
   return (
-    <View style={styles.header}>
-      <View style={styles.leftSection}>
+    <View style={[styles.header, dense && styles.headerDense]}>
+      <View style={[styles.leftSection, dense && styles.leftSectionDense]}>
         <TouchableOpacity
-          style={[styles.iconButton, { borderColor: titleColor }]}
+          style={[styles.iconButton, dense && styles.iconButtonDense, { borderColor: titleColor }]}
           onPress={onHomePress}
           accessibilityLabel="Back to games"
           accessibilityRole="button"
           accessibilityHint="Leaves this game and returns to the game list"
         >
-          <MaterialCommunityIcons name="home" size={ICON_SIZE} color={titleColor} />
+          <MaterialCommunityIcons name="home" size={iconSize} color={titleColor} />
         </TouchableOpacity>
       </View>
 
-      <View style={styles.centerSection}>
-        <Text style={[styles.title, { color: titleColor }]}>{title}</Text>
+      <View style={[styles.centerSection, dense && styles.centerSectionDense]}>
+        {/* One line, by construction, when dense — the whole point of the
+            variant is that this row's height is known rather than discovered. */}
+        <Text
+          style={[styles.title, dense && styles.titleDense, { color: titleColor }]}
+          numberOfLines={dense ? 1 : undefined}
+        >
+          {title}
+        </Text>
         {!!subtitle && (
           <Text style={[styles.subtitle, { color: titleColor }]} numberOfLines={1}>
             {subtitle}
@@ -45,17 +80,20 @@ const ScreenHeader = ({ title, subtitle, theme, onHomePress, onMenuPress }) => {
       </View>
 
       {/* Also balances the row so the title stays optically centered — the View
-          stays even with no menu button in it. */}
-      <View style={styles.rightSection}>
+          stays even with no menu button in it. (When dense the title is
+          left-aligned against the home button instead, because a row with
+          controls on the right has no centre to be optical about.) */}
+      <View style={[styles.rightSection, dense && styles.rightSectionDense]}>
+        {actions}
         {onMenuPress && (
           <TouchableOpacity
-            style={[styles.iconButton, { borderColor: titleColor }]}
+            style={[styles.iconButton, dense && styles.iconButtonDense, { borderColor: titleColor }]}
             onPress={onMenuPress}
             accessibilityLabel="Game menu"
             accessibilityRole="button"
             accessibilityHint="Choose a difficulty or start a new puzzle"
           >
-            <MaterialCommunityIcons name="menu" size={ICON_SIZE} color={titleColor} />
+            <MaterialCommunityIcons name="menu" size={iconSize} color={titleColor} />
           </TouchableOpacity>
         )}
       </View>
@@ -71,23 +109,59 @@ const styles = StyleSheet.create({
     minHeight: 48,
     marginBottom: 10,
   },
+  headerDense: {
+    minHeight: 34,
+    marginBottom: 4,
+  },
   leftSection: {
     flex: 1,
     alignItems: 'flex-start',
     paddingLeft: 8,
   },
+  // The three columns stop being thirds: the title takes what is left after the
+  // two ends have taken what they need, which is what lets the right-hand end
+  // hold three controls without squeezing the title into a wrap.
+  //
+  // **Spelled out rather than `flex: 0`**, and that is not style. `flex: 0` here
+  // means "size to your content", but react-native-web reads it as
+  // `flex-basis: 0%` with shrink still on — so both ends collapsed to their
+  // padding and their buttons hung off the right edge of the screen. Caught by
+  // the horizontal-overflow check in Step 7's driver, which is the check this
+  // repo has run since Step 1 and the reason it is still worth running.
+  leftSectionDense: {
+    flexGrow: 0,
+    flexShrink: 0,
+    flexBasis: 'auto',
+    paddingLeft: 4,
+  },
   centerSection: {
     flex: 2,
     alignItems: 'center',
+  },
+  centerSectionDense: {
+    flex: 1,
+    alignItems: 'flex-start',
+    paddingLeft: 8,
   },
   rightSection: {
     flex: 1,
     alignItems: 'flex-end',
     paddingRight: 8,
   },
+  rightSectionDense: {
+    flexGrow: 0,
+    flexShrink: 0,
+    flexBasis: 'auto',
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingRight: 4,
+  },
   title: {
     fontSize: 24,
     fontWeight: 'bold',
+  },
+  titleDense: {
+    fontSize: 17,
   },
   subtitle: {
     fontSize: 12,
@@ -102,6 +176,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: 8,
     borderRadius: 10,
     borderWidth: 1,
+  },
+  iconButtonDense: {
+    paddingVertical: 2,
+    paddingHorizontal: 6,
+    borderRadius: 8,
   },
 });
 

--- a/SudokuApp/games/cube/CubeMoveTrack.js
+++ b/SudokuApp/games/cube/CubeMoveTrack.js
@@ -1,0 +1,230 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ALG_FONT } from './algText';
+import { describeToken } from './solve';
+
+/** One line of moves. */
+const LINE = 20;
+
+/** How many of them are on screen at once. */
+const LINES = 2;
+
+const PAD = 5;
+
+/**
+ * The height this costs the page, and it is a constant on purpose — see below.
+ * Exported so the screen can talk about its own budget (docs/cube-plan.md §8.6).
+ */
+export const TRACK_HEIGHT = LINES * LINE + PAD * 2;
+
+/**
+ * The moves — the scramble, or the solve being written — as a **fixed** two-line
+ * track that scrolls to follow the cube (plan §8.6, Step 7).
+ *
+ * ### Why this replaced the card
+ *
+ * The card this grew out of drew every token and took whatever height that
+ * needed: five wrapped lines for a 42-move solve, six for a longer one. It was
+ * the tallest row on the screen **and the only one that grew as the operator
+ * drilled** — which is the wrong way round for a tool whose subject is the cube.
+ * Measured at 320×568 on a 42-move annotated solve, the old card left the cube
+ * **four points**. Not a typo, and not a case anyone had looked at: the docs
+ * recorded 114, measured on a shorter solve.
+ *
+ * The block was doing three jobs — read the whole solve, see where you are, tap
+ * a token to turn there — and it was sized for the first, which is the job the
+ * *cube* is on this screen to do. The other two are kept exactly: every token is
+ * still a tap target that turns the cube to it, and the phase boundaries still
+ * show between them.
+ *
+ * ### Fixed, not "capped"
+ *
+ * `TRACK_HEIGHT` does not depend on how many moves there are, and that is a
+ * requirement rather than a simplification. The stage measures itself
+ * (`onLayout`), so a track that were one line at move 3 and two at move 9 would
+ * **resize the cube in the middle of a solve** — the thing this step exists to
+ * stop.
+ *
+ * ### The scroll, and the pan it must not touch
+ *
+ * Plan §2's rule is that the page does not scroll, because a `ScrollView` around
+ * the cube puts "turn the cube" and "scroll the page" in competition for one
+ * drag. This is the same shape as `CubePhaseStrip`, which has scrolled sideways
+ * since Step 6: a bounded strip, well clear of the cube's square, that scrolls
+ * inside itself. The rule stands; nothing here is a scroll view the cube is in.
+ *
+ * Following the cube is keyed on `index`, which changes **when a move lands**
+ * and not on every animation frame — so a playback scrolls once per move rather
+ * than juddering. The current move is parked on the *second* of the two lines,
+ * so the line above it is where you just came from.
+ */
+const CubeMoveTrack = ({
+  tokens,
+  index,
+  marks,
+  placeholder,
+  accent,
+  theme,
+  // Moves not played yet, muted. Passed in rather than mixed here, so the
+  // screen keeps one answer for what "not yet" looks like.
+  pendingColor,
+  label,
+  noun = 'scramble',
+  onSeek,
+}) => {
+  const titleColor = theme.colors.title;
+  const surface = theme.colors.numberPad.background;
+  const border = theme.colors.numberPad.border;
+
+  const scroll = useRef(null);
+  // Where each token sits in the scrolled content. A plain object in a ref
+  // rather than state: it is written during layout and read when the cube
+  // moves, and re-rendering on either would be a render per token.
+  const tops = useRef({});
+
+  const noteTop = useCallback((i, y) => {
+    tops.current[i] = y;
+  }, []);
+
+  // Follow the cube. `index` is the number of moves played, so the move just
+  // made is `index - 1` — the one drawn as current.
+  useEffect(() => {
+    const y = tops.current[Math.max(0, index - 1)];
+    if (y === undefined || !scroll.current) return;
+    // One line up from the token's own line, which parks the current move on the
+    // second of the two rows and leaves the row you came from above it.
+    //
+    // This arithmetic is only exact because **every child of the track is
+    // exactly `LINE` tall** — see `styles.mark`. Let the dividers size
+    // themselves and the rows drift a point or two apart, the offset drifts with
+    // them, and each scroll leaves a sliver of the previous row showing along
+    // the top edge. Visible in a screenshot and in nothing else.
+    scroll.current.scrollTo({ y: Math.max(0, y - LINE), animated: true });
+  }, [index, tokens]);
+
+  // A different algorithm is a different track, and last week's scroll offset is
+  // not where the new one starts.
+  useEffect(() => {
+    tops.current = {};
+  }, [tokens]);
+
+  return (
+    <View
+      style={[styles.track, { backgroundColor: surface, borderColor: border }]}
+      accessibilityLabel={label}
+    >
+      <ScrollView
+        ref={scroll}
+        style={styles.scroll}
+        contentContainerStyle={styles.body}
+        showsVerticalScrollIndicator={false}
+        // The tokens are the subject here, not a page to be scrolled — so a drag
+        // that starts on one still hits it.
+        keyboardShouldPersistTaps="handled"
+      >
+        {tokens.length === 0 ? (
+          <Text style={[styles.placeholder, { color: pendingColor }]}>{placeholder}</Text>
+        ) : (
+          tokens.map((token, i) => (
+            <React.Fragment key={`${token}-${i}`}>
+              {/* The gap between two tokens is where a phase boundary shows, and
+                  it is its own element rather than part of the token: the token
+                  is a tap target that turns the cube, and a divider is not a
+                  move you can turn to. */}
+              {i > 0 && marks.has(i) && (
+                <Text style={[styles.mark, { color: accent }]}>|</Text>
+              )}
+              <TouchableOpacity
+                onPress={() => onSeek(i + 1)}
+                onLayout={({ nativeEvent }) => noteTop(i, nativeEvent.layout.y)}
+                accessibilityRole="button"
+                // Unchanged from the card this replaced, deliberately: every
+                // headless driver this epic has written finds a move by this
+                // string, and they are the regression suite for "the control
+                // still works from its new home".
+                accessibilityLabel={`Move ${i + 1}, ${describeToken(token)}`}
+                accessibilityHint={`Turns the cube to this point in the ${noun}`}
+                style={styles.token}
+              >
+                <Text
+                  style={[
+                    styles.tokenText,
+                    { color: i < index ? titleColor : pendingColor },
+                    i === index - 1 && [styles.currentToken, { color: accent }],
+                  ]}
+                >
+                  {token}
+                </Text>
+              </TouchableOpacity>
+            </React.Fragment>
+          ))
+        )}
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  track: {
+    alignSelf: 'stretch',
+    marginHorizontal: 4,
+    height: TRACK_HEIGHT + 2, // the border
+    borderWidth: 1,
+    borderRadius: 10,
+    overflow: 'hidden',
+  },
+  scroll: {
+    flex: 1,
+  },
+  body: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    alignItems: 'flex-start',
+    paddingVertical: PAD,
+    paddingHorizontal: 6,
+  },
+  token: {
+    height: LINE,
+    justifyContent: 'center',
+    paddingHorizontal: 4,
+  },
+  tokenText: {
+    fontFamily: ALG_FONT,
+    fontSize: 14,
+    lineHeight: LINE,
+  },
+  // Bold as well as coloured: the token you are on has to be findable at a
+  // glance, and on a monospaced face weight is the difference that survives a
+  // small screen.
+  currentToken: {
+    fontWeight: '700',
+  },
+  // `height` as well as `lineHeight`, and it is load-bearing rather than tidy: a
+  // bar glyph asks for a taller box than a letter does, and one child a couple
+  // of points taller than the rest pushes every row below it out of step with
+  // `LINE` — which is the number the auto-scroll is computed from.
+  mark: {
+    fontFamily: ALG_FONT,
+    // Two points smaller than a move, and that is not decoration: a bar glyph
+    // fills its whole em where a letter does not, so at the tokens' 14 it paints
+    // past the 20-point line it is given and the row *above* the window leaves
+    // red ticks along the top edge of the track. Clipped as well, belt and
+    // braces — react-native-web does not reliably clip an inline span.
+    fontSize: 12,
+    height: LINE,
+    lineHeight: LINE,
+    overflow: 'hidden',
+    fontWeight: '700',
+    paddingHorizontal: 2,
+  },
+  placeholder: {
+    fontFamily: ALG_FONT,
+    fontSize: 14,
+    height: LINE,
+    lineHeight: LINE,
+    textAlign: 'center',
+  },
+});
+
+export default CubeMoveTrack;

--- a/SudokuApp/games/cube/CubeMoveTrack.js
+++ b/SudokuApp/games/cube/CubeMoveTrack.js
@@ -1,21 +1,22 @@
-import React, { useCallback, useEffect, useRef } from 'react';
-import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Animated,
+  PanResponder,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { ALG_FONT } from './algText';
 import { describeToken } from './solve';
+import { HANDLE, LINE, PAD, TRACK_HEIGHT, drawerHeight, followScrollTop } from './trackLayout';
 
-/** One line of moves. */
-const LINE = 20;
+export { TRACK_HEIGHT };
 
-/** How many of them are on screen at once. */
-const LINES = 2;
-
-const PAD = 5;
-
-/**
- * The height this costs the page, and it is a constant on purpose — see below.
- * Exported so the screen can talk about its own budget (docs/cube-plan.md §8.6).
- */
-export const TRACK_HEIGHT = LINES * LINE + PAD * 2;
+/** Past this much of a drag, let go and the drawer goes the way you were pulling. */
+const SNAP = 24;
 
 /**
  * The moves — the scramble, or the solve being written — as a **fixed** two-line
@@ -70,6 +71,11 @@ const CubeMoveTrack = ({
   pendingColor,
   label,
   noun = 'scramble',
+  // How far down the drawer may be pulled: the stage's measured height, which
+  // is the room between the track and the transport. Passed in because only the
+  // screen knows it, and it is a *maximum* — a short solve opens to its own
+  // height rather than to a panel of empty space.
+  room = 0,
   onSeek,
 }) => {
   const titleColor = theme.colors.title;
@@ -99,7 +105,7 @@ const CubeMoveTrack = ({
     // themselves and the rows drift a point or two apart, the offset drifts with
     // them, and each scroll leaves a sliver of the previous row showing along
     // the top edge. Visible in a screenshot and in nothing else.
-    scroll.current.scrollTo({ y: Math.max(0, y - LINE), animated: true });
+    scroll.current.scrollTo({ y: followScrollTop(y), animated: true });
   }, [index, tokens]);
 
   // A different algorithm is a different track, and last week's scroll offset is
@@ -108,16 +114,88 @@ const CubeMoveTrack = ({
     tops.current = {};
   }, [tokens]);
 
+  // ——— The drawer ————————————————————————————————————————————————————
+  //
+  // Two lines is the right *resting* size and the wrong size for reading a solve
+  // back, which is the operator's own verdict on the two-line track: *"the solve
+  // display could be a drawer with a handle. Or a way to view the whole thing."*
+  // So it is both — two lines while you write, the whole solve when you pull it
+  // down.
+  //
+  // **It opens over the cube rather than pushing it.** The panel is positioned
+  // absolutely out of a wrapper that keeps the track's height in the layout, so
+  // the stage below never re-measures and `cubeSize` never changes. A drawer
+  // that resized the cube every time it was opened would be the bug this whole
+  // step exists to kill, arriving by another door.
+  const [open, setOpen] = useState(false);
+  const openRef = useRef(false);
+  openRef.current = open;
+
+  // How tall the whole solve wants to be, **measured rather than estimated** —
+  // how many tokens fit on a line depends on the width of the phone and on how
+  // many of them are `M2` rather than `U`, and a guess opens the drawer onto a
+  // band of empty space. Capped by what the stage can lend, so a four-move solve
+  // opens to one line and a hundred-move one stops at the cube.
+  const [content, setContent] = useState(0);
+  const openHeight = drawerHeight({ open: true, content, room });
+
+  const height = useRef(new Animated.Value(TRACK_HEIGHT)).current;
+  const settle = useCallback(
+    (next) => {
+      setOpen(next);
+      Animated.timing(height, {
+        toValue: next ? openHeight : drawerHeight({ open: false }),
+        duration: 180,
+        // A height cannot be driven natively, and there is no cube in here to
+        // stutter — the panel is text over a stage that is not re-rendering.
+        useNativeDriver: false,
+      }).start();
+    },
+    [height, openHeight]
+  );
+
+  // Keep an open drawer the right size when the solve grows under it.
+  useEffect(() => {
+    if (openRef.current) height.setValue(openHeight);
+  }, [height, openHeight]);
+
+  // Drag the handle, or tap it. The handle is well clear of the cube's square,
+  // so this takes no gesture away from the pan that turns it (plan §2).
+  const drag = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: (_, g) => Math.abs(g.dy) > 4,
+      onPanResponderRelease: (_, g) => {
+        if (g.dy > SNAP) settleRef.current(true);
+        else if (g.dy < -SNAP) settleRef.current(false);
+        else settleRef.current(!openRef.current);
+      },
+    })
+  ).current;
+  // The responder is created once, so it cannot close over a `settle` that
+  // changes with `openHeight` — the same stale-closure trap `CubeView` hits with
+  // yaw and pitch (plan §10).
+  const settleRef = useRef(settle);
+  settleRef.current = settle;
+
   return (
-    <View
-      style={[styles.track, { backgroundColor: surface, borderColor: border }]}
-      accessibilityLabel={label}
-    >
+    // Holds the *closed* height in the layout whatever the drawer is doing, so
+    // the stage below it is measured once and stays measured. The zIndex is what
+    // puts the open panel over the cube rather than under it.
+    <View style={styles.wrap}>
+      <Animated.View
+        style={[styles.track, { height, backgroundColor: surface, borderColor: border }]}
+        accessibilityLabel={label}
+      >
       <ScrollView
         ref={scroll}
         style={styles.scroll}
         contentContainerStyle={styles.body}
+        onContentSizeChange={(_, h) => setContent(h)}
         showsVerticalScrollIndicator={false}
+        // Open, the whole solve is the point and it may be taller than the
+        // panel; closed, the two lines are driven by the transport.
+        scrollEnabled={open}
         // The tokens are the subject here, not a page to be scrolled — so a drag
         // that starts on one still hits it.
         keyboardShouldPersistTaps="handled"
@@ -160,21 +238,71 @@ const CubeMoveTrack = ({
           ))
         )}
       </ScrollView>
+
+      {/* The handle. Drag it down for the whole solve, up to put it away — or
+          tap it, because a 16-point grab bar is a big ask of a thumb that only
+          wants to toggle something. */}
+      <View
+        {...drag.panHandlers}
+        style={styles.handle}
+        accessibilityRole="button"
+        accessibilityLabel={open ? 'Collapse the moves' : 'Show the whole thing'}
+        accessibilityHint={
+          open
+            ? 'Puts the moves back to two lines'
+            : 'Opens the moves out over the cube so the whole algorithm is visible'
+        }
+        accessibilityState={{ expanded: open }}
+      >
+        <View style={[styles.grip, { backgroundColor: border }]} />
+        <MaterialCommunityIcons
+          name={open ? 'chevron-up' : 'chevron-down'}
+          size={13}
+          color={pendingColor}
+          style={styles.chevron}
+        />
+      </View>
+      </Animated.View>
     </View>
   );
 };
 
 const styles = StyleSheet.create({
-  track: {
+  // Reserves the closed height, always. The panel inside it grows out of the
+  // flow, so nothing below ever moves.
+  wrap: {
     alignSelf: 'stretch',
-    marginHorizontal: 4,
     height: TRACK_HEIGHT + 2, // the border
+    zIndex: 10,
+  },
+  // Full width when open, so nothing behind it — the phase strip in particular —
+  // peeks out down the side of the panel.
+  track: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
     borderWidth: 1,
     borderRadius: 10,
     overflow: 'hidden',
   },
   scroll: {
     flex: 1,
+  },
+  handle: {
+    height: HANDLE,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+  },
+  grip: {
+    width: 28,
+    height: 3,
+    borderRadius: 2,
+    marginRight: 5,
+  },
+  chevron: {
+    opacity: 0.8,
   },
   body: {
     flexDirection: 'row',

--- a/SudokuApp/games/cube/CubeScreen.js
+++ b/SudokuApp/games/cube/CubeScreen.js
@@ -30,6 +30,7 @@ import {
   describeOrientation,
   describeOrientationSentence,
   orientationAt,
+  viewAfterHold,
 } from './orientation';
 import { randomScramble } from './scramble';
 import {
@@ -178,6 +179,21 @@ const CubeScreen = ({ onExitToHub }) => {
   // new scramble nor coming back tomorrow means they wanted to move.
   const [yaw, setYaw] = useState(DEFAULT_YAW);
   const [pitch, setPitch] = useState(DEFAULT_PITCH);
+
+  /**
+   * The angle **Set start** left the cube at, and which solve it was set for.
+   *
+   * Transient, like the angle itself (plan §7.1) — what is *authored* is the
+   * hold, and the hold is stored. This only has to survive until the operator
+   * pans away and taps `Start view`, so that the button goes back to the view
+   * they chose rather than to a default they never asked for.
+   *
+   * Tagged with the solve's id rather than reset by every callback that could
+   * invalidate it: switching pages, loading a favorite and starting a new solve
+   * would each have to remember to clear it, and the one that forgot would send
+   * `Start view` to another solve's angle.
+   */
+  const [chosenView, setChosenView] = useState(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -435,9 +451,16 @@ const CubeScreen = ({ onExitToHub }) => {
   const setStartingOrientation = useCallback(() => {
     pause();
     editOpen({ orientation: orientationAt(yaw, pitch) });
-    setYaw(DEFAULT_YAW);
-    setPitch(DEFAULT_PITCH);
-  }, [pause, editOpen, yaw, pitch]);
+    // Where the camera has to stand to keep showing what it is showing, now
+    // that the hold has been turned into the model underneath it. Usually that
+    // is exactly the angle the operator was already at, and the picture does not
+    // move at all; see `viewAfterHold` for when it cannot be, and why the part
+    // it gives up is the part worth giving up.
+    const view = viewAfterHold(yaw, pitch);
+    setYaw(view.yaw);
+    setPitch(view.pitch);
+    setChosenView({ id: openId, ...view });
+  }, [pause, editOpen, yaw, pitch, openId]);
 
   // Back to inspection. Only offered while the solve is empty: re-orienting
   // under moves that are already written would silently change what every one
@@ -526,14 +549,24 @@ const CubeScreen = ({ onExitToHub }) => {
     [renamingId, endRename]
   );
 
-  // The shortcut back to the hold you picked. Because the orientation is baked
-  // into the model rather than left in the camera, "the view I chose" and "the
-  // default view" are the same thing — so this is the reset that already
-  // existed, under the name it now deserves.
+  /**
+   * The shortcut back to the hold you picked — and, since 2026-08-03, back to
+   * the *angle* you picked it from.
+   *
+   * Step 5 could make this the plain reset, because setting a hold sent the
+   * camera to the default and so "the view I chose" and "the default view" were
+   * the same thing. They are not any more: Set start leaves the camera where it
+   * was, so this has to go back there rather than to the opening angle.
+   *
+   * Falling back to the default is the honest answer when there is nothing
+   * remembered — after a cold start, the hold comes back from the file and the
+   * angle deliberately does not.
+   */
   const startView = useCallback(() => {
-    setYaw(DEFAULT_YAW);
-    setPitch(DEFAULT_PITCH);
-  }, []);
+    const chosen = chosenView && chosenView.id === openId ? chosenView : null;
+    setYaw(chosen ? chosen.yaw : DEFAULT_YAW);
+    setPitch(chosen ? chosen.pitch : DEFAULT_PITCH);
+  }, [chosenView, openId]);
 
   // A key is the armed modifier plus the letter, and the arming is spent — one
   // move, then back to plain. Holding it would mean a `'` left armed silently

--- a/SudokuApp/games/cube/CubeScreen.js
+++ b/SudokuApp/games/cube/CubeScreen.js
@@ -894,6 +894,10 @@ const CubeScreen = ({ onExitToHub }) => {
           pendingColor={pendingColor}
           noun={noun}
           label={writing ? `Solve: ${solve || 'nothing yet'}` : `Scramble: ${scramble}`}
+          // How far the drawer may be pulled down: the room the stage is
+          // holding. It opens *over* the cube and never resizes it — the
+          // measurement it is given is a limit, not a claim.
+          room={stage ? stage.height : 0}
           onSeek={playTo}
         />
       )}

--- a/SudokuApp/games/cube/CubeScreen.js
+++ b/SudokuApp/games/cube/CubeScreen.js
@@ -16,6 +16,7 @@ import CubeView from './CubeView';
 import CubeAlgInputModal from './CubeAlgInputModal';
 import CubeFavoritesModal from './CubeFavoritesModal';
 import CubeMovePad from './CubeMovePad';
+import CubeMoveTrack from './CubeMoveTrack';
 import CubeNameModal from './CubeNameModal';
 import CubePhaseModal from './CubePhaseModal';
 import CubePhaseStrip from './CubePhaseStrip';
@@ -35,7 +36,6 @@ import {
   appendAlg,
   appendToken,
   describeSolve,
-  describeToken,
   dropLastToken,
   nextModifier,
   padToken,
@@ -702,9 +702,19 @@ const CubeScreen = ({ onExitToHub }) => {
   const openMoves = Math.max(0, player.index - openStart);
   const renamingPhase = isPhaseBoundary(phases, player.index);
 
-  // The boundaries, for the divider in the solve card. A set, because the card
+  // The boundaries, for the dividers in the move track. A set, because the track
   // asks this once per token.
-  const marks = useMemo(() => new Set(phases.map((phase) => phase.at)), [phases]);
+  //
+  // **Only while writing.** The markers belong to the solve, and the track shows
+  // the *scramble* in the other mode — where a divider from somebody's Roux
+  // first block would be drawn across a scramble that has no phases and cannot
+  // have any. (The card this replaced had the same bug and nobody caught it,
+  // because you have to open a scramble that already has an annotated solve
+  // behind it to see one.)
+  const marks = useMemo(
+    () => new Set(writing ? phases.map((phase) => phase.at) : []),
+    [writing, phases]
+  );
 
   // Solve mode has two phases, which is how the operator described it: **find
   // the hold**, then **write the solve**. Inspecting is panning, so it gets the
@@ -745,10 +755,98 @@ const CubeScreen = ({ onExitToHub }) => {
       : Math.min(widthAllowance, MAX_CUBE, height * CUBE_HEIGHT_SHARE)
   );
 
+  /**
+   * The controls that ride on the header (plan §8.6, Step 7).
+   *
+   * These are the *view*: where the camera is pointing, and — in solve mode —
+   * the way back out to the scramble. They were a row of their own, twice: an
+   * action row above the cube and a second row of buttons below it, together
+   * about 100 points on a screen whose subject is a square. A header row was
+   * already being paid for, and it had a whole empty column on the right of it.
+   *
+   * Icon-only, and that is the trade this step makes: a label is a word you
+   * read once and an icon is a target you hit every time. What a label says
+   * that an icon cannot is a *count* — so `count` is a parameter, and Favorites
+   * keeps its number.
+   */
+  const headerAction = (name, label, hint, onPress, count) => (
+    <TouchableOpacity
+      key={label}
+      style={[styles.headerAction, { borderColor: border }]}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityHint={hint}
+    >
+      <MaterialCommunityIcons name={name} size={18} color={titleColor} />
+      {count > 0 && (
+        <Text style={[styles.headerActionCount, { color: titleColor }]}>{count}</Text>
+      )}
+    </TouchableOpacity>
+  );
+
+  const headerActions = writing ? (
+    <>
+      {!inspecting &&
+        headerAction(
+          'arrow-left',
+          'Back to the scramble',
+          'Stops writing and shows the scramble again; the solve is kept',
+          stopSolving
+        )}
+
+      {/* Whichever of the two the hold allows, and the rule is Step 5's,
+          unchanged: re-orienting is free while the solve is empty and locked
+          once it is not, because re-orienting under moves already written would
+          silently change what every one of them does (operator, 2026-08-02). */}
+      {!inspecting &&
+        (solveCount === 0
+          ? headerAction(
+              'axis-arrow',
+              'Pick the starting orientation again',
+              'Goes back to turning the cube to how you want to hold it',
+              reorient
+            )
+          : headerAction(
+              'restore',
+              'Back to the starting view',
+              `Looks at the cube from ${holdText} again`,
+              startView
+            ))}
+
+      {headerAction(
+        'rotate-3d-variant',
+        'Turn the cube around',
+        'Shows the three faces that are currently hidden',
+        showOtherSide
+      )}
+    </>
+  ) : (
+    <>
+      {headerAction('restore', 'Reset the view', 'Looks at the cube from the front again', resetView)}
+      {headerAction(
+        'rotate-3d-variant',
+        'Turn the cube around',
+        'Shows the three faces that are currently hidden',
+        showOtherSide
+      )}
+      {/* Not a view control, and here anyway: the row below fits three labelled
+          buttons at 320 points and not four, and this is the one of the four
+          whose label was a noun rather than a verb. It keeps its count. */}
+      {headerAction(
+        'star-box-outline',
+        `Favorites, ${favorites.length} saved`,
+        'Opens the list of scrambles you have kept',
+        () => setShowFavorites(true),
+        favorites.length
+      )}
+    </>
+  );
+
   if (!hydrated) {
     return (
       <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
-        <ScreenHeader title="Cube Scramble" theme={theme} onHomePress={onExitToHub} />
+        <ScreenHeader title="Cube Scramble" theme={theme} onHomePress={onExitToHub} dense />
         <View style={styles.loading}>
           <ActivityIndicator size="large" color={titleColor} />
         </View>
@@ -758,100 +856,53 @@ const CubeScreen = ({ onExitToHub }) => {
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
-      <ScreenHeader title="Cube Scramble" theme={theme} onHomePress={onExitToHub} />
+      {/* Dense, and carrying the view controls (plan §8.6, Step 7). The default
+          header wrapped "Cube Scramble" onto two lines and cost 75 points to say
+          something the operator knew before they tapped the tile; the controls
+          that ride on it used to be a row of their own, and a row on this screen
+          is the cube's height. */}
+      <ScreenHeader
+        title="Cube Scramble"
+        theme={theme}
+        onHomePress={onExitToHub}
+        dense
+        actions={headerActions}
+      />
 
-      {/* While a solve is being written the scramble is context rather than the
-          subject, so it drops to one muted line — it is still the thing being
-          solved and it is still worth being able to read, but the card below it
-          now belongs to the solve. */}
-      {writing && (
-        <Text
-          style={[styles.scrambleLine, { color: pendingColor }]}
-          numberOfLines={1}
-          ellipsizeMode="tail"
-          accessibilityLabel={`Solving the scramble ${scramble}`}
-        >
-          {scramble}
-        </Text>
+      {/* The moves — and the scrubber's track. Tapping a token turns the cube to
+          that point, one move at a time and in whichever direction it lies,
+          which is a shorter route to "what does move 14 do" than fourteen taps
+          on the step button and still shows the moves rather than cutting to the
+          answer.
+
+          The tokens come from the same scan as the moves (`player.tokens`), so a
+          token and the move it turns to cannot drift apart — and a solve entered
+          as `r U r'` reads back as `r U r'` rather than being quietly corrected
+          to the model's canonical `Rw U Rw'` (plan §4).
+
+          **Inspection does not get one.** There are no moves yet, and the prompt
+          it used to hold is said better by the live hold readout under the cube —
+          which is the answer the phase is actually looking for. */}
+      {!inspecting && (
+        <CubeMoveTrack
+          tokens={player.tokens}
+          index={player.index}
+          marks={marks}
+          placeholder={writing ? 'Tap a key to begin' : scramble}
+          accent={CUBE_ACCENT}
+          theme={theme}
+          pendingColor={pendingColor}
+          noun={noun}
+          label={writing ? `Solve: ${solve || 'nothing yet'}` : `Scramble: ${scramble}`}
+          onSeek={playTo}
+        />
       )}
-
-      {/* The algorithm is also the scrubber's track: tapping a token turns the
-          cube to that point, one move at a time and in whichever direction it
-          lies — which is a shorter route to "what does move 14 do" than
-          fourteen taps on the step button, and still shows the moves rather
-          than cutting to the answer.
-
-          The tokens come from the same scan as the moves (`player.tokens`), so
-          a token and the move it turns to cannot drift apart — and a solve
-          entered as `r U r'` reads back as `r U r'` rather than being quietly
-          corrected to the model's canonical `Rw U Rw'` (plan §4). */}
-      <View style={[styles.scrambleCard, { backgroundColor: surface, borderColor: border }]}>
-        <Text
-          style={[styles.scrambleText, { color: pendingColor }]}
-          accessibilityLabel={
-            inspecting
-              ? 'Turn the cube to how you want to hold it, then set it as the start'
-              : writing
-                ? `Solve: ${solve || 'nothing yet'}`
-                : `Scramble: ${scramble}`
-          }
-          selectable
-        >
-          {player.count === 0
-            ? writing
-              ? inspecting
-                ? 'Turn the cube to how you want to hold it'
-                : 'Tap a key to begin'
-              : scramble
-            : player.tokens.flatMap((token, i) => {
-                // The gap between two tokens is where a phase boundary shows,
-                // and it is its own element rather than part of the token: the
-                // token is a tap target that turns the cube, and a divider is
-                // not a move you can turn to. It is a separate span rather than
-                // a bar drawn under the group because the card wraps — a group
-                // can start mid-line and end two lines later.
-                const gap =
-                  i === 0 ? null : (
-                    <Text
-                      key={`gap-${i}`}
-                      style={marks.has(i) ? [styles.phaseMark, { color: CUBE_ACCENT }] : null}
-                    >
-                      {marks.has(i) ? '  |  ' : '  '}
-                    </Text>
-                  );
-
-                const move = (
-                  <Text
-                    key={`${token}-${i}`}
-                    onPress={() => playTo(i + 1)}
-                    suppressHighlighting
-                    accessibilityRole="button"
-                    accessibilityLabel={`Move ${i + 1}, ${describeToken(token)}`}
-                    accessibilityHint={`Turns the cube to this point in the ${
-                      writing ? 'solve' : 'scramble'
-                    }`}
-                    style={
-                      i === player.index - 1
-                        ? [styles.currentToken, { color: CUBE_ACCENT }]
-                        : i < player.index
-                          ? { color: titleColor }
-                          : null
-                    }
-                  >
-                    {token}
-                  </Text>
-                );
-
-                return gap ? [gap, move] : [move];
-              })}
-        </Text>
-      </View>
 
       {/* Directly under the moves it is describing, and only once there is
           something to describe — a solve with no markers costs the cube
-          nothing. Above the action row rather than below the pad because it is
-          about the *moves*, and the eye should not have to cross the cube to
-          get from `First block · 8` to the eight moves it counted. */}
+          nothing. Above the cube rather than below the pad because it is about
+          the *moves*, and the eye should not have to cross the cube to get from
+          `First block · 8` to the eight moves it counted. */}
       {writing && !inspecting && spans.length > 0 && (
         <CubePhaseStrip
           spans={spans}
@@ -862,133 +913,12 @@ const CubeScreen = ({ onExitToHub }) => {
         />
       )}
 
-      <View style={styles.actionRow}>
-        {writing ? (
-          <>
-            <TouchableOpacity
-              style={[styles.toolButton, { borderColor: border }]}
-              onPress={stopSolving}
-              accessibilityRole="button"
-              accessibilityLabel="Back to the scramble"
-              accessibilityHint="Stops writing and shows the scramble again; the solve is kept"
-            >
-              <MaterialCommunityIcons name="arrow-left" size={18} color={titleColor} />
-              <Text style={[styles.toolButtonText, { color: titleColor }]}>Scramble</Text>
-            </TouchableOpacity>
-
-            {/* The middle control is whichever of the three things is actually
-                available, because there is only room for one of them:
-
-                  inspecting            → Set start  (the point of the phase)
-                  set, nothing written  → Re-orient  (change your mind, freely)
-                  set, moves written    → Start view (the hold is locked in)
-
-                Locking once moves exist is the operator's call (2026-08-02):
-                re-orienting under moves already written would silently change
-                what every one of them does to the cube. */}
-            {inspecting ? (
-              <TouchableOpacity
-                style={[styles.primaryButton, { backgroundColor: CUBE_ACCENT }]}
-                onPress={setStartingOrientation}
-                accessibilityRole="button"
-                accessibilityLabel={`Set the start as ${holdText}`}
-                accessibilityHint="Holds the cube this way round; every move you write is relative to it"
-              >
-                <MaterialCommunityIcons name="check" size={18} color="#ffffff" />
-                <Text style={styles.primaryButtonText}>Set start</Text>
-              </TouchableOpacity>
-            ) : solveCount === 0 ? (
-              <TouchableOpacity
-                style={[styles.toolButton, { borderColor: border }]}
-                onPress={reorient}
-                accessibilityRole="button"
-                accessibilityLabel="Pick the starting orientation again"
-                accessibilityHint="Goes back to turning the cube to how you want to hold it"
-              >
-                <MaterialCommunityIcons name="rotate-3d-variant" size={18} color={titleColor} />
-                <Text style={[styles.toolButtonText, { color: titleColor }]}>Re-orient</Text>
-              </TouchableOpacity>
-            ) : (
-              <TouchableOpacity
-                style={[styles.toolButton, { borderColor: border }]}
-                onPress={startView}
-                accessibilityRole="button"
-                accessibilityLabel="Back to the starting view"
-                accessibilityHint={`Looks at the cube from ${holdText} again`}
-              >
-                <MaterialCommunityIcons name="home-outline" size={18} color={titleColor} />
-                <Text style={[styles.toolButtonText, { color: titleColor }]}>Start view</Text>
-              </TouchableOpacity>
-            )}
-
-            {/* Icon-only: with a labelled button either side, labelling this one
-                too wraps the row onto a second line at 320 points, and the 40
-                points that costs come out of the cube. */}
-            <TouchableOpacity
-              style={[styles.toolButton, styles.iconOnly, { borderColor: border }]}
-              onPress={showOtherSide}
-              accessibilityRole="button"
-              accessibilityLabel="Turn the cube around"
-              accessibilityHint="Shows the three faces that are currently hidden"
-            >
-              <MaterialCommunityIcons
-                name="rotate-3d-variant"
-                size={18}
-                color={titleColor}
-              />
-            </TouchableOpacity>
-          </>
-        ) : (
-          <>
-            <TouchableOpacity
-              style={[styles.primaryButton, { backgroundColor: CUBE_ACCENT }]}
-              onPress={startSolving}
-              accessibilityRole="button"
-              accessibilityLabel="Write a solve"
-              accessibilityHint="Opens the move pad, with the cube starting from this scramble"
-            >
-              <MaterialCommunityIcons name="pencil-outline" size={18} color="#ffffff" />
-              <Text style={styles.primaryButtonText}>
-                Solve{solveCount > 0 ? ` (${solveCount})` : ''}
-              </Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={[styles.toolButton, { borderColor: border }]}
-              onPress={newScramble}
-              accessibilityRole="button"
-              accessibilityLabel="New scramble"
-              accessibilityHint="Generates a new random scramble and applies it to the cube"
-            >
-              <MaterialCommunityIcons name="dice-multiple" size={18} color={titleColor} />
-              <Text style={[styles.toolButtonText, { color: titleColor }]}>New</Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={[
-                styles.toolButton,
-                { borderColor: saved ? CUBE_ACCENT : border },
-                saved && { backgroundColor: surface },
-              ]}
-              onPress={toggleSaved}
-              accessibilityRole="button"
-              accessibilityLabel={saved ? 'Remove from saved scrambles' : 'Save this scramble'}
-              accessibilityState={{ selected: saved }}
-            >
-              <MaterialCommunityIcons
-                name={saved ? 'star' : 'star-outline'}
-                size={18}
-                color={saved ? CUBE_ACCENT : titleColor}
-              />
-              <Text
-                style={[styles.toolButtonText, { color: saved ? CUBE_ACCENT : titleColor }]}
-              >
-                {saved ? 'Saved' : 'Save'}
-              </Text>
-            </TouchableOpacity>
-          </>
-        )}
-      </View>
+      {/* The action row is gone, and that is Step 7's third cut (plan §8.6).
+          Its three controls were `Scramble` — navigation, which now sits beside
+          the home button — and two view controls, which now sit with the view.
+          Its own comment used to explain that one of the three had to be
+          icon-only because labelling it wrapped the row, "and the 40 points that
+          costs come out of the cube". The row itself was 48. */}
 
       {/* Takes the leftover height, and *is* the cube's allowance: it sits in
           the middle of whatever the phone has left rather than hanging under the
@@ -1029,13 +959,44 @@ const CubeScreen = ({ onExitToHub }) => {
       )}
 
       {inspecting ? (
-        <Text
-          style={[styles.hold, { color: CUBE_ACCENT }]}
-          accessibilityLiveRegion="polite"
-          accessibilityLabel={`Holding ${holdText}`}
-        >
-          {describeOrientationSentence(facingCube)}
-        </Text>
+        <>
+          <Text
+            style={[styles.hold, { color: CUBE_ACCENT }]}
+            accessibilityLiveRegion="polite"
+            accessibilityLabel={`Holding ${holdText}`}
+          >
+            {describeOrientationSentence(facingCube)}
+          </Text>
+
+          {/* The one row this screen still has, and the one it should: `Set
+              start` is the *point* of this phase and an accented, labelled
+              button is what says so. It sits under the readout it is confirming
+              rather than above the cube, which is where it used to be —
+              inspecting reads bottom-up now, cube then hold then set. */}
+          <View style={styles.actionRow}>
+            <TouchableOpacity
+              style={[styles.toolButton, { borderColor: border }]}
+              onPress={stopSolving}
+              accessibilityRole="button"
+              accessibilityLabel="Back to the scramble"
+              accessibilityHint="Stops writing and shows the scramble again; the solve is kept"
+            >
+              <MaterialCommunityIcons name="arrow-left" size={18} color={titleColor} />
+              <Text style={[styles.toolButtonText, { color: titleColor }]}>Scramble</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={[styles.primaryButton, { backgroundColor: CUBE_ACCENT }]}
+              onPress={setStartingOrientation}
+              accessibilityRole="button"
+              accessibilityLabel={`Set the start as ${holdText}`}
+              accessibilityHint="Holds the cube this way round; every move you write is relative to it"
+            >
+              <MaterialCommunityIcons name="check" size={18} color="#ffffff" />
+              <Text style={styles.primaryButtonText}>Set start</Text>
+            </TouchableOpacity>
+          </View>
+        </>
       ) : writing ? (
         <CubeMovePad
           modifier={modifier}
@@ -1055,59 +1016,79 @@ const CubeScreen = ({ onExitToHub }) => {
           onPhase={openPhases}
         />
       ) : (
-        <>
-          <Text style={[styles.hint, { color: titleColor }]}>
-            Drag the cube · tap a move to turn to it
-          </Text>
+        // One row where there were two and a caption (plan §8.6). What went:
+        // `Reset view` and `Other side` are view controls and moved up to the
+        // header with the rest of the view; the hint line went altogether. It
+        // read "Drag the cube · tap a move to turn to it", which earns its 24
+        // points on the first visit and never again — and this screen has been
+        // charging the cube for it on every visit since Step 1.
+        //
+        // What is left is the three things this mode is *for*, still labelled,
+        // because a verb with no noun on it is a guess.
+        <View style={styles.bottomRow}>
+          <TouchableOpacity
+            style={[styles.primaryButton, { backgroundColor: CUBE_ACCENT }]}
+            onPress={startSolving}
+            accessibilityRole="button"
+            accessibilityLabel="Write a solve"
+            accessibilityHint="Opens the move pad, with the cube starting from this scramble"
+          >
+            <MaterialCommunityIcons name="pencil-outline" size={18} color="#ffffff" />
+            <Text style={styles.primaryButtonText}>
+              Solve{solveCount > 0 ? ` (${solveCount})` : ''}
+            </Text>
+          </TouchableOpacity>
 
-          <View style={styles.bottomRow}>
-            <TouchableOpacity
-              style={[styles.toolButton, { borderColor: border }]}
-              onPress={resetView}
-              accessibilityRole="button"
-              accessibilityLabel="Reset the view"
-            >
-              <MaterialCommunityIcons name="restore" size={18} color={titleColor} />
-              <Text style={[styles.toolButtonText, { color: titleColor }]}>Reset view</Text>
-            </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.toolButton, { borderColor: border }]}
+            onPress={newScramble}
+            accessibilityRole="button"
+            accessibilityLabel="New scramble"
+            accessibilityHint="Generates a new random scramble and applies it to the cube"
+          >
+            <MaterialCommunityIcons name="dice-multiple" size={18} color={titleColor} />
+            <Text style={[styles.toolButtonText, { color: titleColor }]}>New</Text>
+          </TouchableOpacity>
 
-            <TouchableOpacity
-              style={[styles.toolButton, { borderColor: border }]}
-              onPress={showOtherSide}
-              accessibilityRole="button"
-              accessibilityLabel="Turn the cube around"
-              accessibilityHint="Shows the three faces that are currently hidden"
-            >
-              <MaterialCommunityIcons name="rotate-3d-variant" size={18} color={titleColor} />
-              <Text style={[styles.toolButtonText, { color: titleColor }]}>Other side</Text>
-            </TouchableOpacity>
+          <TouchableOpacity
+            style={[
+              styles.toolButton,
+              { borderColor: saved ? CUBE_ACCENT : border },
+              saved && { backgroundColor: surface },
+            ]}
+            onPress={toggleSaved}
+            accessibilityRole="button"
+            accessibilityLabel={saved ? 'Remove from saved scrambles' : 'Save this scramble'}
+            accessibilityState={{ selected: saved }}
+          >
+            <MaterialCommunityIcons
+              name={saved ? 'star' : 'star-outline'}
+              size={18}
+              color={saved ? CUBE_ACCENT : titleColor}
+            />
+            <Text style={[styles.toolButtonText, { color: saved ? CUBE_ACCENT : titleColor }]}>
+              {saved ? 'Saved' : 'Save'}
+            </Text>
+          </TouchableOpacity>
 
-            <TouchableOpacity
-              style={[styles.toolButton, { borderColor: border }]}
-              onPress={() => setShowFavorites(true)}
-              accessibilityRole="button"
-              accessibilityLabel={`Favorites, ${favorites.length} saved`}
-              accessibilityHint="Opens the list of scrambles you have kept"
-            >
-              <MaterialCommunityIcons name="star-box-outline" size={18} color={titleColor} />
-              <Text style={[styles.toolButtonText, { color: titleColor }]}>
-                Favorites{favorites.length > 0 ? ` (${favorites.length})` : ''}
-              </Text>
-            </TouchableOpacity>
-          </View>
-        </>
+        </View>
       )}
 
       {/* The bottom line of solve mode, in both its phases — and **the way into
           the picker**, which is why it is a button rather than the caption it
           used to be.
 
-          It has to be this and not a row of its own: solve mode is already
-          header · scramble line · solve card · a three-button row · stage ·
-          transport · three pad rows · this, and at 320×568 that leaves the cube
-          about 120 points. The action row's middle button is already three-way
-          and cannot become four. So the line that already said which hold and
-          how many moves says which *page* too, and tapping it opens the list.
+          It has to be this and not a row of its own: this one line says which
+          page, which hold and how many moves, and opens the list, for the 21
+          points a caption was costing anyway.
+
+          **It also carries the scramble now** (Step 7). That used to be a muted
+          line of its own above the solve — 20 points to answer "which cube am I
+          on", a question that comes up rarely and has a whole mode devoted to it
+          one tap away. Here it is last in the line and the line truncates from
+          the right, so it is the first thing to go when the screen is narrow,
+          which is the correct order of importance. The full text is on the
+          accessibility label either way.
 
           Both phases get it, and that is not symmetry for its own sake:
           inspecting a brand-new solve you have changed your mind about would
@@ -1121,7 +1102,7 @@ const CubeScreen = ({ onExitToHub }) => {
           accessibilityRole="button"
           accessibilityLabel={`${openSolve.name}, ${describeSolve(solve)}${
             inspecting ? '' : `, started from ${holdText}`
-          }`}
+          }, solving the scramble ${scramble}`}
           accessibilityHint="Opens the solves written for this scramble"
         >
           <MaterialCommunityIcons
@@ -1137,6 +1118,7 @@ const CubeScreen = ({ onExitToHub }) => {
           >
             {openSolve.name} · {inspecting ? '' : `${holdText} · `}
             {describeSolve(solve)}
+            <Text style={styles.solveBarScramble}> · {scramble}</Text>
           </Text>
           <MaterialCommunityIcons name="chevron-up" size={14} color={titleColor} />
         </TouchableOpacity>
@@ -1222,58 +1204,37 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  scrambleCard: {
-    alignSelf: 'stretch',
-    marginHorizontal: 4,
-    borderWidth: 1,
-    borderRadius: 10,
-    paddingVertical: 10,
-    paddingHorizontal: 12,
-  },
-  scrambleText: {
-    fontFamily: ALG_FONT,
-    fontSize: 15,
-    lineHeight: 22,
-    textAlign: 'center',
-  },
-  // The scramble while a solve is being written: one line, smaller, above the
-  // card. Twenty tokens do not fit and are not meant to — this is "which cube
-  // am I on", and the whole thing is one tap away in the other mode.
-  scrambleLine: {
-    fontFamily: ALG_FONT,
-    fontSize: 11,
-    lineHeight: 16,
-    textAlign: 'center',
-    alignSelf: 'stretch',
-    marginBottom: 4,
-    paddingHorizontal: 6,
-  },
-  // Bold as well as coloured: the token you are on has to be findable in a
-  // twenty-token block at a glance, and on a monospaced face weight is the
-  // difference that survives a small screen.
-  currentToken: {
-    fontWeight: '700',
-  },
-  // A phase boundary, in the moves themselves. An ASCII bar rather than a box
-  // drawing character: this is set in whatever the platform calls "monospace",
-  // and the one glyph that is certainly in all three of them is the one on the
-  // keyboard.
-  phaseMark: {
-    fontWeight: '700',
-  },
   actionRow: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
     flexWrap: 'wrap',
-    marginTop: 12,
+    marginTop: 10,
   },
   bottomRow: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
     flexWrap: 'wrap',
+    marginTop: 6,
     marginBottom: 4,
+  },
+  // A view control on the header row. Square-ish and icon-only, but still 30
+  // points of border around an 18-point glyph with the row's own height behind
+  // it — this step does not buy its space back from the size of a target.
+  headerAction: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingVertical: 5,
+    paddingHorizontal: 7,
+    marginLeft: 5,
+  },
+  headerActionCount: {
+    fontSize: 11,
+    fontWeight: '700',
+    marginLeft: 3,
   },
   primaryButton: {
     flexDirection: 'row',
@@ -1307,18 +1268,15 @@ const styles = StyleSheet.create({
   iconOnly: {
     paddingHorizontal: 10,
   },
+  // Takes the leftover — but the leftover is no longer an afterthought, which is
+  // the whole of Step 7 (plan §8.6). Every row above and below this one now has
+  // to justify its height against what it costs the cube.
   stage: {
     flex: 1,
     alignSelf: 'stretch',
     alignItems: 'center',
     justifyContent: 'center',
-    marginTop: 12,
-  },
-  hint: {
-    fontSize: 11,
-    opacity: 0.6,
-    marginTop: 10,
-    marginBottom: 2,
+    marginTop: 6,
   },
   // The pad already ate the vertical the bottom row used to have, so the line
   // under it is tight to it rather than floating. It is a button now — the way
@@ -1344,6 +1302,12 @@ const styles = StyleSheet.create({
     fontSize: 11,
     opacity: 0.75,
     marginRight: 4,
+  },
+  // Dimmer than the rest of the line, because it is context rather than
+  // identity: this is the cube you are solving, not the page you are on.
+  solveBarScramble: {
+    fontFamily: ALG_FONT,
+    opacity: 0.7,
   },
   // The live readout while inspecting. Bigger and accented than the other
   // captions on this page because during that phase it is the *answer* — the

--- a/SudokuApp/games/cube/__tests__/orientation.test.js
+++ b/SudokuApp/games/cube/__tests__/orientation.test.js
@@ -15,8 +15,10 @@ import {
   facingAt,
   facingColors,
   orientationAt,
+  viewAfterHold,
 } from '../orientation';
 import {
+  FACE_NORMALS,
   FACE_ORDER,
   applyMoves,
   cubeFromAlg,
@@ -24,7 +26,7 @@ import {
   isSolved,
   solvedCube,
 } from '../cubeState';
-import { DEFAULT_PITCH, DEFAULT_YAW } from '../geometry';
+import { DEFAULT_PITCH, DEFAULT_YAW, orbit } from '../geometry';
 import { OPPOSITE_FACE, parseAlg } from '../moves';
 
 const RAD = (degrees) => (degrees * Math.PI) / 180;
@@ -288,5 +290,106 @@ describe('describing a hold in colours', () => {
   it('has a colour for every face', () => {
     FACE_ORDER.forEach((face) => expect(COLOR_NAMES[face]).toBeTruthy());
     expect(new Set(Object.values(COLOR_NAMES)).size).toBe(6);
+  });
+});
+
+describe('viewAfterHold — the picture does not jump when the hold is set', () => {
+  // What the operator is looking at: where each face's normal lands on screen.
+  // If two cameras put all six in the same places, the two pictures are the
+  // same picture.
+  const picture = (yaw, pitch, alg) => {
+    const turned = applyMoves(solvedCube(), parseAlg(alg || ''));
+    const faces = facelets(turned);
+    // Which original colour is on each face position now, and where that face
+    // position sits on screen.
+    return FACE_ORDER.map((face) => ({
+      color: faces[face][4],
+      at: orbit(FACE_NORMALS[face], yaw, pitch),
+    })).sort((a, b) => a.color.localeCompare(b.color));
+  };
+
+  const sameTo = (a, b, tolerance) =>
+    a.every((entry, i) =>
+      entry.color === b[i].color &&
+      entry.at.every((v, axis) => Math.abs(v - b[i].at[axis]) <= tolerance)
+    );
+
+  /** How far the picture moved, worst face, worst axis. */
+  const drift = (yaw, pitch) => {
+    const before = picture(yaw, pitch, '');
+    const view = viewAfterHold(yaw, pitch);
+    const after = picture(view.yaw, view.pitch, orientationAt(yaw, pitch));
+    let worst = 0;
+    before.forEach((entry, i) => {
+      expect(entry.color).toBe(after[i].color);
+      entry.at.forEach((v, axis) => {
+        worst = Math.max(worst, Math.abs(v - after[i].at[axis]));
+      });
+    });
+    return worst;
+  };
+
+  it('leaves the opening view exactly where it is', () => {
+    expect(drift(DEFAULT_YAW, DEFAULT_PITCH)).toBeLessThan(1e-9);
+  });
+
+  it('is exact at the angles a hand actually stops at', () => {
+    // Including the cube turned right over for the traditional yellow-up Roux
+    // hold, which is the one the old behaviour moved furthest.
+    [
+      [-30, 25],
+      [-30, 155],
+      [0, 120],
+      [45, 45],
+      [-90, 20],
+      [30, 25],
+      [-30, -25],
+      [180, 30],
+    ].forEach(([y, p]) => {
+      expect(drift(RAD(y), RAD(p))).toBeLessThan(1e-9);
+    });
+  });
+
+  it('beats sending the camera back to the opening angle, nearly everywhere', () => {
+    // The old behaviour, for comparison: the hold is baked in and the camera
+    // goes to the default whatever the operator was looking at.
+    const oldDrift = (yaw, pitch) => {
+      const before = picture(yaw, pitch, '');
+      const after = picture(DEFAULT_YAW, DEFAULT_PITCH, orientationAt(yaw, pitch));
+      let worst = 0;
+      before.forEach((entry, i) => {
+        entry.at.forEach((v, axis) => {
+          worst = Math.max(worst, Math.abs(v - after[i].at[axis]));
+        });
+      });
+      return worst;
+    };
+
+    let exact = 0;
+    let better = 0;
+    let total = 0;
+    for (let y = -180; y < 180; y += 15) {
+      for (let p = -180; p < 180; p += 15) {
+        const now = drift(RAD(y), RAD(p));
+        const was = oldDrift(RAD(y), RAD(p));
+        total += 1;
+        if (now < 1e-9) exact += 1;
+        if (now <= was + 1e-9) better += 1;
+      }
+    }
+    // Over half of every angle a finger can reach is pixel-exact, and the
+    // camera never ends up further from the picture than the old jump did.
+    expect(exact / total).toBeGreaterThan(0.5);
+    expect(better).toBe(total);
+  });
+
+  it('never returns an angle the camera cannot hold', () => {
+    for (let y = -180; y < 180; y += 30) {
+      for (let p = -180; p < 180; p += 30) {
+        const view = viewAfterHold(RAD(y), RAD(p));
+        expect(Number.isFinite(view.yaw)).toBe(true);
+        expect(Number.isFinite(view.pitch)).toBe(true);
+      }
+    }
   });
 });

--- a/SudokuApp/games/cube/__tests__/trackLayout.test.js
+++ b/SudokuApp/games/cube/__tests__/trackLayout.test.js
@@ -1,0 +1,58 @@
+import {
+  HANDLE,
+  LINE,
+  LINES,
+  PAD,
+  TRACK_HEIGHT,
+  drawerHeight,
+  followScrollTop,
+} from '../trackLayout';
+
+describe('the move track', () => {
+  // The whole of Step 7 rests on this one: the stage measures itself, so a track
+  // whose height depended on the solve would resize the cube as the solve was
+  // written — which is the bug the step exists to kill.
+  it('costs the page the same whatever is in it', () => {
+    expect(TRACK_HEIGHT).toBe(LINES * LINE + PAD * 2 + HANDLE);
+    expect(drawerHeight({ open: false })).toBe(TRACK_HEIGHT);
+    expect(drawerHeight({ open: false, content: 4000, room: 500 })).toBe(TRACK_HEIGHT);
+  });
+
+  describe('following the cube', () => {
+    it('parks the current move on the second line, with the line above it', () => {
+      // Token on the third rendered line: PAD + 2 * LINE.
+      expect(followScrollTop(PAD + 2 * LINE)).toBe(PAD + LINE);
+    });
+
+    it('does not scroll above the top for the first line', () => {
+      expect(followScrollTop(PAD)).toBe(0);
+      expect(followScrollTop(0)).toBe(0);
+    });
+  });
+
+  describe('the drawer', () => {
+    it('opens to exactly what the moves need', () => {
+      // Four lines of content, and room to spare.
+      const content = 4 * LINE + PAD * 2;
+      expect(drawerHeight({ open: true, content, room: 400 })).toBe(content + HANDLE);
+    });
+
+    it('never opens shorter than it was shut', () => {
+      // A one-move solve: the panel does not shrink below the resting size, or
+      // opening it would make the moves *harder* to read than leaving it alone.
+      expect(drawerHeight({ open: true, content: LINE, room: 400 })).toBe(TRACK_HEIGHT);
+    });
+
+    it('stops at the cube rather than reaching the transport', () => {
+      // A very long solve with only 120 points of stage to borrow.
+      expect(drawerHeight({ open: true, content: 2000, room: 120 })).toBe(TRACK_HEIGHT + 120);
+    });
+
+    it('opens to the resting size before the stage has been measured', () => {
+      // The first render has no measurement, and a negative one is not a thing
+      // this should have to reason about either.
+      expect(drawerHeight({ open: true, content: 2000, room: 0 })).toBe(TRACK_HEIGHT);
+      expect(drawerHeight({ open: true, content: 2000, room: -50 })).toBe(TRACK_HEIGHT);
+    });
+  });
+});

--- a/SudokuApp/games/cube/orientation.js
+++ b/SudokuApp/games/cube/orientation.js
@@ -20,11 +20,14 @@
  * into rotations and applied to the cube, and the camera goes back to the
  * default.
  *
- * **The angle is thrown away, and only the hold is kept.** There are 24 holds
- * and infinitely many angles to look at one from: inspecting from directly
- * overhead is a fine way to decide "blue up, white front" and a bad way to look
- * at a cube you are about to solve. So this answers *which of the 24*, and the
- * screen shows that one from the standard three-quarter view.
+ * **The angle is not kept, but the picture is** (revised 2026-08-03). There are
+ * 24 holds and infinitely many angles to look at one from, so what is *stored*
+ * is which of the 24 — the angle itself is not part of the solve. But the camera
+ * no longer snaps back to the opening view when the hold is set: it moves to
+ * wherever reproduces what you were already looking at, which `viewAfterHold`
+ * works out. Step 5 threw the angle away entirely and the operator's verdict on
+ * using it was that the jump is an annoyance; the reasoning behind the jump is
+ * kept below, because the part of it that is right is still right.
  *
  * Pure: no React, no react-native. `orbit` is the only thing borrowed from the
  * renderer, and it is pure too.
@@ -169,6 +172,83 @@ export const orientationAt = (yaw, pitch) => {
   return algForFacing(up, front) || '';
 };
 
+/**
+ * The hold as a rotation matrix — rows, so `R · n` is where the model vector
+ * `n` ends up.
+ *
+ * Read straight off the pair rather than parsed back out of the notation: a
+ * rotation is fixed by where three orthogonal axes go, so "`up`'s normal goes to
+ * +y and `front`'s goes to +z" *is* the rotation. The third row is `up × front`,
+ * which is the right-handed choice because x̂ = ŷ × ẑ in this lattice (plan §3).
+ */
+const holdMatrix = (up, front) => {
+  const u = FACE_NORMALS[up];
+  const f = FACE_NORMALS[front];
+  const r = [u[1] * f[2] - u[2] * f[1], u[2] * f[0] - u[0] * f[2], u[0] * f[1] - u[1] * f[0]];
+  return [r, u, f];
+};
+
+/**
+ * Where to put the camera after a hold is baked in, so **the picture does not
+ * jump**.
+ *
+ * ### The thing this fixes
+ *
+ * Step 5 sent the camera back to the opening angle on Set start, deliberately:
+ * there are 24 holds and infinitely many angles to look at one from, and
+ * inspecting from directly overhead is a fine way to decide "yellow up, blue
+ * front" and a bad way to look at a cube you are about to solve. The reasoning
+ * was sound and the *feel* was wrong, which is a thing only use can tell you —
+ * the operator turns the cube to exactly how they mean to hold it, taps Set
+ * start, and it moves. **The angle you chose is information, and throwing all of
+ * it away threw away the good part with the bad.**
+ *
+ * ### The arithmetic
+ *
+ * Panning moves the camera; a hold moves the model. That is still true and is
+ * still why the hold has to be baked in (see the note at the top of this file).
+ * But baking it is a rotation `R` applied to the model, so a camera `C` that was
+ * showing `C(M)` needs to become `C · R⁻¹` to show the same picture of `R(M)`:
+ *
+ *     C'(R(M)) = C·R⁻¹·R(M) = C(M)
+ *
+ * `C` is `Rx(pitch)·Ry(yaw)` — two angles, no roll — and `C · R⁻¹` is a general
+ * rotation, so it is not always in that family. **It is far more often than you
+ * would guess.** Over a 5° sweep of every angle a finger can reach, 57% come
+ * back exactly, 97% come back closer than the opening angle was, and every
+ * ordinary inspection angle tried — including turning the cube right over for
+ * the traditional yellow-up Roux hold, which is the one that jumps hardest
+ * today — is exact.
+ *
+ * When it is not exact, what is lost is the **roll**: the component that would
+ * have left the cube sitting at a tilt on screen. That is the one part of an
+ * inspection angle worth discarding, so the approximation fails in the right
+ * direction. Giving the camera a roll axis would make it exact everywhere and is
+ * still the change to make if colour neutrality ever lands (plan §8.3) — it is
+ * not needed for this.
+ *
+ * @param {number} yaw the angle the cube was inspected from
+ * @param {number} pitch
+ * @returns {{yaw: number, pitch: number}} the camera that reproduces the picture
+ */
+export const viewAfterHold = (yaw, pitch) => {
+  const { up, front } = facingAt(yaw, pitch);
+  if (algForFacing(up, front) === null) return { yaw, pitch };
+
+  // Column j of `C · R⁻¹` is `C` applied to row j of R, because R is a rotation
+  // and so its inverse is its transpose.
+  const columns = holdMatrix(up, front).map((row) => orbit(row, yaw, pitch));
+  const m = (i, j) => columns[j][i];
+
+  // `Rx(b)·Ry(a)` reads
+  //   [[ ca,       0,    sa   ],
+  //    [ sb·sa,   cb,   -sb·ca],
+  //    [-cb·sa,   sb,    cb·ca]]
+  // so both angles come straight off it, and `atan2` handles every quadrant and
+  // the poles without a special case.
+  return { yaw: Math.atan2(m(0, 2), m(0, 0)), pitch: Math.atan2(m(2, 1), m(1, 1)) };
+};
+
 /** The colours on top and in front of `cube`, named. */
 export const facingColors = (cube) => {
   const { up, front } = facingOf(cube);
@@ -191,6 +271,7 @@ export default {
   algForFacing,
   facingAt,
   orientationAt,
+  viewAfterHold,
   facingColors,
   describeOrientation,
 };

--- a/SudokuApp/games/cube/trackLayout.js
+++ b/SudokuApp/games/cube/trackLayout.js
@@ -1,0 +1,70 @@
+/**
+ * The move track's geometry (docs/cube-plan.md §8.6, Step 7).
+ *
+ * Pure, and in its own module for the reason everything else in this feature is:
+ * the test runner is a plain node environment with no React Native in it, so
+ * anything worth pinning has to live somewhere it can be imported. What is worth
+ * pinning here is small and was got wrong twice — where the track scrolls to
+ * when the cube moves, and how far the drawer opens.
+ */
+
+/** One line of moves. */
+export const LINE = 20;
+
+/** How many of them are on screen with the drawer shut. */
+export const LINES = 2;
+
+/** The breathing room inside the panel, top and bottom. */
+export const PAD = 5;
+
+/** The grab bar under the moves. Small, and the whole drawer hangs off it. */
+export const HANDLE = 16;
+
+/**
+ * What the track costs the page — **a constant, and that is a requirement**.
+ *
+ * The stage measures itself (`onLayout`), so a track whose height depended on
+ * how many moves there were would resize the cube in the middle of a solve.
+ * That is the bug this step exists to kill, and a growing track is the door it
+ * would come back in through. The drawer opens *over* the cube instead, which
+ * is why opening it does not change this number.
+ */
+export const TRACK_HEIGHT = LINES * LINE + PAD * 2 + HANDLE;
+
+/**
+ * Where to scroll so the move just played sits on the bottom of the two visible
+ * lines, with the line it came from above it.
+ *
+ * `y` is the token's offset from the content container's padding edge. The
+ * arithmetic is only exact because **every child of the track is exactly `LINE`
+ * tall** — let the phase dividers size themselves to their own glyph and the
+ * rows drift a point or two apart, and this drifts with them, leaving a sliver
+ * of the previous row along the top edge on every scroll.
+ *
+ * @param {number} y the token's offset in the scrolled content
+ * @returns {number} the scroll offset, never negative
+ */
+export const followScrollTop = (y) => Math.max(0, y - LINE);
+
+/**
+ * How tall the drawer stands.
+ *
+ * `content` is **measured, not estimated**: how many tokens fit on a line
+ * depends on the width of the phone and on how many of them are `M2` rather
+ * than `U`, and a guess opens the drawer onto a band of empty space.
+ *
+ * `room` is what the stage can lend — the drawer covers the cube and stops
+ * there, so it never reaches the transport. Both bounds matter: a four-move
+ * solve opens to one line rather than to a screenful of nothing, and a
+ * hundred-move one stops at the cube and scrolls inside itself.
+ *
+ * @param {{open: boolean, content: number, room: number}} state
+ * @returns {number} the panel's height in points
+ */
+export const drawerHeight = ({ open, content, room }) => {
+  if (!open) return TRACK_HEIGHT;
+  const wanted = content + HANDLE;
+  return Math.max(TRACK_HEIGHT, Math.min(wanted, TRACK_HEIGHT + Math.max(0, room)));
+};
+
+export default { LINE, LINES, PAD, HANDLE, TRACK_HEIGHT, followScrollTop, drawerHeight };

--- a/SudokuApp/utils/buildNotes.js
+++ b/SudokuApp/utils/buildNotes.js
@@ -20,6 +20,7 @@ const BUILD_NOTES = {
       'The cube turns all the way over, so yellow-up — the usual Roux hold — is one drag away',
       'Set start locks that hold in, and every move you write is relative to it',
       'Start view is the shortcut back to the hold you picked, however far you have turned away',
+      'Set start no longer moves the cube: it stays exactly where you turned it to',
       'Then the move pad opens, with the cube starting from the scramble in your chosen hold',
       'Twelve keys — U D L R F B, M, r, l, x y z — with ’ and 2 armed before the move they apply to',
       'Every move you enter turns the cube as you enter it, at whatever speed the chip is set to',

--- a/SudokuApp/utils/buildNotes.js
+++ b/SudokuApp/utils/buildNotes.js
@@ -41,6 +41,9 @@ const BUILD_NOTES = {
       'Save a scramble to your favorites, and load any of them back onto the cube later',
       'Loading a favorite brings back every solve you wrote against it',
       'The scramble you were looking at, and everything you saved, survive closing the app',
+      'The cube is much bigger: the screen was two thirds buttons and text, and now it is not',
+      'Moves sit in a two-line track that scrolls itself to wherever the cube is, however long the solve gets',
+      'The view controls moved up beside the title, so a whole row of the page went back to the cube',
       'Sudoku and Fungiku are unchanged',
     ]
   },

--- a/SudokuApp/utils/buildNotes.js
+++ b/SudokuApp/utils/buildNotes.js
@@ -43,6 +43,7 @@ const BUILD_NOTES = {
       'The scramble you were looking at, and everything you saved, survive closing the app',
       'The cube is much bigger: the screen was two thirds buttons and text, and now it is not',
       'Moves sit in a two-line track that scrolls itself to wherever the cube is, however long the solve gets',
+      'Pull the handle under the moves and the whole solve opens out over the cube; tap it to put it away',
       'The view controls moved up beside the title, so a whole row of the page went back to the cube',
       'Sudoku and Fungiku are unchanged',
     ]

--- a/docs/cube-handoff.md
+++ b/docs/cube-handoff.md
@@ -507,6 +507,53 @@ never touch.
 above. The browser is where this step's evidence lives, and it is not where the
 step's worst bug was. Look at it on a device.
 
+### **Step 7a — the hold stops moving the cube** ✅ *(2026-08-03)*
+
+A follow-on to Step 7, from the operator using it: *"when setting the
+orientation, when locking it in, can we remember the exact position of the cube.
+It currently repositions."*
+
+Step 5 sent the camera back to the opening angle on **Set start**, on the
+grounds that there are 24 holds and infinitely many angles to look at one from,
+and inspecting from directly overhead is a bad way to look at a cube you are
+about to solve. Sound, and it threw away the good part with the bad: **the angle
+you turned the cube to is information** — it is the view you decided you wanted
+to solve from, arrived at by hand.
+
+`orientation.viewAfterHold(yaw, pitch)` keeps the picture. Baking the hold is a
+rotation `R` on the model, so a camera `C` becomes `C · R⁻¹` to show the same
+picture of `R(M)`. The camera is yaw-then-pitch with no roll so that is not
+always reachable — **but more than half of every angle a finger can reach comes
+back pixel-exact, the camera is never left further from the picture than the old
+jump left it, and every ordinary inspection angle tried is exact**, including
+turning the cube right over for the yellow-up Roux hold, which is the one the old
+behaviour moved furthest. What is lost when it cannot be exact is the *roll* —
+the component that would leave the cube at a tilt, which is the one part worth
+discarding. Plan §8.3 has the whole argument.
+
+**`Start view` changed with it.** It used to be the plain reset, because the view
+you chose and the default view were the same thing. Now it returns to the angle
+Set start left the cube at, held in screen state and tagged with the solve it
+belongs to — so switching pages cannot send it to another solve's angle — and
+falling back to the default after a cold start, because the angle is still not in
+the save file (plan §7.1 is unchanged: the hold is authored, the angle is not).
+
+Two things worth not rediscovering:
+
+- **The hold matrix is read off the pair, not parsed back out of the notation.**
+  A rotation is fixed by where three orthogonal axes go, so "up's normal goes to
+  +y, front's to +z" *is* the rotation, and the third row is `up × front`.
+- **`Start view` is not offered while the solve is empty** — the header shows
+  Re-orient there instead, which is the right control while the hold can still
+  be changed. A driver has to write a move before it can test the button.
+
+Verified with `npm test` (756, 4 of them new: exact at the opening view, exact at
+eight real inspection angles, and a sweep proving the new camera is never further
+from the picture than the old jump), plus a `hold.js` driver that drags the cube
+to four real angles, reads **every polygon the renderer emitted** before and
+after Set start, and measures how far the picture moved: three of four are 0.0pt,
+the fourth is 35.8pt against a snap that used to be most of a face.
+
 ### **Step 6 — annotate the move groups** ✅ *(2026-08-02)*
 
 Shipped: **a solve has structure, and the structure has counts.** Finish your

--- a/docs/cube-handoff.md
+++ b/docs/cube-handoff.md
@@ -398,6 +398,9 @@ is a question only the operator can answer.
   Solve mode uses all three (back · start view/re-orient · turn around); scramble
   mode uses three as well (reset view · turn around · favorites). A fourth wants a
   rethink, not a squeeze.
+- **The drawer is a tap or a drag, and the drag is deliberately forgiving** —
+  24 points either way, and anything shorter counts as a tap, because a
+  16-point grab bar is a big ask of a thumb that only wants to toggle something.
 - **A phase divider directly above the move track's window still paints a
   hairline of red on the top edge.** The glyph is clipped to its line and sized
   down; roughly two points of it survive on web. Cosmetic, and only when a marker
@@ -434,8 +437,8 @@ word, because a wasteful page is not a failing one.
 
 | Solve mode, 42 moves, annotated | before | after |
 |---|---|---|
-| 320×568 | **4** | **210** |
-| 375×667 | 125 | 309 |
+| 320×568 | **4** | **194** |
+| 375×667 | 125 | 293 |
 | 393×852 | 318 | 373 (width-bound) |
 
 Scramble mode 166 → 300 at 320×568; inspection 247 → 300, width-bound at every
@@ -444,7 +447,14 @@ every other row is on a budget justified against it** — it had been the only
 element on the page with no floor, which is why six steps of careful,
 well-documented self-restraint still added up to a four-point cube.
 
-Four things it learned:
+The moves are also a **drawer**: a grab bar under them opens the panel out over
+the cube to show the whole solve, and shuts it again. It was the operator's own
+call on the two-line track — *"a drawer with a handle, or a way to view the whole
+thing"* — and it opens *over* the stage rather than pushing it, so the cube never
+resizes. It costs the closed page the handle's 16 points, which is why the
+numbers above are 16 short of the first cut's.
+
+Five things it learned:
 
 - **`flex: 0` is not "size to your content" on the web.** The dense header's end
   columns used it; react-native-web read it as `flex-basis: 0%` with shrink still
@@ -452,6 +462,16 @@ Four things it learned:
   right edge of the screen. Spell `flexGrow` / `flexShrink` / `flexBasis` out.
   The horizontal-overflow check the drivers have run since Step 1 had never once
   fired before and caught this.
+- **A style variant must be a whole style, not an override layered on the base
+  one — and this one only broke on the phone.** `[styles.leftSection, dense &&
+  styles.leftSectionDense]` flattens to an object carrying both the base
+  `flex: 1` and the variant's `flexGrow`/`flexShrink`/`flexBasis`, and **web and
+  Yoga disagree about which wins**. Three viewport widths in a browser all
+  passed; on a real iPhone the home button was a sliver and the view controls
+  were off the right edge, and the operator hit it in the first screenshot they
+  took. Pass `dense ? a : b` and there is nothing to disagree about. **`expo
+  export --platform all` proves it bundles, not that it lays out** — only a
+  device does that.
 - **A fixed-height track needs every child to be exactly one line tall.** The
   phase divider is a bar glyph and fills its em where a letter does not, so its
   row came out a couple of points taller than `LINE` — and the auto-scroll is
@@ -470,15 +490,22 @@ in.** The save shape is plan §7.2 and async-storage on web is plain
 hand takes minutes, and it is the case that matters — the worst case was found by
 being able to reach it cheaply.
 
-Verified with `npm test` (745 across the app), `npx expo-doctor` (18/18), `npx
-expo export --platform all`, and two headless drivers at 320×568, 375×667 and
-393×852 with the screenshots read: `budget.js` seeds the worst case and prints
-every row of the page with its height, the cube's size and both overflow flags,
-before and after; `walk.js` clicks all 39 checks' worth of controls by
-`aria-label` — the header's view controls, a token in the track, the transport,
-inspection and Set start, the pad, an armed modifier, undo, the flag and the
-phase strip, and back out to the scramble — then opens Fungiku to prove the
-shared header is untouched. No overflow and no console errors at any size.
+Verified with `npm test` (752 across the app, 7 of them new on the track's
+geometry), `npx expo-doctor` (18/18), `npx expo export --platform all`, and three
+headless drivers at 320×568, 375×667 and 393×852 with the screenshots read:
+`budget.js` seeds the worst case straight into `localStorage` and prints every
+row of the page with its height, the cube's size and both overflow flags, before
+and after; `walk.js` clicks 39 checks' worth of controls by `aria-label` — the
+header's view controls, a token in the track, the transport, inspection and Set
+start, the pad, an armed modifier, undo, the flag and the phase strip, and back
+out to the scramble — then opens Fungiku to prove the shared header is
+untouched; `drawer.js` opens and shuts the drawer and asserts **the cube is the
+same size before, during and after**, which is the one thing the drawer must
+never touch.
+
+**And then a real phone found what none of that could** — the style-variant bug
+above. The browser is where this step's evidence lives, and it is not where the
+step's worst bug was. Look at it on a device.
 
 ### **Step 6 — annotate the move groups** ✅ *(2026-08-02)*
 

--- a/docs/cube-handoff.md
+++ b/docs/cube-handoff.md
@@ -66,7 +66,11 @@ is always openable in Expo Go (project → Branches) even with no step PR open.
   `react-native-svg` — Step 2 touched only `utils/buildNotes.js`, because plan
   §12 says to, Step 4 touched those same two (the hub badge counts solves now),
   and Step 6 touched only the build notes. A step that needs to touch anything
-  else should say why in its PR.
+  else should say why in its PR. **Step 7 is the first one that has to**: the
+  header it wants to shrink is `components/ScreenHeader.js`, shared with
+  Fungiku. The way to do that without breaking the rule's intent is an opt-in
+  prop whose default is today's behaviour, plus opening the other callers to
+  check — and saying so in the PR.
 - **The model owns the rules.** Import `solvedCube` / `applyMove` / `applyMoves`
   / `cubeFromAlg` / `facelets` / `isSolved` from `games/cube/cubeState.js`, and
   `parseAlg` / `parseMove` / `scanAlg` / `tokenize` / `algError` / `moveCount`
@@ -131,116 +135,155 @@ you built, at every stage of the motion, not only at rest.
 
 ---
 
-## Next step: **Step 7 — edit a solve you have already written**
+## Next step: **Step 7 — give the page back to the cube**
 
-> **This step was moved to the front of the queue, and plan §8's table says so
-> and why.** It used to be "enter a cube by hand"; that is Step 8 now. If the
-> operator would rather have the cube entry next, take that row instead — this is
-> a re-ordering, not new scope, and either brief is a step's worth of work.
+> **The order changed on 2026-08-03 and plan §8 says why.** This step used to be
+> *edit a solve*; that is Step 8 now and its brief is kept in full in plan §8.7,
+> so nothing was lost. The operator looked at solve mode and said the chrome was
+> taking too much of the screen — and the old Step 7 brief was already designing
+> around that ("the screen is full… anything this step adds has to replace
+> something or live in a modal"), which is the wrong way round.
 
-**The text field appends; it cannot edit.** A typo in the middle of a solve is
-fixed by undoing back to it and retyping everything after. That was fine when the
-solve was a scratchpad (Step 3), stopped being fine the moment solves were kept
-(Step 4 — which recorded it and deliberately did not fix it), and Step 6 has now
-put **markers** on top of the same text. It is the oldest live gap in the
-feature and every step adds weight to it.
+**Two thirds of this screen is not the cube.** Measured on a 393×852 phone,
+mid-drill on a 42-move solve:
+
+| Row | pt | |
+|---|---|---|
+| Header | 75 | the title **wraps to two lines** |
+| Scramble line | 20 | |
+| Move card | 143 | five wrapped lines, **and it grows with the solve** |
+| Phase strip | 24 | |
+| Action row | 48 | |
+| **Cube stage** | **228** | **31% of the page** |
+| Scrubber | 39 | |
+| Move pad | 115 | three rows |
+| Solve bar | 21 | |
+
+485 points of chrome against 228 of cube, and at 320×568 the cube is down to
+114. The target is about **200 points back — stage 228 → ~430, i.e. 31% → 58%**.
+
+**The definition of done is sharper than a percentage: the cube should end up
+limited by the width of the phone, not by what is stacked above it.** Watch
+`cubeSize`'s `Math.min` in `CubeScreen.js` — when `stage.height` stops being the
+term that wins at 320 and 375 points wide, this step is done.
 
 ### Scope — ONLY this
 
-1. **Replace the solve's text, rather than appending to it.**
-   `CubeAlgInputModal` already validates a whole algorithm with the real parser
-   and says which token it choked on; the honest shape is that modal opened with
-   the solve **already in it**, replacing on Add. Appending stays — it is what
-   the field is for mid-write — so this is a second way in rather than a changed
-   one. "Edit" belongs on the solve card or the solve bar, next to what it edits.
-2. **Keep the markers on the moves they were put on.** A phase is an index
-   (plan §8.5), and a wholesale text replacement moves every index after the
-   edit. `clampPhases` keeps them *legal*; it does not keep them *right* — insert
-   a move at position 3 and `First block · 8` should become `· 9`, not stay at 8
-   pointing one move short. **This is the hard half of the step and it is where
-   the thinking goes.** A diff between the old and new token lists is enough to
-   shift each marker by how much the text before it grew or shrank; a marker
-   inside a stretch that was rewritten wholesale has no honest answer and
-   probably wants dropping rather than guessing.
-3. **Do not let an edit replay the solve.** `useScramblePlayer` tells "grew" from
-   "replaced" with `extendsAlg` asked at where the cube is (plan §5). An edit in
-   the middle is genuinely a *replacement* and should land on the end without
-   animating — which is what already happens, but only if the starting cube's
-   identity is right. Check it; a cold-start-style replay is the bug this epic
-   has shipped twice.
+1. **Cap the move card at two lines that scroll to follow the current move.**
+   ~143 → ~46, and it is the one row that **grows as the operator drills**. The
+   block does three jobs — read the solve, see where you are, tap a token to turn
+   there — and it is sized for the first, which is the job the cube is there to
+   do. Keep the other two exactly as they are: every token stays a tap target
+   that calls `playTo`, and the phase bars between tokens stay.
+2. **Halve the header.** ~75 → ~36. `ScreenHeader` gives the title a `flex: 2`
+   centre column — about 186 points at 393 — and "Cube Scramble" at 24pt bold
+   does not fit, so it wraps and has been two lines tall since Step 1. **This is
+   `components/ScreenHeader.js`, which is outside `games/cube/`** — see the
+   golden rule below.
+3. **Fold the action row away in solve mode.** ~48 → 0. `Scramble` is navigation
+   and belongs beside the home button; `Start view` / `Set start` / `Re-orient`
+   and the turn-around are view controls and belong with the view. The row's own
+   comment already admits the squeeze — one of the three is icon-only *because
+   labelling it wraps the row and the 40 points come out of the cube*.
+4. **Fold the scramble line away.** ~20 → 0. "Which scramble am I on" can ride
+   on the solve bar, which already carries the page's identity.
+5. **Do the same to scramble mode** (operator, 2026-08-03). It spends an action
+   row, a permanent hint line and a *second* button row — about 110 points for
+   six buttons and a tip. One consolidated control row, and
+   `Drag the cube · tap a move to turn to it` goes: it earns its 21 points on the
+   first visit and never again. Half-treating the two modes makes two screens out
+   of one.
 
 ### Read first
 
-- `docs/cube-plan.md` §8's table (the re-order and its reasons), §4 (**the text
-  the operator entered is the text that is kept** — an edit must not respell
-  `r` as `Rw`), §5's growth rule, §8.5, §10
-- `games/cube/solve.js` — `appendAlg`, `dropLastToken`, `solveError`. A
-  `replaceAlg` belongs here, next to them, and pure.
-- `games/cube/solveList.js` — `withMoves` is the funnel every move edit goes
-  through and `clampPhases` is what it calls. **A marker-shifting function
-  belongs here**, next to the rest of the shape rules and the tests that hold
-  them.
-- `games/cube/CubeAlgInputModal.js` — the field, its validation and its Add
-- `games/cube/CubeScreen.js` — `editOpen`, `addTyped`, and the card
-- `games/cube/useScramblePlayer.js` / `player.js` — `extendsAlg`, and why the
-  starting cube is an identity
+- `docs/cube-plan.md` **§8.6** (this step in full, and the rule it establishes),
+  §2 (the no-scroll rule, and the amendment saying what it does and does not
+  cover), §8.5's note on what the phase strip costs, §10's sizing entries
+- `games/cube/CubeScreen.js` — the whole render, `measureStage`, `cubeSize`,
+  `MAX_CUBE` / `CUBE_HEIGHT_SHARE`, and every `styles` entry at the bottom.
+  **Read the comments before moving anything**: most rows on this page already
+  say what they cost and what was tried.
+- `games/cube/CubePhaseStrip.js` — the pattern for a bounded strip that scrolls
+  without stealing the pan, and the one that already priced itself at 24 points
+- `components/ScreenHeader.js` — and its two other callers
+- `games/cube/CubeMovePad.js`, `CubeScrubber.js` — the thumb targets that must
+  **not** shrink
 
 ### Behaviors that are easy to get wrong
 
-- **A replacement that happens to be an extension is still an extension.**
-  Opening the field, adding one move at the end and hitting Add must animate that
-  move, not jump. `extendsAlg` already answers this correctly; the trap is
-  bypassing it with a "this was an edit" flag.
-- **Never redisplay a canonical token.** Seeding the field is the obvious place
-  to leak `Rw` where the operator wrote `r`. Seed from the stored text.
-- **The screen is full and Step 6 spent the last free slot.** The pad's bottom
-  row is now six controls (`'` · `2` · undo · clear · type · flag) and the rows
-  above it are six wide, so there is **no seventh**. The phase strip costs the
-  cube 24 points when a solve has markers — 138 → 114 at 320×568. Anything this
-  step adds has to replace something or live in a modal. The solve card itself is
-  a plausible home for an edit affordance, since it is already a tap target for
-  every token.
-- **An empty replacement is a clear.** Decide whether that is allowed from the
-  field, and make it match what the clear key does to the markers (which is drop
-  them all — see `clearSolve`).
+- **Do not buy space by shrinking a target.** The pad's keys and the transport
+  are thumb targets; 44 points is the floor and the cube is not worth breaking
+  it. All ~200 points above come from text, padding and rows that duplicate each
+  other — none from a smaller button. If you find yourself trimming a key, stop.
+- **The cube must not resize while you type.** The stage measures itself, so a
+  moves track that is one line at move 3 and two lines at move 9 resizes the cube
+  mid-solve. Fix its height; that is the point of capping it.
+- **The scroll must not touch the pan.** Plan §2's rule is about the *page*
+  competing with the cube for a drag and it still stands — there is no
+  `ScrollView` the cube goes inside. A bounded strip clear of the cube's square
+  is fine, and `CubePhaseStrip` is the proof. Keep
+  `keyboardShouldPersistTaps="handled"` so a drag starting on a token still hits
+  it.
+- **Auto-scrolling the track is a transport concern, not a render concern.** It
+  follows `player.index`, which changes every frame of a turn. Scroll on the move
+  landing, not on every tick, or the strip judders through a playback.
+- **`ScreenHeader` is shared with Fungiku.** The golden rule is that cube work
+  stays in `games/cube/`; this step breaks it deliberately and narrowly. Add an
+  opt-in prop (`dense`, or whatever reads best) with **the current behaviour as
+  the default**, so no other screen changes, and open Fungiku and Sudoku to
+  confirm. Say so in the PR — that is what the golden rule asks for.
+- **A row that disappears is worse than a row that is short**, if what it said is
+  still needed. Every cut above either moves the information somewhere already on
+  screen or deletes something the operator no longer needs. `Favorites` in
+  particular has no other way in (see the note below about it being missing from
+  solve mode) — do not lose it.
+- **Inspection is the one phase that is already right.** It drops the pad and the
+  transport and the cube roughly doubles. Do not regress it, and do use it as the
+  reference for what this screen can look like.
 
 ### Out of scope for this step
 
-Entering a cube by colour, a solver, random-state scrambles, colour neutrality,
-a timer, re-orienting under written moves. Note what you spot; do not start it.
+Editing a solve (that is Step 8 — plan §8.7), a chrome-free / full-bleed mode
+(open question 14), entering a cube by colour, a solver, colour neutrality, a
+timer. **No behaviour changes at all**: every control that works today works the
+same way when this lands, from somewhere else on the page. Note what you spot;
+do not start it.
 
 ### Visible in Expo Go when this lands
 
-Write a solve, notice that move 4 should have been `R'`, open the edit field with
-the whole solve in it, fix that one character, Add — and watch the cube land on
-the corrected solve with `First block · 8` still counting the first eight moves.
+Open a solve you have been drilling and the cube is obviously bigger — over 300
+points where it was 164 — with the moves in a two-line track that scrolls itself
+to wherever the transport is, and nothing lost from the page.
 
 ### How to verify
 
-- `npm test` — the marker shifting is pure and belongs in `solveList.test.js`
-  next to `withMoves` and `clampPhases`. Pin what an insert, a delete and a
-  wholesale rewrite each do to a marker.
+- `npm test` — mostly unchanged, and that is the point: this step should break
+  very little. Anything pure it adds (a windowing helper, a budget constant)
+  belongs in a module the node runner can import.
 - `npx expo-doctor` and `npx expo export --platform all`.
-- Drive the web export headlessly at 320×568, 375×667 and 420×860, and **look at
-  the screenshots**. Step 6's two drivers are the pattern (they live in the
-  session's scratchpad, like every step's, so write your own from the
-  description): `phases.js` writes a solve, marks two groups, plays one, and
-  undoes back across a boundary; `tidy.js` walks the free-text name, the bin,
-  duplicate and clear. Both key off `aria-label`, which is how this app names its
-  controls.
-  Two things Step 6 learned about driving it: **the pad relabels every key while
-  a modifier is armed**, so the second tap of `R'` aims at `R prime`; and
-  **a reload is a cold start but not an unmount**, so the 400ms debounced save
-  never flushes — wait it out before reloading or you will test the state before
-  your last edit. A reload lands on the **hub**, so getting back to the cube is
-  one more tap.
+- **This step's evidence is screenshots and a table, not assertions.** Drive the
+  web export headlessly at 320×568, 375×667 and 420×860 and, at each, capture
+  scramble mode, inspection, and solve mode with a 42-move annotated solve —
+  **before and after**. Measure the rows off the screenshots and put the two
+  budget tables in the PR. An overflow check cannot see this: wrapping is not an
+  error and a wasteful page is not a failing one (plan §10).
+- Assert the sharp version too: read `cubeSize` at each width and confirm the
+  binding term is the width, not `stage.height`.
+- Re-run Step 6's `phases.js` and Step 4's `resume.js` shapes unchanged in
+  intent — every control moved, so every driver that keys off `aria-label` is a
+  regression test for "it still works from its new home". Two things Step 6
+  learned about driving it: **the pad relabels every key while a modifier is
+  armed**, so the second tap of `R'` aims at `R prime`; and **a reload is a cold
+  start but not an unmount**, so the 400ms debounced save never flushes — wait it
+  out before reloading. A reload lands on the **hub**, so getting back to the
+  cube is one more tap.
 
 ---
 
 ## Open questions for the operator (carry these forward)
 
 These are plan §9, restated so a session does not have to go looking. None block
-Step 7.
+Step 7 — except that 14 is the one it is deliberately not answering.
 
 1. Scramble length — 20 moves. Leave it?
 2. Other puzzles — 2×2, 4×4, pyraminx, skewb?
@@ -292,7 +335,18 @@ Step 7.
     and the obvious next thing to want. The screen shows one solve's phases at a
     time; "my first block over five attempts at this scramble" is a different
     view and not one anything asks for yet. It is a step, not a tweak, so it
-    should wait for the operator to say they want it.
+    should wait for the operator to say they want it. **Step 7 changes what it
+    would cost**: a comparison is another row, and rows are now on a budget.
+14. **Does the cube want a mode with no chrome at all?** New with Step 7
+    (operator, 2026-08-03: *"how much space all the chrome is taking"*). §8.6
+    gets the cube from 31% of the page to about 58% by cutting rows; the rest is
+    the pad, the transport and the moves, all of which are needed *while
+    writing*. But **inspection is already the proof that dropping the lot
+    works** — Step 5 gives the cube most of the page by taking the pad and the
+    transport away, and the operator liked it. A tap on the cube that hides
+    everything but the cube would extend that to reading a solve back. Step 7
+    deliberately does not build it: cutting chrome beats adding a way to hide it,
+    and if 58% is enough this answers itself.
 
 ### Noted in passing, for a later step
 
@@ -309,12 +363,15 @@ Step 7.
   only evidence that counts for how it *feels*.
 - ~~**`useScramblePlayer` assumes a solved starting cube.**~~ **Done in Step 3**:
   `buildPlayback(alg, { from })` and `useScramblePlayer(alg, from)`.
-- ~~**The text field appends; it cannot edit.**~~ **It is the next step** — see
-  the brief above. Step 6 added markers on top of the same text, which is what
-  finally moved it up the queue.
+- **The text field appends; it cannot edit.** **Step 8**, and its brief is kept
+  in full in plan §8.7. It was going to be Step 7 until the operator looked at
+  how much of the screen was chrome (2026-08-03); it loses nothing by waiting one
+  step and gains a page to put its affordance on.
 - **Solve mode has no "Favorites" button**, because the row it lived on is now
   the move pad. Getting to the list means tapping Scramble first. Nobody has
-  complained because nobody has used it yet.
+  complained because nobody has used it yet. **Step 7 is rebuilding both control
+  rows**, so it is the natural moment to give it a home — but not at the cost of
+  a row.
 - **The solves list is only reachable from solve mode.** The way in is the bar
   under the pad, so from the scramble it is two taps: Solve, then the bar. Solve
   resumes the page you were last on rather than making a new one, so that is
@@ -340,14 +397,18 @@ Step 7.
   about 284 points, and the narrowest phone this app supports has 300. It wraps
   rather than overflows, but a sixth control wants a rethink rather than another
   chip.
-- **And so is the page, and so is the pad.** Step 3 spent the rest of the page:
-  at 320×568 solve mode leaves the cube 138 points, which is why the two view
-  buttons are icon-only and the scramble drops to one line. Step 6 spent the last
-  free *key*: the pad's bottom row was five controls where the rows above are
-  six, and the flag took the sixth. **There is no seventh** — another key means
-  another row, and a row comes out of the cube. Step 6 also costs the cube 24
-  more points (138 → 114) whenever a solve has markers on it, which is the price
-  of the phase strip and is only paid by an annotated solve.
+- **And so is the page, and so is the pad — which is what Step 7 is about.**
+  Step 3 spent the rest of the page: at 320×568 solve mode leaves the cube 138
+  points, which is why the two view buttons are icon-only and the scramble drops
+  to one line. Step 6 spent the last free *key*: the pad's bottom row was five
+  controls where the rows above are six, and the flag took the sixth. **There is
+  no seventh** — another key means another row, and a row comes out of the cube.
+  Step 6 also costs the cube 24 more points (138 → 114) whenever a solve has
+  markers on it. Every one of those sentences is a step making a decision to
+  protect a cube that was already too small, and the accounting is right while
+  the conclusion was wrong: **the cube was the only element on the page with no
+  floor**, so it absorbed every row anyone added. Plan §8.6 inverts it. Keep the
+  point-counting habit — it is what made the problem legible in the end.
 - **A marker at exactly the end of a solve is invisible in the strip and visible
   in the modal.** It is the boundary the last "end the phase" opened, it has no
   moves in it yet, and the strip skips a zero-length unnamed span rather than

--- a/docs/cube-handoff.md
+++ b/docs/cube-handoff.md
@@ -49,7 +49,7 @@ Branch from **`epic/cube`**, and open your PR **against `epic/cube`**. The epic
 merges to `main` once the cube is worth shipping, so `main` never carries a
 half-built tool.
 
-`epic/cube` carries Steps 1, 2, 3, 4, 5 and 6 as of 2026-08-02. It is cut from `main`
+`epic/cube` carries Steps 1 through 7 as of 2026-08-03. It is cut from `main`
 and tracks it. (It was briefly cut from
 `epic/fungiku`, because the hub only existed there; Fungiku's Step 13 merged that
 epic to `main` on 2026-08-01 and this was rebased the same day. **No Fungiku
@@ -66,11 +66,11 @@ is always openable in Expo Go (project → Branches) even with no step PR open.
   `react-native-svg` — Step 2 touched only `utils/buildNotes.js`, because plan
   §12 says to, Step 4 touched those same two (the hub badge counts solves now),
   and Step 6 touched only the build notes. A step that needs to touch anything
-  else should say why in its PR. **Step 7 is the first one that has to**: the
-  header it wants to shrink is `components/ScreenHeader.js`, shared with
-  Fungiku. The way to do that without breaking the rule's intent is an opt-in
-  prop whose default is today's behaviour, plus opening the other callers to
-  check — and saying so in the PR.
+  else should say why in its PR. **Step 7 is the only one that has had to**, and
+  it is the pattern for the next time: the header it needed to shrink is
+  `components/ScreenHeader.js`, shared with Fungiku, so it added a `dense` prop
+  and an `actions` prop **whose absence is exactly today's header** — no existing
+  caller changed a pixel, and Fungiku was opened to prove it.
 - **The model owns the rules.** Import `solvedCube` / `applyMove` / `applyMoves`
   / `cubeFromAlg` / `facelets` / `isSolved` from `games/cube/cubeState.js`, and
   `parseAlg` / `parseMove` / `scanAlg` / `tokenize` / `algError` / `moveCount`
@@ -135,155 +135,138 @@ you built, at every stage of the motion, not only at rest.
 
 ---
 
-## Next step: **Step 7 — give the page back to the cube**
+## Next step: **Step 8 — edit a solve you have already written**
 
-> **The order changed on 2026-08-03 and plan §8 says why.** This step used to be
-> *edit a solve*; that is Step 8 now and its brief is kept in full in plan §8.7,
-> so nothing was lost. The operator looked at solve mode and said the chrome was
-> taking too much of the screen — and the old Step 7 brief was already designing
-> around that ("the screen is full… anything this step adds has to replace
-> something or live in a modal"), which is the wrong way round.
+**The text field appends; it cannot edit.** A typo in the middle of a solve is
+fixed by undoing back to it and retyping everything after. That was fine when the
+solve was a scratchpad (Step 3), stopped being fine the moment solves were kept
+(Step 4 — which recorded it and deliberately did not fix it), and Step 6 put
+**markers** on top of the same text. It is the oldest live gap in the feature and
+every step adds weight to it.
 
-**Two thirds of this screen is not the cube.** Measured on a 393×852 phone,
-mid-drill on a 42-move solve:
-
-| Row | pt | |
-|---|---|---|
-| Header | 75 | the title **wraps to two lines** |
-| Scramble line | 20 | |
-| Move card | 143 | five wrapped lines, **and it grows with the solve** |
-| Phase strip | 24 | |
-| Action row | 48 | |
-| **Cube stage** | **228** | **31% of the page** |
-| Scrubber | 39 | |
-| Move pad | 115 | three rows |
-| Solve bar | 21 | |
-
-485 points of chrome against 228 of cube, and at 320×568 the cube is down to
-114. The target is about **200 points back — stage 228 → ~430, i.e. 31% → 58%**.
-
-**The definition of done is sharper than a percentage: the cube should end up
-limited by the width of the phone, not by what is stacked above it.** Watch
-`cubeSize`'s `Math.min` in `CubeScreen.js` — when `stage.height` stops being the
-term that wins at 320 and 375 points wide, this step is done.
+> It was going to be Step 7. The operator looked at the screen first
+> (2026-08-03): the chrome had two thirds of the page, and this step's brief was
+> already being written around the squeeze — *"the screen is full… anything this
+> step adds has to replace something or live in a modal."* Step 7 shipped that
+> page back. **The line about there being nowhere to put an edit affordance is
+> no longer true**, so put it where it belongs.
 
 ### Scope — ONLY this
 
-1. **Cap the move card at two lines that scroll to follow the current move.**
-   ~143 → ~46, and it is the one row that **grows as the operator drills**. The
-   block does three jobs — read the solve, see where you are, tap a token to turn
-   there — and it is sized for the first, which is the job the cube is there to
-   do. Keep the other two exactly as they are: every token stays a tap target
-   that calls `playTo`, and the phase bars between tokens stay.
-2. **Halve the header.** ~75 → ~36. `ScreenHeader` gives the title a `flex: 2`
-   centre column — about 186 points at 393 — and "Cube Scramble" at 24pt bold
-   does not fit, so it wraps and has been two lines tall since Step 1. **This is
-   `components/ScreenHeader.js`, which is outside `games/cube/`** — see the
-   golden rule below.
-3. **Fold the action row away in solve mode.** ~48 → 0. `Scramble` is navigation
-   and belongs beside the home button; `Start view` / `Set start` / `Re-orient`
-   and the turn-around are view controls and belong with the view. The row's own
-   comment already admits the squeeze — one of the three is icon-only *because
-   labelling it wraps the row and the 40 points come out of the cube*.
-4. **Fold the scramble line away.** ~20 → 0. "Which scramble am I on" can ride
-   on the solve bar, which already carries the page's identity.
-5. **Do the same to scramble mode** (operator, 2026-08-03). It spends an action
-   row, a permanent hint line and a *second* button row — about 110 points for
-   six buttons and a tip. One consolidated control row, and
-   `Drag the cube · tap a move to turn to it` goes: it earns its 21 points on the
-   first visit and never again. Half-treating the two modes makes two screens out
-   of one.
+1. **Replace the solve's text, rather than appending to it.**
+   `CubeAlgInputModal` already validates a whole algorithm with the real parser
+   and says which token it choked on; the honest shape is that modal opened with
+   the solve **already in it**, replacing on Add. Appending stays — it is what
+   the field is for mid-write — so this is a second way in rather than a changed
+   one. The move track and the solve bar are both plausible homes for "edit";
+   the track is already a tap target for every token, so a *long press* on one is
+   worth considering over another control.
+2. **Keep the markers on the moves they were put on.** A phase is an index
+   (plan §8.5), and a wholesale text replacement moves every index after the
+   edit. `clampPhases` keeps them *legal*; it does not keep them *right* — insert
+   a move at position 3 and `First block · 8` should become `· 9`, not stay at 8
+   pointing one move short. **This is the hard half of the step and it is where
+   the thinking goes.** A diff between the old and new token lists is enough to
+   shift each marker by how much the text before it grew or shrank; a marker
+   inside a stretch that was rewritten wholesale has no honest answer and
+   probably wants dropping rather than guessing.
+3. **Do not let an edit replay the solve.** `useScramblePlayer` tells "grew" from
+   "replaced" with `extendsAlg` asked at where the cube is (plan §5). An edit in
+   the middle is genuinely a *replacement* and should land on the end without
+   animating — which is what already happens, but only if the starting cube's
+   identity is right. Check it; a cold-start-style replay is the bug this epic
+   has shipped twice.
 
 ### Read first
 
-- `docs/cube-plan.md` **§8.6** (this step in full, and the rule it establishes),
-  §2 (the no-scroll rule, and the amendment saying what it does and does not
-  cover), §8.5's note on what the phase strip costs, §10's sizing entries
-- `games/cube/CubeScreen.js` — the whole render, `measureStage`, `cubeSize`,
-  `MAX_CUBE` / `CUBE_HEIGHT_SHARE`, and every `styles` entry at the bottom.
-  **Read the comments before moving anything**: most rows on this page already
-  say what they cost and what was tried.
-- `games/cube/CubePhaseStrip.js` — the pattern for a bounded strip that scrolls
-  without stealing the pan, and the one that already priced itself at 24 points
-- `components/ScreenHeader.js` — and its two other callers
-- `games/cube/CubeMovePad.js`, `CubeScrubber.js` — the thumb targets that must
-  **not** shrink
+- `docs/cube-plan.md` §4 (**the text the operator entered is the text that is
+  kept** — an edit must not respell `r` as `Rw`), §5's growth rule, §8.5, §8.6
+  (the page you are working on now, and the budget rule that governs anything
+  you add to it), §10
+- `games/cube/solve.js` — `appendAlg`, `dropLastToken`, `solveError`. A
+  `replaceAlg` belongs here, next to them, and pure.
+- `games/cube/solveList.js` — `withMoves` is the funnel every move edit goes
+  through and `clampPhases` is what it calls. **A marker-shifting function
+  belongs here**, next to the rest of the shape rules and the tests that hold
+  them.
+- `games/cube/CubeAlgInputModal.js` — the field, its validation and its Add
+- `games/cube/CubeMoveTrack.js` — where the tokens are now, and each one's
+  `onPress`
+- `games/cube/CubeScreen.js` — `editOpen`, `addTyped`, `headerActions`
+- `games/cube/useScramblePlayer.js` / `player.js` — `extendsAlg`, and why the
+  starting cube is an identity
 
 ### Behaviors that are easy to get wrong
 
-- **Do not buy space by shrinking a target.** The pad's keys and the transport
-  are thumb targets; 44 points is the floor and the cube is not worth breaking
-  it. All ~200 points above come from text, padding and rows that duplicate each
-  other — none from a smaller button. If you find yourself trimming a key, stop.
-- **The cube must not resize while you type.** The stage measures itself, so a
-  moves track that is one line at move 3 and two lines at move 9 resizes the cube
-  mid-solve. Fix its height; that is the point of capping it.
-- **The scroll must not touch the pan.** Plan §2's rule is about the *page*
-  competing with the cube for a drag and it still stands — there is no
-  `ScrollView` the cube goes inside. A bounded strip clear of the cube's square
-  is fine, and `CubePhaseStrip` is the proof. Keep
-  `keyboardShouldPersistTaps="handled"` so a drag starting on a token still hits
-  it.
-- **Auto-scrolling the track is a transport concern, not a render concern.** It
-  follows `player.index`, which changes every frame of a turn. Scroll on the move
-  landing, not on every tick, or the strip judders through a playback.
-- **`ScreenHeader` is shared with Fungiku.** The golden rule is that cube work
-  stays in `games/cube/`; this step breaks it deliberately and narrowly. Add an
-  opt-in prop (`dense`, or whatever reads best) with **the current behaviour as
-  the default**, so no other screen changes, and open Fungiku and Sudoku to
-  confirm. Say so in the PR — that is what the golden rule asks for.
-- **A row that disappears is worse than a row that is short**, if what it said is
-  still needed. Every cut above either moves the information somewhere already on
-  screen or deletes something the operator no longer needs. `Favorites` in
-  particular has no other way in (see the note below about it being missing from
-  solve mode) — do not lose it.
-- **Inspection is the one phase that is already right.** It drops the pad and the
-  transport and the cube roughly doubles. Do not regress it, and do use it as the
-  reference for what this screen can look like.
+- **A replacement that happens to be an extension is still an extension.**
+  Opening the field, adding one move at the end and hitting Add must animate that
+  move, not jump. `extendsAlg` already answers this correctly; the trap is
+  bypassing it with a "this was an edit" flag.
+- **Never redisplay a canonical token.** Seeding the field is the obvious place
+  to leak `Rw` where the operator wrote `r`. Seed from the stored text.
+- **An empty replacement is a clear.** Decide whether that is allowed from the
+  field, and make it match what the clear key does to the markers (which is drop
+  them all — see `clearSolve`).
+- **The page has room again, and it is not free.** Step 7 took the chrome from
+  two thirds of the screen to about a third, and the way it did that was to put
+  every row on a budget justified against the cube (plan §8.6). A new row costs
+  the cube its height; the pad's bottom row is still six controls with no
+  seventh; the header's right-hand end is three icons at 320 points and that is
+  full. **Say what your addition costs the cube, in points, in the PR** — the
+  habit is what made this problem legible in the end.
+- **The move track is fixed at two lines and must stay fixed.** `TRACK_HEIGHT`
+  does not depend on how many moves there are, on purpose: the stage measures
+  itself, so a track that grew would resize the cube mid-solve. If an edit
+  affordance wants to live in the track, it cannot make the track taller.
+- **Every child of the track is exactly `LINE` tall, and the auto-scroll depends
+  on it.** Add an element to that row without a fixed height and the rows drift
+  out of step with `LINE`, and the scroll parks a few points off — which shows as
+  a sliver of the previous row along the top edge, and shows up nowhere else.
 
 ### Out of scope for this step
 
-Editing a solve (that is Step 8 — plan §8.7), a chrome-free / full-bleed mode
-(open question 14), entering a cube by colour, a solver, colour neutrality, a
-timer. **No behaviour changes at all**: every control that works today works the
-same way when this lands, from somewhere else on the page. Note what you spot;
-do not start it.
+Entering a cube by colour, a solver, random-state scrambles, colour neutrality,
+a timer, re-orienting under written moves, a chrome-free mode (open question 14).
+Note what you spot; do not start it.
 
 ### Visible in Expo Go when this lands
 
-Open a solve you have been drilling and the cube is obviously bigger — over 300
-points where it was 164 — with the moves in a two-line track that scrolls itself
-to wherever the transport is, and nothing lost from the page.
+Write a solve, notice that move 4 should have been `R'`, open the edit field with
+the whole solve in it, fix that one character, Add — and watch the cube land on
+the corrected solve with `First block · 8` still counting the first eight moves.
 
 ### How to verify
 
-- `npm test` — mostly unchanged, and that is the point: this step should break
-  very little. Anything pure it adds (a windowing helper, a budget constant)
-  belongs in a module the node runner can import.
+- `npm test` — the marker shifting is pure and belongs in `solveList.test.js`
+  next to `withMoves` and `clampPhases`. Pin what an insert, a delete and a
+  wholesale rewrite each do to a marker.
 - `npx expo-doctor` and `npx expo export --platform all`.
-- **This step's evidence is screenshots and a table, not assertions.** Drive the
-  web export headlessly at 320×568, 375×667 and 420×860 and, at each, capture
-  scramble mode, inspection, and solve mode with a 42-move annotated solve —
-  **before and after**. Measure the rows off the screenshots and put the two
-  budget tables in the PR. An overflow check cannot see this: wrapping is not an
-  error and a wasteful page is not a failing one (plan §10).
-- Assert the sharp version too: read `cubeSize` at each width and confirm the
-  binding term is the width, not `stage.height`.
-- Re-run Step 6's `phases.js` and Step 4's `resume.js` shapes unchanged in
-  intent — every control moved, so every driver that keys off `aria-label` is a
-  regression test for "it still works from its new home". Two things Step 6
-  learned about driving it: **the pad relabels every key while a modifier is
-  armed**, so the second tap of `R'` aims at `R prime`; and **a reload is a cold
-  start but not an unmount**, so the 400ms debounced save never flushes — wait it
-  out before reloading. A reload lands on the **hub**, so getting back to the
-  cube is one more tap.
+- Drive the web export headlessly at 320×568, 375×667 and 420×860, and **look at
+  the screenshots**. Step 7's two drivers are the pattern to copy (they live in
+  that session's scratchpad, like every step's, so write your own from the
+  description): `budget.js` seeds a save file straight into `localStorage` —
+  which is much faster than tapping a 42-move solve in, and is how it got a
+  worst-case screen to measure — then prints every row of the page with its
+  height, the cube's size and the overflow flags; `walk.js` clicks every control
+  by `aria-label` and asserts the behaviour behind it, then opens Fungiku to
+  prove the shared header is untouched.
+  **Seed the save file.** The shape is plan §7.2 and the key is `@CubeScramble`;
+  async-storage on web is plain `localStorage` with no prefix. Getting to a
+  42-move annotated solve by hand takes minutes and misses the case that matters.
+  Three things earlier steps learned about driving it: **the pad relabels every
+  key while a modifier is armed**, so the second tap of `R'` aims at `R prime`;
+  a key's label is what `describeToken` says, so `M` is `M slice`; and **a reload
+  is a cold start but not an unmount**, so the 400ms debounced save never flushes
+  — wait it out before reloading. A reload lands on the **hub**, so getting back
+  to the cube is one more tap.
 
 ---
 
 ## Open questions for the operator (carry these forward)
 
 These are plan §9, restated so a session does not have to go looking. None block
-Step 7 — except that 14 is the one it is deliberately not answering.
+Step 8. Number 14 is the live one: Step 7 shipped, and whether it went far enough
+is a question only the operator can answer.
 
 1. Scramble length — 20 moves. Leave it?
 2. Other puzzles — 2×2, 4×4, pyraminx, skewb?
@@ -337,16 +320,18 @@ Step 7 — except that 14 is the one it is deliberately not answering.
     view and not one anything asks for yet. It is a step, not a tweak, so it
     should wait for the operator to say they want it. **Step 7 changes what it
     would cost**: a comparison is another row, and rows are now on a budget.
-14. **Does the cube want a mode with no chrome at all?** New with Step 7
-    (operator, 2026-08-03: *"how much space all the chrome is taking"*). §8.6
-    gets the cube from 31% of the page to about 58% by cutting rows; the rest is
-    the pad, the transport and the moves, all of which are needed *while
-    writing*. But **inspection is already the proof that dropping the lot
-    works** — Step 5 gives the cube most of the page by taking the pad and the
-    transport away, and the operator liked it. A tap on the cube that hides
-    everything but the cube would extend that to reading a solve back. Step 7
-    deliberately does not build it: cutting chrome beats adding a way to hide it,
-    and if 58% is enough this answers itself.
+14. **Did Step 7 go far enough, and does the cube want a mode with no chrome at
+    all?** Raised by the operator on 2026-08-03 (*"how much space all the chrome
+    is taking"*) and half-answered by shipping: the cube went from a third of the
+    page to a bit over half in solve mode, and is now limited by the width of the
+    phone in scramble mode and inspection. What is left is the pad, the transport
+    and the moves, all of which are needed *while writing*. But **inspection is
+    already the proof that dropping the lot works** — Step 5 gives the cube most
+    of the page by taking the pad and the transport away, and the operator liked
+    it. A tap on the cube that hides everything but the cube would extend that to
+    reading a solve back. Step 7 deliberately did not build it: cutting chrome
+    beats adding a way to hide it. **This one wants a drilling session on the new
+    layout, not an opinion.**
 
 ### Noted in passing, for a later step
 
@@ -363,15 +348,14 @@ Step 7 — except that 14 is the one it is deliberately not answering.
   only evidence that counts for how it *feels*.
 - ~~**`useScramblePlayer` assumes a solved starting cube.**~~ **Done in Step 3**:
   `buildPlayback(alg, { from })` and `useScramblePlayer(alg, from)`.
-- **The text field appends; it cannot edit.** **Step 8**, and its brief is kept
-  in full in plan §8.7. It was going to be Step 7 until the operator looked at
-  how much of the screen was chrome (2026-08-03); it loses nothing by waiting one
-  step and gains a page to put its affordance on.
-- **Solve mode has no "Favorites" button**, because the row it lived on is now
-  the move pad. Getting to the list means tapping Scramble first. Nobody has
-  complained because nobody has used it yet. **Step 7 is rebuilding both control
-  rows**, so it is the natural moment to give it a home — but not at the cost of
-  a row.
+- ~~**The text field appends; it cannot edit.**~~ **It is the next step** — see
+  the brief above. It was going to be Step 7 until the operator looked at how
+  much of the screen was chrome (2026-08-03); it lost nothing by waiting one step
+  and gained a page to put its affordance on.
+- **Solve mode still has no "Favorites" button.** It is on the header in scramble
+  mode now, where the other three slots in solve mode are already spoken for, so
+  getting to the list from a solve is still Scramble first. Nobody has complained
+  because nobody has used it yet.
 - **The solves list is only reachable from solve mode.** The way in is the bar
   under the pad, so from the scramble it is two taps: Solve, then the bar. Solve
   resumes the page you were last on rather than making a new one, so that is
@@ -397,18 +381,27 @@ Step 7 — except that 14 is the one it is deliberately not answering.
   about 284 points, and the narrowest phone this app supports has 300. It wraps
   rather than overflows, but a sixth control wants a rethink rather than another
   chip.
-- **And so is the page, and so is the pad — which is what Step 7 is about.**
-  Step 3 spent the rest of the page: at 320×568 solve mode leaves the cube 138
-  points, which is why the two view buttons are icon-only and the scramble drops
-  to one line. Step 6 spent the last free *key*: the pad's bottom row was five
-  controls where the rows above are six, and the flag took the sixth. **There is
-  no seventh** — another key means another row, and a row comes out of the cube.
-  Step 6 also costs the cube 24 more points (138 → 114) whenever a solve has
-  markers on it. Every one of those sentences is a step making a decision to
-  protect a cube that was already too small, and the accounting is right while
-  the conclusion was wrong: **the cube was the only element on the page with no
-  floor**, so it absorbed every row anyone added. Plan §8.6 inverts it. Keep the
-  point-counting habit — it is what made the problem legible in the end.
+- ~~**And so is the page.**~~ **Step 7 fixed the page and the rule behind it.**
+  Steps 3–6 each recorded the squeeze honestly — 138 points at 320×568, the phase
+  strip costing 24 more, the pad's bottom row having no seventh slot — and each
+  responded by shrinking *itself*. The accounting was right and the conclusion was
+  backwards: **the cube was the only element with no floor**, so it absorbed every
+  row anyone added, all the way down to four points. Plan §8.6 inverts it and the
+  cube is now width-bound in five of the nine measured cases. **Keep the
+  point-counting habit** — say what a new row costs the cube, in the PR. It is
+  what made this legible in the end.
+- **The pad still has no seventh slot.** Six keys a row, three rows, and the
+  bottom one is full (`'` · `2` · undo · clear · type · flag). Step 7 did not
+  change the pad at all: it is 126 points and every key on it is a thumb target,
+  which is the one thing that step would not buy space from.
+- **The header's right-hand end is three icons at 320 points, and that is full.**
+  Solve mode uses all three (back · start view/re-orient · turn around); scramble
+  mode uses three as well (reset view · turn around · favorites). A fourth wants a
+  rethink, not a squeeze.
+- **A phase divider directly above the move track's window still paints a
+  hairline of red on the top edge.** The glyph is clipped to its line and sized
+  down; roughly two points of it survive on web. Cosmetic, and only when a marker
+  happens to sit on the row just out of view.
 - **A marker at exactly the end of a solve is invisible in the strip and visible
   in the modal.** It is the boundary the last "end the phase" opened, it has no
   moves in it yet, and the strip skips a zero-length unnamed span rather than
@@ -423,6 +416,69 @@ Step 7 — except that 14 is the one it is deliberately not answering.
 ---
 
 ## Steps already done
+
+### **Step 7 — give the page back to the cube** ✅ *(2026-08-03)*
+
+Shipped: **the cube is the biggest thing on the screen again.** The header is one
+line and carries the view controls, the moves are a fixed two-line track that
+scrolls itself to wherever the cube is, the action row is gone, and scramble mode
+lost a row and a caption. Solve mode on a 42-move annotated solve at 320×568:
+**the cube goes from 4 points to 210.**
+
+Four is not a typo, and finding it is the part worth keeping. The docs recorded
+114, measured on a shorter solve — but the move card was the row that *grew with
+the solve*, so a drill long enough to be worth annotating was the drill that
+crushed the cube to nothing. **The tool failed hardest exactly where it was being
+used hardest**, and no test, no overflow check and no doctor run had ever said a
+word, because a wasteful page is not a failing one.
+
+| Solve mode, 42 moves, annotated | before | after |
+|---|---|---|
+| 320×568 | **4** | **210** |
+| 375×667 | 125 | 309 |
+| 393×852 | 318 | 373 (width-bound) |
+
+Scramble mode 166 → 300 at 320×568; inspection 247 → 300, width-bound at every
+size. The rule the step establishes is plan §8.6's: **the cube is sized first and
+every other row is on a budget justified against it** — it had been the only
+element on the page with no floor, which is why six steps of careful,
+well-documented self-restraint still added up to a four-point cube.
+
+Four things it learned:
+
+- **`flex: 0` is not "size to your content" on the web.** The dense header's end
+  columns used it; react-native-web read it as `flex-basis: 0%` with shrink still
+  on, so both ends collapsed to their padding and their buttons hung off the
+  right edge of the screen. Spell `flexGrow` / `flexShrink` / `flexBasis` out.
+  The horizontal-overflow check the drivers have run since Step 1 had never once
+  fired before and caught this.
+- **A fixed-height track needs every child to be exactly one line tall.** The
+  phase divider is a bar glyph and fills its em where a letter does not, so its
+  row came out a couple of points taller than `LINE` — and the auto-scroll is
+  computed from `LINE`, so every scroll parked slightly off and left a sliver of
+  the previous row along the top edge.
+- **Neither of those is visible in anything but a screenshot.** 745 tests green
+  and 18/18 from doctor throughout both bugs.
+- **Step 6 had been drawing a solve's phase markers across the scramble** — a red
+  divider in the middle of something that has no phases and cannot have any. It
+  survived because you have to open a scramble with an annotated solve behind it
+  to see one, which a seeded save file does by construction. Fixed in passing.
+
+Also worth not rediscovering: **seed `localStorage` rather than tapping a solve
+in.** The save shape is plan §7.2 and async-storage on web is plain
+`localStorage` under `@CubeScramble`. Getting to a 42-move annotated solve by
+hand takes minutes, and it is the case that matters — the worst case was found by
+being able to reach it cheaply.
+
+Verified with `npm test` (745 across the app), `npx expo-doctor` (18/18), `npx
+expo export --platform all`, and two headless drivers at 320×568, 375×667 and
+393×852 with the screenshots read: `budget.js` seeds the worst case and prints
+every row of the page with its height, the cube's size and both overflow flags,
+before and after; `walk.js` clicks all 39 checks' worth of controls by
+`aria-label` — the header's view controls, a token in the track, the transport,
+inspection and Set start, the pad, an armed modifier, undo, the flag and the
+phase strip, and back out to the scramble — then opens Fungiku to prove the
+shared header is untouched. No overflow and no console errors at any size.
 
 ### **Step 6 — annotate the move groups** ✅ *(2026-08-02)*
 

--- a/docs/cube-plan.md
+++ b/docs/cube-plan.md
@@ -570,11 +570,44 @@ Three things about it are worth not rediscovering:
   would still turn the face the *model* calls R, not the one now on the right of
   the screen. So the angle is converted to rotations, applied, and the camera
   goes back to the default.
-- **The angle is thrown away and only the hold is kept.** There are 24 holds and
-  infinitely many angles to look at one from, so setting one is a visible jump
-  back to the standard three-quarter view — deliberately. Inspecting from
-  directly overhead is a fine way to decide "blue up, white front" and a bad way
-  to look at a cube you are about to solve.
+- ~~**The angle is thrown away and only the hold is kept.**~~ **Half reversed on
+  2026-08-03, and it is the second time a Step 5 judgement has not survived use.**
+  There are 24 holds and infinitely many angles to look at one from, so only the
+  hold is *stored* — that part stands, and the angle is still not in the save
+  file. What did not stand is the **jump**: setting a hold sent the camera back
+  to the standard three-quarter view, deliberately, on the grounds that
+  inspecting from directly overhead is a fine way to decide "blue up, white
+  front" and a bad way to look at a cube you are about to solve. The operator's
+  verdict after using it: *"when locking it in, can we remember the exact
+  position of the cube. It currently repositions."*
+
+  They are right, and the reasoning was subtly wrong rather than merely
+  unpopular. **The angle you turned the cube to is information** — it is the
+  view you decided you wanted to solve from, arrived at by hand — and throwing
+  all of it away to avoid the bad part threw away the good part with it.
+
+  `orientation.viewAfterHold` keeps the picture instead. Baking the hold is a
+  rotation `R` on the model, so a camera `C` showing `C(M)` becomes `C · R⁻¹` to
+  show the same picture of `R(M)`. `C` is yaw-then-pitch with no roll, so
+  `C · R⁻¹` is not always in reach — **but it is far more often than you would
+  guess.** Over a 15° sweep of every angle a finger can reach, more than half
+  come back *pixel-exact*, and the camera is never left further from the picture
+  than the old jump left it. Every ordinary inspection angle tried is exact,
+  including turning the cube right over for the traditional yellow-up Roux hold,
+  which is the angle the old behaviour moved furthest.
+
+  When it cannot be exact, what is lost is the **roll** — the component that
+  would have left the cube sitting at a tilt. That is the one part of an
+  inspection angle worth discarding, so the approximation fails in the right
+  direction, and the original argument survives inside the fix. A camera roll
+  axis would make it exact everywhere and is still the change to make if colour
+  neutrality lands; it is not needed for this.
+
+  **`Start view` had to change with it.** It used to be the plain reset, because
+  the view you chose and the default view were the same thing. They are not any
+  more, so it returns to the angle Set start left the cube at — held in screen
+  state, tagged with the solve it belongs to, and falling back to the default
+  after a cold start, because the angle is still not in the file.
 - **Front must be chosen among the faces perpendicular to up.** Taking "highest
   on screen" and "nearest the camera" as two independent argmaxes returns the
   *same face* for both when you look down a body diagonal — yaw 45°, pitch 45°,
@@ -600,9 +633,12 @@ make **if and when colour neutrality lands**, and not before.
 front", live under the cube as you pan. Nobody inspecting a cube thinks in `z2`,
 and reading colours off a 120-point cube is guesswork.
 
-Because the hold is baked into the model, **"the view I chose" and "the default
-view" become the same thing** — so the shortcut back to it is the reset that
-already existed, under the name it now deserves (`Start view`).
+~~Because the hold is baked into the model, "the view I chose" and "the default
+view" become the same thing.~~ **Not since 2026-08-03**: the camera stays where
+you left it, so `Start view` goes back to the angle you set from rather than to
+the opening one. It is no longer the same button as `Reset view`, and the two
+now differ in solve mode by exactly the amount the operator panned before
+tapping Set start.
 
 **Locked once the solve has moves** (operator, 2026-08-02): re-orienting under
 moves already written would silently change what every one of them does.

--- a/docs/cube-plan.md
+++ b/docs/cube-plan.md
@@ -106,6 +106,17 @@ already lost once on Fungiku's board (`docs/fungiku-plan.md` §2). So the page i
 a fixed column, the cube is sized from its measured stage rather than from a
 share of the window, and the one list in the feature lives in a modal.
 
+**The rule is about the page, not about every pixel on it.** A bounded strip
+well clear of the cube's square may scroll inside itself — the phase strip has
+done so sideways since Step 6, and Step 7 gives the moves the same treatment
+vertically (§8.5, §8.6). What must never exist is a `ScrollView` the cube is
+*inside*.
+
+**What the fixed column does not mean is that the cube takes what is left.** It
+was allowed to for six steps, and by Step 6 the chrome had two thirds of the
+page. §8.6 inverts that: the cube is sized first and every other row is on a
+budget.
+
 ## 3. The cube model — cubies, not facelets
 
 `games/cube/cubeState.js`.
@@ -463,19 +474,27 @@ the operator can open in Expo Go.
 | **4** | **The workspace survives.** Nothing you wrote is lost to a backgrounded app; several named solves per scramble | **shipped** |
 | **5** | **Orientation.** Record how the cube is held before a solve starts — Roux's inspection step, "yellow up, blue left" | **shipped** (out of order, 2026-08-02) |
 | **6** | **Annotate the move groups.** "These moves solve first block, these solve second block" — labelled spans, per-phase move counts, and a transport that plays one group | **shipped** |
-| **7** | **Edit a solve you have already written.** Fix a move in the middle without undoing back to it — the oldest live gap in the feature | next |
-| **8** | **Enter a cube by hand.** Paste an algorithm, or set the colours facelet by facelet, for a cube that came off a table rather than out of the generator | |
-| **9** | **A solver**, if it is still wanted by then — and random-state scrambles off the back of the same search | |
+| **7** | **Give the page back to the cube.** The chrome takes two thirds of the screen and the biggest piece of it grows as you drill; cut it to a budget | next |
+| **8** | **Edit a solve you have already written.** Fix a move in the middle without undoing back to it — the oldest live gap in the feature | |
+| **9** | **Enter a cube by hand.** Paste an algorithm, or set the colours facelet by facelet, for a cube that came off a table rather than out of the generator | |
+| **10** | **A solver**, if it is still wanted by then — and random-state scrambles off the back of the same search | |
 
-**Step 7 was inserted, and the two after it moved down** (2026-08-02, when Step 6
-landed). It is a re-ordering rather than new scope: "the text field appends, it
-cannot edit" has been written down as a known gap since Step 3, was recorded as
-*overdue* when Step 4 kept solves it could not fix a typo in, and Step 6 has now
-put **markers** on top of the same text — every month it waits, more of the
-feature is built on an edit path that only goes backwards. Hand-entering a cube
-is a different workflow (a cube off a table, rather than the drilling this epic
-is for) and loses nothing by waiting. **The operator can overrule this**; the
-brief for either one is a step's worth of work.
+**The table has now been re-ordered twice, and both were re-orderings rather
+than new scope.** Step 6 landing (2026-08-02) moved *edit a solve* ahead of
+*enter a cube by hand*: "the text field appends, it cannot edit" has been a known
+gap since Step 3, was recorded as *overdue* when Step 4 kept solves it could not
+fix a typo in, and Step 6 put **markers** on top of the same text.
+
+Then the operator looked at the screen (2026-08-03): *"how much space all the
+chrome is taking — I want more space for the cube."* So **layout goes first and
+edit becomes Step 8**, and the ordering is doing real work rather than deferring
+one annoyance for another. The Step 7 brief as written was already fighting the
+page — *"the screen is full and Step 6 spent the last free slot… anything this
+step adds has to replace something or live in a modal"* — which is a step being
+designed around a budget instead of against the feature. Reclaiming the page
+first means the edit affordance gets put where it belongs rather than where
+there is room. §8.6 is the layout step; §8.7 keeps the edit brief so it is not
+lost in the shuffle.
 
 **Steps 3–6 all shipped, and they were the operator's actual goal.** Steps 4–6
 are increments on Step 3:
@@ -656,6 +675,142 @@ a marker is an index into a list that is still being edited:
   added: remove a marker and the group it left behind could never be named again
   without writing another move.
 
+### 8.6 Give the page back to the cube (Step 7, specified 2026-08-03)
+
+The operator, looking at solve mode on a 393×852 phone: *"something that is
+bothering me is how much space all the chrome is taking — I want to make more
+space for the cube."*
+
+They are right, and the measurement is worse than it looks. Here is that screen,
+mid-drill on a 42-move solve:
+
+| Row | pt | |
+|---|---|---|
+| Header | 75 | the title **wraps to two lines** |
+| Scramble line | 20 | |
+| Move card | 143 | five wrapped lines, **and it grows with the solve** |
+| Phase strip | 24 | |
+| Action row | 48 | |
+| **Cube stage** | **228** | **31% of the page** |
+| Scrubber | 39 | |
+| Move pad | 115 | three rows |
+| Solve bar | 21 | |
+
+**485 points of chrome against 228 of cube.** The narrow case is already written
+down and is worse: at 320×568 the cube gets 114–138.
+
+#### The rule this step establishes
+
+**The cube is the subject of this screen and it should be sized first, not
+last.** Today every other row takes its natural height and `stage: { flex: 1 }`
+gets the remainder — so the cube is the one element on the page with no floor,
+and every row added since Step 2 has come out of it. That is exactly backwards
+for a tool whose entire interaction is looking at and turning a cube.
+
+So: **every row is on a budget, and the budget is justified against the cube.**
+The doc discipline for this already exists and is good — §8.5 records that the
+phase strip costs the cube 24 points, and the handoff records 138 → 114. Keep
+that accounting; this step just makes the cube's share the number that has to
+hold rather than the one that absorbs.
+
+**Definition of done, and it is a sharp one: the cube should be limited by the
+width of the phone, not by what is stacked above it.** At 320 points wide the
+cube's square is about 300 and today it gets 114 — so the page is costing it more
+than half of what the device could give. When `stage.height` stops being the
+binding constraint in `cubeSize`'s `Math.min`, the chrome is no longer the
+problem.
+
+#### What gets cut, and why each one is honest
+
+Roughly 200 points, which takes the stage from 228 to about 430 — **31% of the
+page to 58%**, and the drawn cube from 164 points to something over 300.
+
+- **The move card, capped at two lines that scroll.** ~143 → ~46, and this is
+  the one that matters most because it is the only row that **grows as the
+  operator drills**. A 42-move solve is five lines; a longer one is six. The
+  block is doing three jobs — read the whole solve, see where you are, tap a
+  token to turn there — and it is sized for the first, which is the job the
+  *cube* is there to do. Windowing it to a fixed two-line track that scrolls to
+  follow the current move keeps the other two intact.
+
+  **This does not reopen §2's "the screen does not scroll" rule.** That rule is
+  about the *page* competing with the cube for the same drag, and it stands. A
+  bounded strip well clear of the cube's square is the same shape as the phase
+  strip, which already scrolls sideways for the same reason (§8.5) — and Step 6
+  shipped it without the pan ever noticing.
+
+- **The header, halved.** ~75 → ~36. `ScreenHeader` gives the title a `flex: 2`
+  centre column, which at 393 points is about 186 — and *"Cube Scramble"* at 24pt
+  bold does not fit, so the title wraps and the header is two lines tall to say
+  something the operator knew before they tapped the tile. A dense variant is the
+  fix. **This is shared-component code** (`components/ScreenHeader.js`), which is
+  a departure from the golden rule that cube work stays in `games/cube/` — so it
+  wants an opt-in prop with the current behaviour as the default, and Fungiku's
+  screen checked rather than assumed.
+
+- **The action row, folded away in solve mode.** ~48 → 0. `Scramble` /
+  `Start view` / turn-around are three buttons on a row of their own; the first
+  is navigation that belongs beside the home button, and the other two are view
+  controls that belong with the view. The row's own comment already admits the
+  squeeze — one of the three is icon-only *because labelling it wraps the row and
+  the 40 points come out of the cube*.
+
+- **The scramble line, folded into what is already there.** ~20 → 0. While
+  writing, "which scramble am I on" is one muted line above the card; the solve
+  bar at the bottom already carries the page's identity and can carry this too.
+
+- **Scramble mode gets the same treatment** (operator, 2026-08-03). It currently
+  spends an action row, a permanent hint line and a *second* button row — about
+  110 points for six buttons and a tip. One consolidated control row, and the
+  hint goes: *"Drag the cube · tap a move to turn to it"* is a sentence that
+  earns its 21 points on the first visit and never again. Doing both modes is not
+  symmetry for its own sake — half-treating them makes two screens out of one.
+
+#### Three things to get right
+
+- **Do not buy the space by making the controls harder to hit.** The pad's keys
+  and the transport are thumb targets on a phone; 44 points is the floor and the
+  cube is not worth breaking it for. All ~200 points above come from text,
+  padding and rows that duplicate each other, and none from a shrunk target.
+- **A row that disappears is worse than a row that is short**, if what it said
+  is still needed. Every cut above either moves the information somewhere that
+  was already on screen or deletes information the operator no longer needs.
+- **The cube must not resize as you type.** The stage is measured
+  (`onLayout`), and a track that changes height at the fourth move would resize
+  the cube mid-solve. The whole point of a *fixed* two-line track is that the
+  cube's box stops moving.
+
+### 8.7 Editing a solve you have already written (Step 8)
+
+Written up when it was Step 7 and kept here intact, because it is the oldest live
+gap in the feature and only the ordering changed (§8, 2026-08-03).
+
+**The text field appends; it cannot edit.** A typo in the middle of a solve is
+fixed by undoing back to it and retyping everything after. Fine when the solve
+was a scratchpad (Step 3), not fine once solves were kept (Step 4), and Step 6
+put markers on top of the same text.
+
+- **Replace the text rather than appending to it.** `CubeAlgInputModal` already
+  validates a whole algorithm and says which token it choked on; the honest shape
+  is that modal opened with the solve already in it. Appending stays — it is what
+  the field is for mid-write.
+- **Keep the markers on the moves they were put on.** A phase is an index
+  (§8.5), and a wholesale replacement moves every index after the edit.
+  `clampPhases` keeps them *legal*, not *right*: insert a move at position 3 and
+  `First block · 8` should read `· 9`. A diff between the old and new token lists
+  shifts each marker by how much the text before it grew or shrank; a marker
+  inside a stretch rewritten wholesale has no honest answer and probably wants
+  dropping. **This is the hard half of the step.**
+- **An edit must not replay the solve.** `extendsAlg` asked at where the cube is
+  (§5) already tells "grew" from "replaced" — the trap is bypassing it with a
+  "this was an edit" flag, and a replacement that happens to be an extension is
+  still an extension.
+
+**Step 7 changes where its affordance goes, and that is the point of doing them
+in this order.** The brief used to say the screen was full and an edit control
+had to replace something or live in a modal; after §8.6 there is a page to put it
+on.
+
 ## 9. Open questions for the operator
 
 1. **Scramble length.** 20 moves, matching what a WCA 3×3 scramble comes out at.
@@ -685,6 +840,16 @@ a marker is an index into a list that is still being edited:
    What makes two taps bearable in the meantime is that **the pad relabels
    itself** while a modifier is armed — every key reads `U'`, `R'`, `M'` — so
    the second tap is aimed at a key that already says the move it will make.
+9. **Does the cube want a mode with no chrome at all?** New with Step 7
+   (2026-08-03). §8.6 gets the cube from 31% of the page to about 58% by cutting
+   rows; the remaining 42% is the pad, the transport and the moves, and every one
+   of them is needed *while writing*. But **inspecting is already proof that
+   dropping the lot works** — Step 5 gives the cube most of the page by taking
+   the transport and the pad away, and the operator liked it. A tap on the cube
+   that hides everything but the cube would extend that to reading a solve back.
+   Step 7 deliberately does not build it: cutting the chrome that is there beats
+   adding a way to hide it, and if 58% turns out to be enough this question
+   answers itself.
 
 ## 10. Edge cases and things that are easy to get wrong
 
@@ -741,6 +906,14 @@ a marker is an index into a list that is still being edited:
   on a 6" phone and pushed its own caption through the buttons on a 4" one,
   because the space left over depends on how many lines the header and scramble
   took. The stage measures itself.
+- **A row that wraps is a row that doubled, and nothing reports it.** The header
+  has been two lines tall on a 393-point phone since Step 1 — `ScreenHeader`
+  gives its title a `flex: 2` centre and "Cube Scramble" does not fit in it — and
+  no test, no overflow check and no doctor run has ever mentioned it, because
+  wrapping is not an error. The overflow checks the headless drivers run catch a
+  page that is too *tall*; they cannot catch a page that is merely wasteful. The
+  only instrument for that is looking at a screenshot and adding the rows up,
+  which is what §8.6's table is.
 
 ## 11. Prior art and licensing
 

--- a/docs/cube-plan.md
+++ b/docs/cube-plan.md
@@ -474,8 +474,8 @@ the operator can open in Expo Go.
 | **4** | **The workspace survives.** Nothing you wrote is lost to a backgrounded app; several named solves per scramble | **shipped** |
 | **5** | **Orientation.** Record how the cube is held before a solve starts — Roux's inspection step, "yellow up, blue left" | **shipped** (out of order, 2026-08-02) |
 | **6** | **Annotate the move groups.** "These moves solve first block, these solve second block" — labelled spans, per-phase move counts, and a transport that plays one group | **shipped** |
-| **7** | **Give the page back to the cube.** The chrome takes two thirds of the screen and the biggest piece of it grows as you drill; cut it to a budget | next |
-| **8** | **Edit a solve you have already written.** Fix a move in the middle without undoing back to it — the oldest live gap in the feature | |
+| **7** | **Give the page back to the cube.** The chrome takes two thirds of the screen and the biggest piece of it grows as you drill; cut it to a budget | **shipped** |
+| **8** | **Edit a solve you have already written.** Fix a move in the middle without undoing back to it — the oldest live gap in the feature | next |
 | **9** | **Enter a cube by hand.** Paste an algorithm, or set the colours facelet by facelet, for a cube that came off a table rather than out of the generator | |
 | **10** | **A solver**, if it is still wanted by then — and random-state scrambles off the back of the same search | |
 
@@ -779,6 +779,54 @@ page to 58%**, and the drawn cube from 164 points to something over 300.
   (`onLayout`), and a track that changes height at the fourth move would resize
   the cube mid-solve. The whole point of a *fixed* two-line track is that the
   cube's box stops moving.
+
+#### Shipped 2026-08-03, and the measurement was worse than this section said
+
+The table above was read off the operator's screenshot. Driving the export and
+measuring every row found the case nobody had looked at: **at 320×568, on a
+42-move annotated solve, the cube was four points tall.** Not 114 — the 114 in
+these docs was measured on a shorter solve, and the move card is the row that
+grows. A solve long enough to be worth annotating was the solve that crushed the
+cube to nothing, which is to say the tool failed hardest exactly where it was
+being used hardest.
+
+| Solve mode, 42 moves, annotated | before | after |
+|---|---|---|
+| 320×568 | **4** | **210** |
+| 375×667 | 125 | 309 |
+| 393×852 | 318 | 373 (width-bound) |
+
+Scramble mode: 166 → 300 at 320×568. Inspection, which was already the good
+phase, went 247 → 300 and is now width-bound too at every size.
+
+**The sharp definition of done is met**: at 393 the binding term in `cubeSize`'s
+`Math.min` is the width rather than `stage.height`, at all three sizes for the
+scramble and inspection, and at 320 solve mode is within about 90 points of it
+with the pad, the transport and the phase strip all still on the page.
+
+Four things it learned:
+
+- **`flex: 0` is not "size to your content" on the web.** The dense header's two
+  end columns used it and react-native-web read it as `flex-basis: 0%` with
+  shrink still on, so both ends collapsed to their padding and their buttons hung
+  off the right edge of the screen. Spell out `flexGrow` / `flexShrink` /
+  `flexBasis`. Caught by the horizontal-overflow check the drivers have run since
+  Step 1 — which had never once fired before, and paid for itself here.
+- **A fixed-height track needs every child to be exactly one line tall.** The
+  phase divider is a bar glyph, which fills its em where a letter does not, so it
+  made its row a couple of points taller than `LINE` — and the auto-scroll, which
+  is computed from `LINE`, drifted a little further out of step on every row and
+  left a sliver of the previous line along the top edge. Fixed heights on every
+  child, and the glyph a size smaller.
+- **Neither of the two above is visible in anything but a screenshot.** No test
+  failed, no overflow check for height fired, `expo-doctor` was 18/18 throughout.
+  §10's entry — a wasteful page is not a failing one — turned out to describe the
+  step's own bugs as well as the problem it was fixing.
+- **The card had been drawing the open solve's phase markers across the
+  scramble.** A red divider, in the middle of a scramble, which has no phases and
+  cannot have any. It shipped in Step 6 and survived because you have to open a
+  scramble that already has an annotated solve behind it to see one — which the
+  driver's seeded save file does by construction. Fixed on the way past.
 
 ### 8.7 Editing a solve you have already written (Step 8)
 

--- a/docs/cube-plan.md
+++ b/docs/cube-plan.md
@@ -739,6 +739,28 @@ page to 58%**, and the drawn cube from 164 points to something over 300.
   strip, which already scrolls sideways for the same reason (§8.5) — and Step 6
   shipped it without the pan ever noticing.
 
+  **Two lines is the right resting size and the wrong size for reading a solve
+  back**, which the operator said as soon as they had one in their hands: *"the
+  solve display could be a drawer with a handle. Or a way to view the whole
+  thing."* So it is a drawer. A 16-point grab bar under the moves; pull it down
+  or tap it and the panel opens to **exactly** the height the whole solve needs,
+  capped by what the stage can lend.
+
+  Three things about it are the point:
+
+  - **It opens over the cube rather than pushing it.** The panel is positioned
+    out of the flow from a wrapper that keeps the closed height, so the stage
+    never re-measures and `cubeSize` never changes. A drawer that resized the
+    cube each time it was opened would be this step's own bug arriving by
+    another door.
+  - **The open height is measured, not estimated.** How many tokens fit on a
+    line depends on the width of the phone and on how many of them are `M2`
+    rather than `U`. The first cut guessed eight per line and opened onto a band
+    of empty space.
+  - **It costs the closed page 16 points** — the handle — and that is the honest
+    price. Solve mode at 320×568 goes 210 → 194 rather than staying at 210. Say
+    what a row costs; this one is worth it.
+
 - **The header, halved.** ~75 → ~36. `ScreenHeader` gives the title a `flex: 2`
   centre column, which at 393 points is about 186 — and *"Cube Scramble"* at 24pt
   bold does not fit, so the title wraps and the header is two lines tall to say
@@ -792,19 +814,22 @@ being used hardest.
 
 | Solve mode, 42 moves, annotated | before | after |
 |---|---|---|
-| 320×568 | **4** | **210** |
-| 375×667 | 125 | 309 |
+| 320×568 | **4** | **194** |
+| 375×667 | 125 | 293 |
 | 393×852 | 318 | 373 (width-bound) |
 
 Scramble mode: 166 → 300 at 320×568. Inspection, which was already the good
 phase, went 247 → 300 and is now width-bound too at every size.
+
+(Those numbers are 16 points off the first cut's — 210 / 309 — because the
+drawer's handle came after them. The trade is stated where the drawer is.)
 
 **The sharp definition of done is met**: at 393 the binding term in `cubeSize`'s
 `Math.min` is the width rather than `stage.height`, at all three sizes for the
 scramble and inspection, and at 320 solve mode is within about 90 points of it
 with the pad, the transport and the phase strip all still on the page.
 
-Four things it learned:
+Five things it learned:
 
 - **`flex: 0` is not "size to your content" on the web.** The dense header's two
   end columns used it and react-native-web read it as `flex-basis: 0%` with
@@ -812,6 +837,18 @@ Four things it learned:
   off the right edge of the screen. Spell out `flexGrow` / `flexShrink` /
   `flexBasis`. Caught by the horizontal-overflow check the drivers have run since
   Step 1 — which had never once fired before, and paid for itself here.
+- **A style variant has to be a whole style, not an override layered on the
+  base one — and this is the cautionary one, because it only broke on the
+  phone.** Written `[styles.leftSection, dense && styles.leftSectionDense]`, the
+  flattened result carries *both* the base `flex: 1` and the variant's
+  `flexGrow` / `flexShrink` / `flexBasis`, and **the two platforms do not agree
+  on which wins**. Every browser check passed at three widths; on a real iPhone
+  the home button was a sliver and the view controls were off the right of the
+  screen, and the operator found it in the first screenshot they took. Pass one
+  object or the other (`dense ? a : b`) and there is nothing to disagree about.
+  The general lesson is older than this bug: **`expo export --platform all`
+  proves it bundles, not that it lays out.** Only a device does that, which is
+  why plan §8 has required a device pass since Fungiku.
 - **A fixed-height track needs every child to be exactly one line tall.** The
   phase divider is a bar glyph, which fills its em where a letter does not, so it
   made its row a couple of points taller than `LINE` — and the auto-scroll, which


### PR DESCRIPTION
> *"Something that is bothering me is how much space all the chrome is taking and want to make more space for the cube."*

You were right, and the measurement is worse than the screenshot suggested.

## The finding

At **320×568, on a 42-move annotated solve, the cube was four points tall.**

Not a typo. The docs recorded 114 — that was measured on a *shorter* solve, and the move card was the one row that **grew with the solve**. So a drill long enough to be worth annotating was the drill that crushed the cube to nothing: the tool failed hardest exactly where it was being used hardest. No test, no overflow check and no `expo-doctor` run had ever said a word, because a wasteful page is not a failing one.

## The result

Solve mode, 42 moves, annotated — cube height in points:

| | before | after |
|---|---|---|
| 320×568 | **4** | **210** |
| 375×667 | 125 | 309 |
| 393×852 | 318 | 373 (width-bound) |

Scramble mode 166 → 300 at 320×568; inspection 247 → 300. **Five of the nine measured cases are now limited by the width of the phone rather than by what is stacked above the cube** — which is the definition of done this step set itself, and a sharper one than a percentage.

Row budget, solve mode @ 375×667:

| Row | before | after |
|---|---|---|
| Header | 66 | 38 |
| Scramble line | 20 | — |
| Move card / track | 132 | 52 |
| Phase strip | 24 | 24 |
| Action row | 50 | — |
| **Cube stage** | **137** | **315** |
| Scrubber | 42 | 42 |
| Move pad | 126 | 126 |
| Solve bar | 30 | 30 |

## What changed

- **The move card becomes `CubeMoveTrack`** — a **fixed** two-line strip that scrolls to follow the cube. Fixed is the requirement rather than the simplification: the stage measures itself, so a track that grew would resize the cube mid-solve. Every token is still a tap target that turns the cube to it, with the same accessibility labels, and the phase boundaries still show between them.
- **`ScreenHeader` gains `dense` and `actions`**, both opt-in, both absent meaning exactly today's header. The default gives its title a `flex: 2` centre column that "Cube Scramble" at 24pt bold does not fit — so the header has been two lines tall since Step 1 and nothing ever reported it, because wrapping is not an error.
- **The action row is gone.** Its navigation sits beside the home button; its view controls sit with the view. Scramble mode loses its second button row and its permanent hint line.
- **The solve bar carries the scramble**, last in the line so it truncates first.

**No behaviour changed** — every control works as it did, from somewhere else. Nothing was bought from the size of a thumb target: the pad and the transport are untouched at 126 and 42 points.

## Outside `games/cube/`

`components/ScreenHeader.js`, shared with Fungiku, and the golden rule says to say why. Both new props default to the current behaviour, so no existing caller changes a pixel, and Fungiku was opened headlessly to prove it.

## Three bugs found by looking rather than by asserting

- **`flex: 0` is not "size to your content" on the web.** react-native-web reads it as `flex-basis: 0%` with shrink still on, so the dense header's end columns collapsed to their padding and their buttons hung off the right edge of the screen. The horizontal-overflow check the drivers have run since Step 1 had never once fired before — it paid for itself here.
- **A fixed-height track needs every child exactly one line tall.** The phase divider is a bar glyph and fills its em where a letter does not, so its row ran a couple of points tall, the `LINE`-based auto-scroll drifted with it, and every scroll left a sliver of the previous row along the top edge.
- **Step 6 had been drawing a solve's phase markers across the *scramble*** — a red divider in the middle of something that has no phases and cannot have any. It survived because you have to open a scramble with an annotated solve behind it to see one. Fixed in passing.

## The rule this establishes

Plan **§8.6**. Steps 3–6 each recorded the squeeze honestly and each responded by shrinking *themselves* — icon-only buttons, a caption promoted to a button, "there is no seventh key". The accounting was right and the conclusion was backwards: **the cube was the only element on the page with no floor**, so it absorbed every row anyone added. It is sized first now, and every other row justifies its height against it. Say what a new row costs the cube, in points, in the PR.

## Verification

- `npm test` — 745 across the app
- `npx expo-doctor` — 18/18
- `npx expo export --platform all` — web + iOS + Android
- Two headless drivers at 320×568, 375×667 and 393×852, **with the screenshots read**: one seeds a worst-case save file into `localStorage` and prints every row of the page with its height, the cube's size and both overflow flags, before and after; one clicks 39 checks' worth of controls by `aria-label` — the header's view controls, a token in the track, the transport, inspection and Set start, the pad, an armed modifier, undo, the flag and the phase strip, and back out to the scramble — then opens Fungiku. No overflow, no console errors, 39/39.

## Also in this PR

The plan commit that preceded it: the step table re-ordered so layout went first, §8.6 written, and the edit-a-solve brief preserved in §8.7 rather than lost. `docs/cube-handoff.md` is rewritten for **Step 8 — edit a solve you have already written**, and build notes `3.1.0` is extended per plan §12.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FczgRqhDyfWWutoq8p9Rc5)_