### PR TITLE
Lengthen the prime hold from 180ms to 300ms

### DIFF
--- a/SudokuApp/games/cube/CubeMovePad.js
+++ b/SudokuApp/games/cube/CubeMovePad.js
@@ -38,7 +38,7 @@ const REPEAT_AFTER_MS = 400;
  *
  * ### Two routes to a prime, because a finger hides one of them
  *
- * **Hold a key** past 180ms, or **tap `′` and then the key**. Tap it a second
+ * **Hold a key** past `HOLD_MS`, or **tap `′` and then the key**. Tap it a second
  * time and the `R` you just wrote becomes `R2`. Every rule about what a press
  * *means* is `applyPadPress`, in `solve.js`, where it can be tested.
  *

--- a/SudokuApp/games/cube/__tests__/solve.test.js
+++ b/SudokuApp/games/cube/__tests__/solve.test.js
@@ -8,6 +8,8 @@
 
 import {
   HOLD_MS,
+  HOLD_MS_MAX,
+  HOLD_MS_MIN,
   PAD_COLUMNS,
   PAD_KEYS,
   PAD_LAYOUT,
@@ -137,6 +139,17 @@ describe('the hold', () => {
   it('never draws past either end', () => {
     expect(holdProgress(-100)).toBe(0);
     expect(holdProgress(HOLD_MS * 10)).toBe(1);
+  });
+
+  it('is long enough that an ordinary tap is not a prime', () => {
+    // The threshold went 180 → 300 because 180 was tripping on taps meant as
+    // plain turns (operator, 2026-08-06), and a false prime turns the cube the
+    // wrong way. 250ms is a slow-but-ordinary tap; it must still read as a tap.
+    expect(isHold(250)).toBe(false);
+    // And it stays inside the range the design sanctioned, so a setting built on
+    // HOLD_MS_MIN/MAX can still reach it.
+    expect(HOLD_MS).toBeGreaterThanOrEqual(HOLD_MS_MIN);
+    expect(HOLD_MS).toBeLessThanOrEqual(HOLD_MS_MAX);
   });
 });
 

--- a/SudokuApp/games/cube/solve.js
+++ b/SudokuApp/games/cube/solve.js
@@ -85,12 +85,20 @@ export const PAD_ROWS = 3;
 /**
  * How long a key must be held before it means a prime (plan §8.8).
  *
- * 180ms is short enough that a deliberate prime does not feel like waiting and
- * long enough that fast typing never trips it. The design shipped it
- * configurable across 120–320 and those bounds are kept here so a setting has
- * somewhere to clamp to.
+ * **180ms was too short in use** (operator, 2026-08-06): *"I'm getting a lot of
+ * prime moves when I want a regular turn."* This is handoff open question 8's
+ * remaining half — whether the threshold is right — answered by drilling on it,
+ * and it fails in the one direction that matters. A tap that reads as a prime
+ * turns the cube **the wrong way** and costs an undo; a prime that needs another
+ * 120ms of thumb costs nothing but the wait. So the threshold moves to the far
+ * end of the design's range rather than splitting the difference.
+ *
+ * 300ms is where the platforms already put a long press (RN's `delayLongPress`
+ * defaults to 500), so a hold that reads as deliberate anywhere else on a phone
+ * reads as deliberate here. The design shipped the threshold configurable across
+ * 120–320 and those bounds are kept, so this stays inside what was designed.
  */
-export const HOLD_MS = 180;
+export const HOLD_MS = 300;
 
 /** The range the threshold may be tuned across, if it is ever exposed. */
 export const HOLD_MS_MIN = 120;

--- a/docs/cube-handoff.md
+++ b/docs/cube-handoff.md
@@ -258,9 +258,8 @@ These are plan §9, restated so a session does not have to go looking. None bloc
 Step 9. **Number 14 is the live one and Step 8 sharpened it into a number**: the
 new pad and scrubber cost the cube 71 points at 320 and 375, and whether that is
 the right trade is a question only the operator can answer by drilling on it.
-Number 8 is now answered *and shipped*, but the part of it that wants use — is
-180ms the right threshold, does a hold read as natural under a thumb — is asked
-in the same session.
+Number 8 is now answered *and shipped*, including the part of it that wanted
+use: the threshold was drilled on and moved from 180ms to 300ms.
 
 1. Scramble length — 20 moves. Leave it?
 2. Other puzzles — 2×2, 4×4, pyraminx, skewb?
@@ -287,13 +286,16 @@ in the same session.
     thumb's contact patch, and a mis-hit there turns the cube **the wrong way**
     rather than doing nothing.
 
-    **What is left is use, not design.** The gesture has been driven as a timed
-    gesture at three widths and behaves. Whether **180ms** is right, and whether
-    a hold feels natural under a thumb mid-drill, only a real session says —
-    `HOLD_MS` is one constant in `solve.js` with the design's 120–320 range
-    recorded beside it. The fallback if the hold tests badly is written down and
-    is a standalone `'` key, which would cost the pad a rethink rather than a
-    slot, because the cross has no spare cell.
+    **The threshold half is now answered too** (operator, 2026-08-06): 180ms was
+    too short under a real thumb — *"I'm getting a lot of prime moves when I want
+    a regular turn"* — and `HOLD_MS` is **300**, the far end of the design's
+    120–320 range. The asymmetry decided it: a tap misread as a prime turns the
+    cube the wrong way and costs an undo, while a prime that waits another 120ms
+    costs only the wait. The fallback if the hold still tests badly is written
+    down and is a standalone `'` key, which would cost the pad a rethink rather
+    than a slot, because the cross has no spare cell — but with a second route to
+    a prime already shipped (the armed `′`), the hold no longer has to carry the
+    gesture alone.
 9. **Colour neutrality** — raised and deferred by the operator on 2026-08-01
    ("we're not gonna get into that right now"). Solves assume you pick a top and
    a left colour and hold it that way. **It now has a concrete cost attached**:


### PR DESCRIPTION
## The complaint

> It's a little too short and I'm getting a lot of prime moves when I want a regular turn.

The hold-for-prime gesture shipped in Step 8 at 180ms, and the handoff's open question 8 explicitly left *the threshold itself* to be settled by real use rather than by driving it as a timed gesture in a browser. Use has now settled it: taps meant as plain turns are crossing 180ms and coming back as primes.

## Why 300 and not 220

The failure is asymmetric, and that is what picks the number rather than splitting the difference:

- A **tap misread as a prime** turns the cube the wrong way. You notice, you undo, you re-enter.
- A **prime that needs another 120ms of thumb** costs the wait and nothing else.

So the threshold goes to the far end of the design's sanctioned 120–320 range instead of nudging and re-testing. 300ms is also where the platforms already put a long press — React Native's `delayLongPress` defaults to 500 — so a hold that reads as deliberate elsewhere on a phone reads as deliberate here.

## What actually changed

One constant, `HOLD_MS` in `games/cube/solve.js`. The hairline fill animation, the arm timer that fires the haptic, and the touch-up check all read it, so the visual feedback stretches with the threshold and stays truthful — the fill still starts at 0ms and still completes exactly when the gesture arms. Nothing about the pad's layout, tints, or the second-tap promotion moves.

The armed `′` key is untouched and remains the route for anyone who does not want to hold at all, which is why raising the hold is a safe direction to be wrong in: there is a second way to write a prime.

- `solve.js` — `HOLD_MS` 180 → 300, with the reasoning recorded beside it. `HOLD_MS_MIN`/`HOLD_MS_MAX` unchanged; 300 stays inside them so a future setting can still reach it.
- `CubeMovePad.js` — the header prose said "past 180ms"; it now names the constant so it cannot go stale again.
- `docs/cube-handoff.md` — open question 8's remaining half is marked answered, with the date and the asymmetry that decided it.
- `solve.test.js` — a guard that a slow-but-ordinary 250ms tap is still a tap, and that the threshold stays within the designed range.

## Testing

`npx jest` — 834 tests across 24 suites, all passing. The change is one number, so what wants checking is the thing tests cannot check: whether 300ms now reads as a deliberate hold under a thumb mid-drill, and whether the fill taking a little longer to cross the key reads as feedback or as lag. If 300 overshoots, the same constant walks back to 250 with no other edits.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCTe9UuRzyA736bQDdEo6q)_