### PR TITLE
Replan the epic: table the editor, outsource the optimizer, add the architecture review

### DIFF
--- a/docs/cube-handoff.md
+++ b/docs/cube-handoff.md
@@ -136,117 +136,107 @@ you built, at every stage of the motion, not only at rest.
 
 ---
 
-## Next step: **Step 9 — edit a solve you have already written**
+## Next step: **Step 9 — compare your attempts**
 
 > **Branch from `epic/cube`, PR against `epic/cube`** — as every step does.
-> Step 8 merged on 2026-08-05, so the epic has the pad, the scrubber and the
-> palette this step sits next to.
+> Step 8 merged on 2026-08-05 and the hold threshold moved to 300ms on
+> 2026-08-06, so the epic has the pad, the scrubber and the palette this step
+> sits next to.
 
-**The text field appends; it cannot edit.** A typo in the middle of a solve is
-fixed by undoing back to it and retyping everything after. Fine when the solve
-was a scratchpad (Step 3), not fine once solves were kept (Step 4), and Step 6
-put **markers** on top of the same text — so an edit now has to move them
-honestly as well.
+**Read `docs/cube-plan.md` §8.9 before anything else.** On 2026-08-06 the
+operator tabled the solve editor and outsourced the optimizer to an API, and
+this step exists *because of* that decision rather than beside it. A session that
+picks up the old Step 9 brief will build the wrong thing.
 
-This is **the oldest live gap in the feature**. It has been re-ordered twice and
-gained something both times: Step 7 gave it a page to sit on, and Step 8's design
-bundle decided where its affordance goes. What is left is the marker arithmetic,
-which is where the difficulty always was.
+**The question this screen cannot answer is "am I getting better at this
+scramble?"** Step 6 made every phase count knowable and Step 8 put them on the
+page — one solve at a time, so `First block · 8` is a fact with nothing to
+compare it against. If you improve a block by **re-attempting** it rather than by
+editing it — which is what §8.9 decided — then this is the step that closes the
+loop.
 
 ### Read first
 
-- **`docs/cube-plan.md` §8.7** — the brief, and it is the whole of it. Then §8.5
-  (what a phase is, and why markers rather than ranges), §5 (`extendsAlg`, and
-  why "the algorithm changed" is two events), §10.
-- `games/cube/CubeAlgInputModal.js` — it already validates a whole algorithm and
-  names the token it choked on. The honest shape of this step is **that modal,
-  opened with the solve already in it**.
-- `games/cube/solveList.js` — `withMoves` and `clampPhases`. This step's new
-  function belongs beside them, and has to be the *only* implementation of its
-  rule (see the golden rules above).
-- `games/cube/solve.js` — `appendAlg`, which stays: it is what the field is for
-  mid-write.
+- **`docs/cube-plan.md` §8.9** — why the editor is tabled and the optimizer is
+  outsourced. Then **§8.10**, which is this step's brief and the whole of it.
+  Then §8.5 (what a phase is, and why markers rather than ranges) and §8.6 (the
+  height budget, and the rule about saying what a row costs).
+- `games/cube/solveList.js` — `solvesFor`, `phaseSpans`, `describePhaseSpan`,
+  `duplicateSolve`. **Everything this step displays is already computed here.**
+  If you find yourself writing a second way to count a phase, stop.
+- The solves list as Step 8 left it — the most likely home for this, and the
+  version of the step that costs the solve screen nothing.
 
 ### Scope — ONLY this
 
-1. **Replace the text rather than appending to it.** The modal opens with the
-   solve in it, edits it, and the result replaces the solve's moves. Appending
-   stays, because a CMLL alg dropped into the middle of a write is what the field
-   was built for — so the modal needs to be able to do both and to say which it
-   is about to do.
-2. **Keep the markers on the moves they were put on.** A phase is an index into
-   the move list (§8.5), so a wholesale replacement moves every index after the
-   edit. `clampPhases` keeps them *legal*, not *right*: insert a move at position
-   3 and `First block · 8` should read `· 9`. A diff between the old and new
-   token lists shifts each marker by how much the text before it grew or shrank.
-   **This is the hard half of the step and the reason it is a step.**
-3. **A marker inside a stretch rewritten wholesale has no honest answer.** It
-   probably wants dropping, the way undo drops one rather than clamping it — but
-   say which you chose and why, because it is a judgement call and the next
-   session should not have to re-derive it.
+1. **Show the solves for one scramble with their phase counts beside each
+   other.** Nothing new is computed; it is arranged. `solvesFor` gives the list,
+   `phaseSpans` gives the phases and counts.
+2. **Compare by phase name, not by position.** Solve 1's second span and Solve
+   3's second span line up only if they are both `Second block`. This is the
+   step's one real piece of thinking — the arrangement is a join on a label, and
+   solves annotated with different methods, or with free-text names, or with
+   nothing at all, all have to land somewhere honest.
+3. **A solve with no markers has nothing to line up.** Say so plainly rather than
+   guessing; an unannotated solve is a legitimate thing to have written and it
+   should not be made to look like a bad one.
+4. **Mark the best; do not average.** Which attempt has the shortest first block
+   is the question being asked. A mean over four attempts where one was abandoned
+   half-way is a number that lies.
 
-### Where the affordance goes — **decide this before you build**
+### Where it lives — **decide this before you build**
 
-The design bundle put an `Edit` link on the **solve card's caption row**, 10pt
-weight 600 in the accent, opposite `Solve 2 · 21 moves`. That decision was made
-against a screen that no longer exists: **Step 7 removed the solve card**, and
-Step 8 kept it removed. So the design has settled the *shape* of the affordance
-and not its home, and the honest candidates are:
+- **The solves list.** It is already the per-scramble list of solves, it is
+  already where solve-level operations moved in Step 8, and columns added to a
+  list that exists is the cheapest version of this step. **Most likely right**,
+  and it costs the solve screen zero points, which is most of the argument.
+- **A separate screen.** Reach for this only if the list genuinely cannot hold
+  it — say what stopped it, in the PR.
 
-- **The drawer handle row** under the move track. It is 16pt of grab bar with
-  nothing at either end, it is attached to the moves being edited, and it is
-  already a control. Most likely right.
-- **The solves list**, next to Clear, which moved there in Step 8. Consistent —
-  it is where solve-level operations now live — but it is two taps from the
-  moves and it is the wrong altitude: this edits *the text*, not *the page*.
-- **A long-press on a token in the track.** Cheapest in points and least
-  discoverable; the track's tap is already spoken for by "turn the cube to here".
-
-Say which you picked and why in the PR. Do not add a header slot: the header's
-right-hand end is three icons at 320 points and it is full.
+Do not add a row to the solve screen for this. §8.6's budget is the standing rule
+and Step 8 already spent 71 points of cube; a comparison is not what buys the
+next row.
 
 ### Behaviors that are easy to get wrong
 
-- **An edit must not replay the solve.** `extendsAlg` asked at *where the cube
-  is* (plan §5) already tells "grew" from "replaced". **The trap is bypassing it
-  with a "this was an edit" flag** — a replacement that happens to be an
-  extension is still an extension, and should animate like one.
-- **One rule, one function.** Whatever shifts the markers is the only thing that
-  shifts them, and it goes through `withMoves` like every other edit to a solve's
-  moves. Two implementations of one rule is how "it survived the reload but not
-  the undo" gets shipped — Step 6 has the scar.
-- **The promotion has to be disarmed by an edit.** Step 8 added `armPromotion`,
-  and every path that changes the moves out from under the pad already calls it
-  with `null`. A new one that does not would leave a `2` on a key pointing at a
-  token the edit replaced. `promoteLastToken` refuses on a mismatched last token,
-  so this is a cosmetic bug rather than a corrupting one — but it is a bug.
-- **The modal is validated by the same parser twice.** Do not add a third path.
+- **One rule, one function.** The counts on this screen must come from
+  `phaseSpans` and nothing else. Two implementations of "how long is first block"
+  is how the comparison ends up disagreeing with the solve screen it is
+  comparing.
+- **A phase at the end of a solve with no moves in it** is a real boundary that
+  the strip already skips and the modal already lists (see the notes below).
+  Decide what a zero-length span does *here* and say which you chose.
+- **`MAX_SOLVES` is 100 and culling is by creation date.** A comparison view is
+  the first thing that makes an old solve worth keeping, so if this step makes
+  the cap feel real, say so — do not quietly change it.
+- **Do not suggest a better solve.** Displaying the ones written is this step;
+  proposing a shorter one is the API's job and is not being built (§8.9).
 
 ### Out of scope for this step
 
-Entering a cube by colour (Step 10), a solver (Step 11), colour neutrality,
-a timer, the CFOP switch, and the chrome-free mode (open question 14). Note what
-you spot; do not start it.
+Editing a solve (tabled — §8.9), an optimizer or solver of any kind (outsourced —
+§8.9, and that includes a placeholder button or a client stub), entering a cube
+by colour (Step 10), comparing across *different* scrambles, a timer, colour
+neutrality, and the chrome-free mode (open question 14). Note what you spot; do
+not start it.
 
 ### Visible in Expo Go when this lands
 
-Open a solve with a typo three moves in, fix that one move, and watch the phase
-counts stay right — `First block · 8` still reading 8 if the edit was inside it
-and reading 9 if the edit added a move to it. Nothing replays.
+Write three solves at one scramble with first blocks of 8, 7 and 6 moves, open
+the list, and read the improvement down a column.
 
 ### How to verify
 
-- `npm test` — the marker arithmetic is pure and belongs in `solveList.js`'s
-  tests next to `clampPhases`. Pin: an edit before a marker shifts it; an edit
-  after it does not; an edit that grows a phase grows its count; a marker inside
-  a rewritten stretch does whatever you decided, deliberately.
+- `npm test` — whatever joins spans across solves is pure and belongs in
+  `solveList.js`'s tests. Pin: solves with the same phase names line up; a solve
+  with no phases does whatever you decided, deliberately; the best is the
+  minimum and not the first; two solves annotated with different methods do not
+  produce a nonsense column.
 - `npx expo-doctor` (expect 18/18) and `npx expo export --platform all`.
 - **Drive it and look at the screenshots**, at 320×568, 375×667 and 393×852.
-  Step 8's five drivers are described in its entry below and are worth
-  re-creating: `budget.mjs` prints the row-by-row height table, and this step
-  **must not move those numbers** — say so with the table.
-- **Sample the position label across the edit** to prove nothing replays, the way
-  Step 4's `resume.js` did.
+  `budget.mjs` prints the row-by-row height table and **this step must not move
+  those numbers** — say so with the table. If it lands in the solves list that
+  should be trivially true, which is the point.
 - **Then look at it on a device.** Step 7 shipped a header that passed every
   browser check at three widths and was broken on a phone.
 
@@ -255,11 +245,18 @@ and reading 9 if the edit added a move to it. Nothing replays.
 ## Open questions for the operator (carry these forward)
 
 These are plan §9, restated so a session does not have to go looking. None block
-Step 9. **Number 14 is the live one and Step 8 sharpened it into a number**: the
-new pad and scrubber cost the cube 71 points at 320 and 375, and whether that is
-the right trade is a question only the operator can answer by drilling on it.
-Number 8 is now answered *and shipped*, including the part of it that wanted
-use: the threshold was drilled on and moved from 180ms to 300ms.
+Step 9. **Number 13 stopped being a question on 2026-08-06 and became the step
+itself** — see the brief above. **Number 14 is the live one and Step 8 sharpened
+it into a number**: the new pad and scrubber cost the cube 71 points at 320 and
+375, and whether that is the right trade is a question only the operator can
+answer by drilling on it. Number 8 is now answered *and shipped*, including the
+part of it that wanted use: the threshold was drilled on and moved from 180ms to
+300ms.
+
+**What is left in the epic after Step 9** is Step 10 (enter a cube by hand) and
+these questions. Two rows left the table on 2026-08-06 rather than moving down
+it — the editor is tabled and the optimizer is outsourced — so the backlog is
+genuinely shorter than it was, not rearranged. Plan §8.9.
 
 1. Scramble length — 20 moves. Leave it?
 2. Other puzzles — 2×2, 4×4, pyraminx, skewb?
@@ -267,7 +264,9 @@ use: the threshold was drilled on and moved from 180ms to 300ms.
 4. Colour scheme — a setting, or is the standard one enough?
 5. ~~Where a solve comes from.~~ **Answered, and it replanned the epic**
    (operator, 2026-08-01): solves are **written by the operator**, not computed.
-   See plan §8.1.
+   See plan §8.1. **Fully closed on 2026-08-06** — the part that *is* wanted
+   eventually, optimize a phase I already wrote, is **outsourced to an API** and
+   is not this repo's code (plan §8.9).
 6. Drag direction — currently "push the surface under your finger".
 7. ~~Turn speed.~~ **Answered** (operator, 2026-08-01): a speed control, and it
    is in — a chip cycling 1× → 2× → 0.5×, scaling the beat between moves as well
@@ -319,12 +318,15 @@ use: the threshold was drilled on and moved from 180ms to 300ms.
     that wants one real drilling session, not an opinion. **Step 6 gives it a
     concrete candidate**: `First block · 8` is now known, and it is the number
     the operator said they were trying to improve.
-13. **Whether the counts are worth comparing across solves** — new with Step 6,
-    and the obvious next thing to want. The screen shows one solve's phases at a
-    time; "my first block over five attempts at this scramble" is a different
-    view and not one anything asks for yet. It is a step, not a tweak, so it
-    should wait for the operator to say they want it. **Step 7 changes what it
-    would cost**: a comparison is another row, and rows are now on a budget.
+13. ~~**Whether the counts are worth comparing across solves.**~~ **Answered, and
+    it is now Step 9** (2026-08-06). It was filed with Step 6 as "the obvious
+    next thing to want" and parked because nothing had asked for it — and then
+    **tabling the editor asked for it.** If a better first block comes from
+    re-attempting rather than editing (plan §8.9), the loop does not close until
+    the attempts sit next to each other. Plan §8.10 is the brief; the note under
+    Step 7 still applies and is now a constraint on *where* it goes rather than
+    whether it happens: a comparison is another row, rows are on a budget, so it
+    belongs in the solves list where it costs the solve screen nothing.
 14. **Did Step 7 go far enough, and does the cube want a mode with no chrome at
     all?** Raised by the operator on 2026-08-03 (*"how much space all the chrome
     is taking"*) and half-answered by shipping: the cube went from a third of the
@@ -363,11 +365,27 @@ use: the threshold was drilled on and moved from 180ms to 300ms.
   only evidence that counts for how it *feels*.
 - ~~**`useScramblePlayer` assumes a solved starting cube.**~~ **Done in Step 3**:
   `buildPlayback(alg, { from })` and `useScramblePlayer(alg, from)`.
-- **The text field appends; it cannot edit.** **Step 9, and it is the brief
-  above.** Plan §8.7 keeps the detail. Note that the design bundle put its `Edit`
-  link on **the solve card's caption row** — a row Step 7 removed and Step 8 kept
-  removed — so the design settled the *shape* of the affordance and not its home.
-  The brief above lists the three honest candidates.
+- **The text field appends; it cannot edit.** **Tabled on 2026-08-06 — plan §8.9
+  is the reasoning and it is a decision, not a backlog entry.** The short version:
+  the brief was covering two jobs, *fix a typo* and *improve a block*, and only
+  the first is a text edit. Improving a block changes the cube every later move
+  is applied to, so the marker arithmetic that was the hard half of the step
+  would have carefully preserved annotations that had stopped being true. The
+  second job is the optimizer's and the optimizer is an API. **If it comes back
+  it comes back small** — `CubeAlgInputModal` opened with the solve in it,
+  `clampPhases` for the markers, no diff arithmetic — and the affordance
+  candidates are still listed in plan §8.7, which is kept intact.
+- **There is no solver in this repo and there is not going to be one.**
+  Outsourced to an API on 2026-08-06 (plan §8.9). This is here because a search
+  is the single most tempting thing to helpfully start writing, and because the
+  epic's argument for the cubie model over cubing.js was precisely not shipping
+  pruning tables. **Nothing is being built for it** — no client, no protocol, no
+  placeholder. Random-state scrambles went with it (plan §6): the generator stays
+  random-move and the fallback plumbing does not get written before there is
+  something to fall back from. When it is real, the shape is *annotate an
+  existing solve* — a phase already has a start, an end and a cube state at its
+  start, so "optimize this phase" is a request the data model can already
+  describe.
 - **Solve mode still has no "Favorites" button.** It is on the header in scramble
   mode now, where the other three slots in solve mode are already spoken for, so
   getting to the list from a solve is still Scramble first. Nobody has complained
@@ -483,7 +501,8 @@ use: the threshold was drilled on and moved from 180ms to 300ms.
   other way"*. Plan §8.8 has what it would have cost, including the part that
   decided it: a prime became hold **plus a slide**, where it is now just a hold.
   Do not re-propose it as an obvious win; it was tried.
-- **The phase counts are per solve and nothing compares them.** Open question 13.
+- **The phase counts are per solve and nothing compares them.** **This is now
+  Step 9** — the brief at the top of this file.
 - **Half turns animate clockwise.** `shortWay(2)` is 2, not −2; both land in the
   same place and nothing prefers one. If a solve tutorial ever wants `R2` to go
   the way a particular fingertrick goes, that is the line to change.

--- a/docs/cube-handoff.md
+++ b/docs/cube-handoff.md
@@ -216,9 +216,10 @@ next row.
 
 Editing a solve (tabled — §8.9), an optimizer or solver of any kind (outsourced —
 §8.9, and that includes a placeholder button or a client stub), entering a cube
-by colour (Step 10), comparing across *different* scrambles, a timer, colour
+by colour (now Step 11), comparing across *different* scrambles, a timer, colour
 neutrality, and the chrome-free mode (open question 14). Note what you spot; do
-not start it.
+not start it — **and note it well**: Step 10 is an architecture review, and what
+you spot while building is exactly what it wants to read.
 
 ### Visible in Expo Go when this lands
 
@@ -253,10 +254,21 @@ answer by drilling on it. Number 8 is now answered *and shipped*, including the
 part of it that wanted use: the threshold was drilled on and moved from 180ms to
 300ms.
 
-**What is left in the epic after Step 9** is Step 10 (enter a cube by hand) and
-these questions. Two rows left the table on 2026-08-06 rather than moving down
-it — the editor is tabled and the optimizer is outsourced — so the backlog is
-genuinely shorter than it was, not rearranged. Plan §8.9.
+**What is left in the epic after Step 9** is **Step 10 — the architecture review
+and the merge decision** (plan §8.11, added 2026-08-06), then Step 11 (enter a
+cube by hand), then these questions. Two rows also left the table on 2026-08-06
+rather than moving down it — the editor is tabled and the optimizer is
+outsourced — so the backlog is genuinely shorter than it was, not rearranged.
+Plan §8.9.
+
+**Step 10 is the odd one and needs flagging here** so a session does not try to
+make it look like the others: it is the one step **exempt from "must be visible
+in Expo Go"**, because what it ships is a written verdict and a yes/no on merging
+`epic/cube` into `main`. Code changes are allowed only where the review finds
+something concrete and small; anything bigger is written down as a finding. A
+review that ends with no code changes is a good outcome. It must not produce a
+plugin framework, a game SDK or a base class — three games is not enough evidence
+for any of those, and inventing one would fail its own review.
 
 1. Scramble length — 20 moves. Leave it?
 2. Other puzzles — 2×2, 4×4, pyraminx, skewb?

--- a/docs/cube-plan.md
+++ b/docs/cube-plan.md
@@ -469,7 +469,8 @@ Step 5 build still has `scramble` and `favorites` exactly where they were.
 ## 8. Delivery steps
 
 One branch per step, per `.github/dev-process.md`. Every step must ship something
-the operator can open in Expo Go.
+the operator can open in Expo Go — **with one deliberate exception, Step 10**,
+which is a review and ships a verdict instead (§8.11).
 
 | Step | What lands | State |
 |---|---|---|
@@ -482,15 +483,18 @@ the operator can open in Expo Go.
 | **7** | **Give the page back to the cube.** The chrome takes two thirds of the screen and the biggest piece of it grows as you drill; cut it to a budget | **shipped** (#92, 2026-08-05) |
 | **8** | **The designed solve screen.** A spatial cross pad, hold-for-prime, and a phase-split tick scrubber — from a settled design bundle, and the answer to §9.8 | **shipped** (2026-08-05) |
 | **9** | **Compare your attempts.** Every solve written at this scramble, with its phase counts beside each other — "my first block over five attempts" | next |
-| **10** | **Enter a cube by hand.** Paste an algorithm, or set the colours facelet by facelet, for a cube that came off a table rather than out of the generator | |
+| **10** | **Architecture review, and the merge decision.** Does what we built meet the bar, does it plug into the platform the way the platform expects, and can `epic/cube` go to `main`? | |
+| **11** | **Enter a cube by hand.** Paste an algorithm, or set the colours facelet by facelet, for a cube that came off a table rather than out of the generator | |
 | — | ~~**Edit a solve you have already written.**~~ | **tabled** (2026-08-06) |
 | — | ~~**A solver**, and random-state scrambles off the back of the same search~~ | **outsourced** (2026-08-06) |
 
 **The table was re-ordered a third time on 2026-08-06, and this one removed
-scope rather than moving it.** §8.9 has the operator's reasoning and it is worth
-reading before touching either tabled row, because both are *decisions* rather
-than backlog: editing is not deferred until there is time for it, and the solver
-is not waiting for someone to write one.
+scope rather than moving it** — two rows out, one row in. §8.9 has the operator's
+reasoning and it is worth reading before touching either tabled row, because both
+are *decisions* rather than backlog: editing is not deferred until there is time
+for it, and the solver is not waiting for someone to write one. The row that came
+in is **Step 10**, and it is the first step in this epic that looks at the whole
+of what was built rather than adding to it (§8.11).
 
 **The table has now been re-ordered twice, and both were re-orderings rather
 than new scope.** Step 6 landing (2026-08-02) moved *edit a solve* ahead of
@@ -1390,6 +1394,131 @@ solve rather than displaying the ones written (§8.9 — that is the API's job).
 **Visible in Expo Go when this lands:** write three solves at one scramble with
 first blocks of 8, 7 and 6 moves, open the list, and read the improvement down a
 column.
+
+### 8.11 Architecture review, and the merge decision (Step 10, specified 2026-08-06)
+
+Ten steps of feature work have gone into `epic/cube` without anyone standing back
+from it. **This step stands back**, against one bar — *would a staff engineer
+sign this off* — and it ends in a decision rather than a diff: **can the epic
+merge to `main`?**
+
+#### This step is exempt from "must be visible in Expo Go", and that is the point
+
+Every other step must ship something the operator can open (§8, and the handoff's
+golden rules). This one deliberately cannot, and pretending otherwise is how a
+review turns into a refactor nobody asked for. So the rule is replaced rather
+than waived:
+
+> **What ships is a written verdict and a merge decision.** Code changes are
+> allowed only where the review finds something *concrete and small*. Anything
+> bigger gets written down as a finding with a recommendation and does not get
+> built in this step.
+
+If the review ends with no code changes at all, that is a **good** outcome and
+the PR says so.
+
+#### The bar: simple, elegant, data-driven
+
+Not "well-abstracted". The three things to check, in this order:
+
+1. **Is the data the source of truth, or is it in the code?** This epic's best
+   work is already this shape and it is what to measure the rest against:
+   `PAD_LAYOUT` owns which key sits where and `PAD_KEYS` is *derived* from it, so
+   there is one place to add a key rather than two to forget one. `PHASE_METHODS`
+   owns the method vocabulary. `padPalette.js` owns the tints. **Look for the
+   opposite**: a rule spelled out in JSX, a list maintained in two places, a
+   `switch` where a table would do.
+2. **One rule, one function.** The epic's standing golden rule, and Step 6 has
+   the scar that produced it — "it survived the reload but not the undo" is what
+   two implementations of one rule looks like in the wild. Check the rules that
+   have more than one caller: what a press means, what shifts a phase marker,
+   what counts as an extension rather than a replacement.
+3. **Is anything here more general than its one use?** A cube-shaped abstraction
+   with one implementation is a cost with no benefit. **This step must not
+   produce a plugin framework, a game SDK, or a base class.** Three games is not
+   enough evidence for any of those, and inventing one here would fail its own
+   review.
+
+#### Plugging into the greater game platform
+
+The platform's contract is small, real, and already almost identical for both
+games. Cube imports **six** things from outside `games/cube/`:
+
+`hooks/useAppTheme` · `hooks/useBoardSize` · `components/ScreenHeader` ·
+`utils/gameProgress` · `utils/debounce` · `utils/color`
+
+Fungiku imports the same five plus `usePersistentReducer`, `useBoardOrigin`,
+`components/Symbol` and `utils/symbolSets`. **That overlap is the platform**,
+whether or not anyone wrote it down. The review's job is to say whether it is the
+*whole* contract and whether it is honest. Specifically:
+
+- **`games/registry.js` is the data-driven seam and it works.** One entry per
+  game — `id`, `title`, `tagline`, `icon`, `accent`, `Screen`, `readProgress` —
+  and the hub renders cards from the list while `App.js` routes on `id`. The
+  cube's entry is seven lines. Confirm nothing has grown a special case for
+  `id === 'cube'` anywhere; if it has, that is the finding.
+- **`utils/gameProgress.js` inverts the dependency, and this is the review's
+  headline candidate.** A platform util **imports three games' internals** —
+  `games/fungiku/engine`, `games/fungiku/difficulty`, `games/cube/scramble` —
+  and the cube's own `storage.js` then imports `describeCubeProgress` back out of
+  it. So the path is `games/cube/storage → utils/gameProgress → games/cube/scramble`,
+  and **the registry's promise that "adding a game is an entry here, not a UI
+  edit" is not quite true**: adding a game also means editing a shared util that
+  every other game depends on.
+
+  The data-driven fix is already half-built and looks cheap: `readProgress` is
+  *per entry* and already returns `{ label, detail }`, so each `describe*Progress`
+  belongs next to the game whose save it reads, and `gameProgress.js` keeps only
+  what is genuinely shared — `formatElapsed` and the like. **Check the cost
+  before recommending it**: the tests currently reach these functions in a plain
+  node environment precisely because that file has no React Native imports, and a
+  move that breaks that trade is not an improvement. Say which way it came out.
+- **Two ways to persist one thing.** Fungiku uses `hooks/usePersistentReducer`;
+  the cube rolls its own debounced writer over `AsyncStorage` in
+  `games/cube/storage.js`. Both work. Either the platform has a persistence
+  primitive and the cube should be on it, or it does not and `usePersistentReducer`
+  is fungiku's — **say which, because right now the answer is "nobody decided"**.
+  Note the cube's shape is genuinely different (one blob, written on change,
+  read by shape rather than by version) before assuming it should converge.
+- **What the cube does *not* touch is evidence too.** No `contexts/`, no wallet,
+  no coins. Fungiku's economy is entirely fungiku's — ten files, none shared.
+  That is the correct amount of coupling for two games that have nothing to do
+  with each other, and the review should confirm it rather than propose a
+  cross-game economy.
+
+#### Inside the cube, the specific things to look at
+
+- **24 modules in `games/cube/`.** Is each one earning its file? The split has
+  been load-bearing — `favorites.js` holds the save's shape rules precisely so it
+  can be tested without React Native — but a boundary that exists only because a
+  file got long is not a boundary.
+- **`readCubeSave` lives in `favorites.js` and now reads four things**, only one
+  of which is favorites. Already known and already deliberate (it is where every
+  caller looks). This step is the one with standing to decide whether a
+  `cubeSave.js` is worth the churn, and "no" is a legitimate answer to write down.
+- **The pure core is the good news and should be said out loud.** `moves`,
+  `cubeState`, `geometry`, `orientation`, `solve`, `solveList`, `scramble` are
+  free of React Native and carry the bulk of the 835 tests. That is why this epic
+  can be reviewed at all. Any finding that would push logic *out* of that core and
+  into a component is a finding to reject.
+
+#### The merge decision
+
+The output is an explicit **yes or no on merging `epic/cube` into `main`**, with
+whatever is blocking it named. Cover at least:
+
+- **Does it stand up on a device**, not just in a browser at three widths — the
+  epic's own scar (Step 7 shipped a header that passed every browser check and
+  was broken on a phone), and `expo-haptics` fires exactly once in a place only a
+  device can judge.
+- **Storage compatibility.** `@CubeScramble` is at version 2 and is read by shape.
+  A user on a build from Step 3 opening a build from Step 10 must not lose their
+  solves; prove it rather than assert it.
+- **`npx expo-doctor` (expect 18/18), `npx expo export --platform all`, `npm test`.**
+- **Build notes and `app.json`.** Per §12 they are kept per release, not per step:
+  the cube epic is `3.1.0` and the entry gets *extended*, so the merge is the
+  moment that entry has to describe the whole feature rather than the last step
+  of it.
 
 ## 9. Open questions for the operator
 

--- a/docs/cube-plan.md
+++ b/docs/cube-plan.md
@@ -361,9 +361,14 @@ from the *allowed* faces rather than drawing and retrying — same distribution,
 but it terminates by construction instead of depending on the quality of its
 randomness.
 
-Upgrading to random-state is its own step (§8, last row), and it is the same
-search a solver needs — which is why the two share a row now that neither is on
-the critical path (§8.1).
+Upgrading to random-state is the same search a solver needs, which is why the two
+shared a row — and why they left the table together on 2026-08-06 when that
+search was **outsourced to an API** (§8.9). Nothing in the app changes: these
+scrambles stay random-move, which is what nearly every phone timer ships. If the
+API ever answers "give me a random-state scramble" as well as "optimize this
+phase", it is a swap of `scramble.js`'s generator for a fetch with this one as
+the offline fallback — but **do not build the fallback plumbing before there is
+something to fall back from.**
 
 ## 7. Favorites and persistence
 
@@ -476,9 +481,16 @@ the operator can open in Expo Go.
 | **6** | **Annotate the move groups.** "These moves solve first block, these solve second block" — labelled spans, per-phase move counts, and a transport that plays one group | **shipped** |
 | **7** | **Give the page back to the cube.** The chrome takes two thirds of the screen and the biggest piece of it grows as you drill; cut it to a budget | **shipped** (#92, 2026-08-05) |
 | **8** | **The designed solve screen.** A spatial cross pad, hold-for-prime, and a phase-split tick scrubber — from a settled design bundle, and the answer to §9.8 | **shipped** (2026-08-05) |
-| **9** | **Edit a solve you have already written.** Fix a move in the middle without undoing back to it — the oldest live gap in the feature | next |
+| **9** | **Compare your attempts.** Every solve written at this scramble, with its phase counts beside each other — "my first block over five attempts" | next |
 | **10** | **Enter a cube by hand.** Paste an algorithm, or set the colours facelet by facelet, for a cube that came off a table rather than out of the generator | |
-| **11** | **A solver**, if it is still wanted by then — and random-state scrambles off the back of the same search | |
+| — | ~~**Edit a solve you have already written.**~~ | **tabled** (2026-08-06) |
+| — | ~~**A solver**, and random-state scrambles off the back of the same search~~ | **outsourced** (2026-08-06) |
+
+**The table was re-ordered a third time on 2026-08-06, and this one removed
+scope rather than moving it.** §8.9 has the operator's reasoning and it is worth
+reading before touching either tabled row, because both are *decisions* rather
+than backlog: editing is not deferred until there is time for it, and the solver
+is not waiting for someone to write one.
 
 **The table has now been re-ordered twice, and both were re-orderings rather
 than new scope.** Step 6 landing (2026-08-02) moved *edit a solve* ahead of
@@ -520,9 +532,13 @@ the answer arrived from watching the thing be used.
 So the epic becomes a notebook. That is *less* code, not more: no search, no
 pruning tables, no megabyte of dependency, and every step from here is
 recognisably the same shape — moves on a cube that the model and renderer
-already animate. The solver stays in the table because random-state scrambles
-(§6) still want the same search and it would be a good thing to have; it is just
+already animate. The solver stayed in the table because random-state scrambles
+(§6) still want the same search and it would be a good thing to have; it was just
 no longer the thing everything else waits on.
+
+**And on 2026-08-06 it left the table entirely** — the search is **outsourced to
+an API**, which is this section's argument carried to its end rather than a
+change of mind about it. §8.9 has the reasoning.
 
 ### 8.2 What a solve is
 
@@ -1193,7 +1209,11 @@ the tick track came out and the cube took its 22 points back, leaving the real
 cost at **49**. What was bought for it: two routes to a prime rather than two
 taps, and `E` and `S` on the pad.
 
-### 8.7 Editing a solve you have already written (Step 9)
+### 8.7 Editing a solve you have already written — **tabled 2026-08-06**
+
+> **This step is not being built.** The brief below is kept intact, unedited,
+> because it is a good brief and because §8.9 tables it on the strength of *what
+> an edit is for* rather than on any fault in it. Read §8.9 first.
 
 Written up when it was Step 7, moved to 8 by the layout work and to **9** by the
 design bundle (§8.8, 2026-08-04). Kept here intact each time, because it is the
@@ -1229,6 +1249,148 @@ whoever takes this step no longer has to design its way in — that argument is
 settled and the work is the marker arithmetic, which is where it always
 belonged.
 
+### 8.9 Why the editor is tabled and the optimizer is outsourced (2026-08-06)
+
+Two rows left the table on the same day, for one reason, and it is the same kind
+of reason that replanned the epic in §8.1: **looking at what the feature is
+actually for.**
+
+#### The editor was serving two different jobs
+
+The editing brief (§8.7, which was Step 9 until this section replaced it) answers
+*"the text field appends; it cannot edit"*, and
+that sentence has been covering two wants that only look alike:
+
+1. **Fix a typo.** You meant `R'` and wrote `R`. The move list is wrong about
+   what you did.
+2. **Improve a block.** Your first block is 8 moves and you think it can be 6.
+   The move list is *right* about what you did and you want to have done
+   something else.
+
+The brief was built for (1) and quietly justified by (2) — §8.5 is where that
+justification is written down, and it is the honest one: *"first block in 8
+versus first block in 12 is exactly what a Roux learner is trying to improve."*
+The operator took (2) apart on 2026-08-06:
+
+> *"If I wanted to improve first block or second block that would just ripple
+> through the whole thing. So I think that's really editing as the API
+> optimizer."*
+
+That is correct and it is fatal to the step as scoped. **A better first block is
+not a text edit.** Change the six moves that build the block and every move after
+them is now being applied to a different cube — the second block is being built
+somewhere it is not, the CMLL case is no longer that case, and the phase markers
+are pointing at moves that no longer mean anything. A diff that shifts markers by
+how much the text grew (§8.7's hard half) is exactly the wrong tool for it: it
+carefully preserves the annotations on a solve whose annotations are the thing
+that stopped being true.
+
+So the step's hard half was hard in service of the job it could not do anyway,
+and its easy half — open the modal with the solve in it — serves only (1).
+
+#### Which leaves (1), and (1) is not worth a step on its own
+
+A typo is caught within a move or two of making it, because the cube on screen
+turns the wrong way immediately. Backspace repeats at 120ms and the solves are
+around forty moves. The recovery is bad but it is *rare and cheap*, and the
+affordance question (§8.7 lists three honest candidates and no obvious winner)
+costs more to settle than the papercut costs to live with.
+
+**If it ever comes back, it comes back small**: `CubeAlgInputModal` opened with
+the solve already in it, `clampPhases` for the markers, and no diff arithmetic
+at all. That is a couple of hours. What is *not* worth building is the version
+that tries to be right about markers across a rewrite, because that version is
+pretending to be the optimizer.
+
+#### And the optimizer is somebody else's search
+
+The remaining row — a solver, and random-state scrambles off the back of the same
+search — is **outsourced to an API** (operator, 2026-08-06). Not deferred:
+outsourced. The reasoning is §8.1's, one step further along. §8.1 moved the
+solver to the end because a computed solution is not the operator's solution and
+does not help someone drilling. What 2026-08-06 adds is that the *useful* version
+— take the solve I wrote and show me a shorter route through the same phase — is
+a real optimization problem over a real cube, and this repo is not where that
+gets written:
+
+- A two-phase search wants pruning tables measured in megabytes, and this epic's
+  whole argument for the cubie model over cubing.js was **not** shipping that.
+- The interesting query is not "solve this cube" but "solve this *phase* under
+  this *method's* constraints" — a first block that keeps the DL edge, a CMLL
+  that does not disturb the block. That is a constrained search, which is harder
+  than the unconstrained one, not easier.
+- It is a pure function of a cube state and a phase: **request in, algorithm
+  out.** Nothing about it needs to be on the phone, and nothing else in the epic
+  is blocked on it. It is the single most natural thing here to put behind a
+  network call.
+
+**What this means for the plan right now: nothing is being built for it.** No
+client, no protocol, no placeholder button. It is recorded so the next session
+does not helpfully start writing a Kociemba search. When it is real it arrives as
+its own step, and the shape it should take is *annotate an existing solve* — a
+phase already has a start, an end and a cube state at its start (§8.5), so
+"optimize this phase" is a request the data model can already describe.
+
+#### What the epic does instead
+
+If you improve a block by **re-attempting it** rather than by editing it, the
+loop only closes when you can see the attempts next to each other. That was an
+open question carried in the handoff — *"my first block over five attempts at
+this scramble"* — filed as "the obvious next thing to want" and parked with
+*"it should wait for the operator to say they want it."* **Tabling the editor is
+what asks for it**, so it becomes **Step 9** and §8.10 is its brief.
+
+`duplicateSolve` already exists. Copy the solve, rewrite the block on the copy,
+and compare the two numbers: that is the improvement loop the editor was standing
+in for, built out of the thing the epic is already good at — writing a solve
+down — rather than out of a text diff.
+
+### 8.10 Compare your attempts (Step 9, specified 2026-08-06)
+
+**The question this screen cannot answer is "am I getting better at this
+scramble?"** Step 6 made every phase count knowable and Step 8 put them on the
+page — but one solve at a time, so `First block · 8` is a fact with nothing to
+compare it against. The operator's own words for what they are doing with the
+tool are *"working out a Roux first block by hand and trying to remember what I
+did"* (§8.1). Remembering across attempts is the half that is still manual.
+
+**Scope is one view, and the data for it already exists.**
+
+- **A per-scramble comparison of the solves already written.** `solvesFor` gives
+  the list, `phaseSpans` gives each one's phases and counts, `describePhaseSpan`
+  already says them out loud. Nothing new is computed; it is arranged.
+- **The unit of comparison is a phase, not a solve.** Total move count is the
+  least interesting number on the screen — it is what a shorter *anything*
+  improves. `First block: 8, 8, 6, 7` down a column is the thing worth seeing,
+  because a Roux drill improves one phase at a time and the operator says so.
+- **Phases are named, not positional.** Solve 1's second span and Solve 3's
+  second span are only comparable if they are both `Second block`. A solve with
+  no markers has nothing to line up and should say so plainly rather than being
+  guessed at — an unannotated solve is a legitimate thing to have written.
+- **Best is worth marking; average is not.** Which attempt has the shortest first
+  block is the answer to the question being asked. A mean over four attempts,
+  where one of them was abandoned half-way, is a number that lies.
+
+**Two things to decide while building, not before:**
+
+- **Where it lives.** The solves list is the honest home — it is already the
+  per-scramble list of solves and already where solve-level operations moved in
+  Step 8 — and the cheapest version of this step is *columns added to a list that
+  exists*. A separate screen is the version to reach for only if the list cannot
+  hold it.
+- **What it costs the cube.** §8.6's rule stands: say what a new row costs, in
+  points, in the PR. If this lands inside the solves list it costs the solve
+  screen nothing, which is most of the argument for putting it there.
+
+**Out of scope, deliberately:** comparing across *different* scrambles (the
+numbers are not comparable — a scramble with an easy block is not a better
+solve), a timer (§9.3, still unanswered), and anything that suggests a *better*
+solve rather than displaying the ones written (§8.9 — that is the API's job).
+
+**Visible in Expo Go when this lands:** write three solves at one scramble with
+first blocks of 8, 7 and 6 moves, open the list, and read the improvement down a
+column.
+
 ## 9. Open questions for the operator
 
 1. **Scramble length.** 20 moves, matching what a WCA 3×3 scramble comes out at.
@@ -1244,6 +1406,12 @@ belonged.
    (operator, 2026-08-01): solves are **written by the operator**, not computed.
    The question was whether a solver should optimize for move count or follow the
    method's own logic; the real answer was that neither is wanted yet. See §8.1.
+
+   **Fully closed on 2026-08-06**: the part that *is* wanted eventually —
+   optimize a phase I already wrote — is **outsourced to an API** and is not
+   this repo's code (§8.9). The original question is now moot rather than
+   pending: it asked what a local solver should optimize for, and there is no
+   local solver.
 6. **Left-handed drag.** The current mapping is "push the surface under your
    finger". Nobody has complained yet because nobody has used it yet.
 7. **Turn speed.** Answered and shipped in Step 2 — a chip cycling 1× → 2× → 0.5×.
@@ -1259,12 +1427,15 @@ belonged.
    patch, where a mis-hit turns the cube *the wrong way* rather than doing
    nothing.
 
-   **What is left is use, not design.** The hold has been driven as a timed
-   gesture at three widths and behaves; whether **180ms** is the right threshold,
-   and whether a hold reads as natural under a thumb mid-drill, are things only a
-   real session answers. The fallback is written down and cheap — a standalone
-   `'` key, which the pad now has a spare cell's worth of room for nowhere, so it
-   would cost the layout a rethink rather than a slot.
+   **The threshold half is closed too** (operator, 2026-08-06). 180ms shipped and
+   was too short under a real thumb — *"I'm getting a lot of prime moves when I
+   want a regular turn"* — so `HOLD_MS` is **300**, the top of the design's
+   120–320 range. The asymmetry picked the number rather than splitting the
+   difference: a tap misread as a prime turns the cube the wrong way and costs an
+   undo, while a prime that waits another 120ms costs only the wait. Tested and
+   accepted the same day. The fallback is still written down and cheap — a
+   standalone `'` key, which the pad has a spare cell's worth of room for
+   nowhere, so it would cost the layout a rethink rather than a slot.
 
    What the armed modifier got right and should be carried forward: **the pad
    showed the arming**, relabelling every key to `U'`, `R'`, `M'`, so the second


### PR DESCRIPTION
Documentation only — no code changes. Two commits: the replan, and the new Step 10.

## Two rows leave the table

This is a **removal of scope**, not a fourth re-ordering of it, which is why §8.9 exists to say so.

**The editing brief was covering two jobs that only look alike:** *fix a typo*, and *improve a block*. Only the first is a text edit. The operator took the second apart:

> If I wanted to improve first block or second block that would just ripple through the whole thing. So I think that's really editing as the API optimizer.

That is fatal to the step as scoped. Change the six moves that build a first block and every later move is being applied to a different cube — second block is being built somewhere it isn't, the CMLL case is no longer that case. So the marker arithmetic that was the *hard half* of the step would have carefully preserved annotations that had stopped being true. It was hard in service of a job it could not do.

What's left is the typo case, which you catch within a move or two because the cube visibly turns the wrong way. Bad recovery, but rare and cheap — not worth a step, and not worth settling the affordance question (§8.7 lists three candidates and no winner). §8.7 is kept intact and marked tabled, with the small version written down in case it comes back: `CubeAlgInputModal` opened with the solve in it, `clampPhases`, no diff arithmetic.

**The optimizer is outsourced to an API — recorded as a decision, not a deferral.** A constrained search over a cube state is not what this epic wanted the cubie model for, and its whole argument against cubing.js was not shipping pruning tables. The note says explicitly that nothing is being built for it: no client, no protocol, no placeholder button. Random-state scrambles go with it, since they are the same search.

## Step 9 becomes "compare your attempts"

This was open question 13, filed with Step 6 as "the obvious next thing to want" and parked because nothing had asked for it. **Tabling the editor is what asks for it**: if a better first block comes from re-attempting rather than editing, the loop does not close until the attempts sit next to each other.

It is small because nothing new is computed — `solvesFor`, `phaseSpans`, `describePhaseSpan` and `duplicateSolve` already exist. The one real piece of thinking is that the comparison joins on **phase name, not position**. §8.10 is the brief.

## Step 10 is new: the architecture review and the merge decision

Ten steps of feature work have gone into `epic/cube` without anyone standing back from it.

**It is explicitly exempt from "must be visible in Expo Go"**, and the brief says so up front rather than letting the rule quietly rot — pretending otherwise is how a review turns into a refactor nobody asked for. What ships is a written verdict and a yes/no on merging to `main`. Code changes only where the review finds something concrete and small; anything bigger becomes a finding. **Zero code changes is stated as a good outcome.**

The bar is *simple, elegant, data-driven*, in that order, measured against the epic's own best work: `PAD_LAYOUT` owns which key sits where and `PAD_KEYS` is derived from it, so there is one place to add a key rather than two to forget one. The brief names the opposite to hunt for — a rule spelled out in JSX, a list kept in two places, a `switch` where a table would do — and rules out the failure mode a review invites: **no plugin framework, no game SDK, no base class.** Three games is not enough evidence for any of those, and inventing one would fail its own review.

The platform section is grounded rather than aspirational, and banks two findings so the review starts with something real:

- **`utils/gameProgress.js` inverts the dependency.** A platform util imports `games/fungiku/engine`, `games/fungiku/difficulty` and `games/cube/scramble`, and `games/cube/storage.js` imports `describeCubeProgress` back out of it. So the registry's promise that "adding a game is an entry here, not a UI edit" is not quite true. The data-driven fix is half-built — `readProgress` is per entry and already returns `{ label, detail }` — but the brief says **price it first**, because that file is React-Native-free so its tests run in plain node, and a move that breaks that trade is not an improvement.
- **Two ways to persist one thing.** Fungiku uses `usePersistentReducer`; the cube rolls its own debounced writer. Both work, and right now the answer to which one is the platform's is "nobody decided". Decide it, noting the cube's shape is genuinely different before assuming they should converge.

It also confirms a negative worth keeping: the cube touches no `contexts/`, no wallet, no coins, and fungiku's economy is ten files none of which are shared. That is the correct amount of coupling between two unrelated games — confirm it, do not propose a cross-game economy.

*Enter a cube by hand* becomes Step 11.

## Testing

`npx jest` — 835 tests across 24 suites, all passing. Nothing executable changed; the run is here to show the docs commit did not drag anything with it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCTe9UuRzyA736bQDdEo6q)_