### PR TITLE
Cube Scramble Step 10: the architecture review, and the merge decision

### DIFF
--- a/SudokuApp/games/cube/CubePadLegend.js
+++ b/SudokuApp/games/cube/CubePadLegend.js
@@ -21,8 +21,17 @@ import { LEGEND, padPalette } from './padPalette';
 const CubePadLegend = ({ theme, accent }) => {
   const palette = padPalette(theme, accent);
 
+  // Said from `LEGEND` rather than restated. The hand-written version listed the
+  // same four groups a second time, so a fifth tint would have been drawn and
+  // not announced — the failure `PAD_KEYS` is derived to avoid, one file over.
+  const spoken = LEGEND.map((group) => group.spoken).join(', ');
+
   return (
-    <View style={styles.legend} accessibilityRole="summary" accessibilityLabel="Key colours: faces, slices, wide turns, rotations">
+    <View
+      style={styles.legend}
+      accessibilityRole="summary"
+      accessibilityLabel={`Key colours: ${spoken}`}
+    >
       {LEGEND.map(({ tone, label }) => {
         const group = palette.tone(tone);
         return (

--- a/SudokuApp/games/cube/CubeScreen.js
+++ b/SudokuApp/games/cube/CubeScreen.js
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
+  AppState,
   Platform,
   StyleSheet,
   Text,
@@ -329,6 +330,34 @@ const CubeScreen = ({ onExitToHub }) => {
   // Leaving for the hub unmounts the screen, and a debounced write that has not
   // fired yet is a write that never happens.
   useEffect(() => () => saveCubeState.flush(), []);
+
+  /**
+   * Backgrounding the app is the *other* way a pending write is lost, and it is
+   * the one that matters here (Step 10's review).
+   *
+   * Nothing unmounts when the system sends the app to the background — the
+   * effect above does not run — so the 400ms debounce is simply left holding the
+   * last edit, and a phone that then evicts the process never writes it. What
+   * that costs is up to 400ms of *authored* work: the move just entered, the
+   * name just typed, the marker just dropped.
+   *
+   * **That is the exact complaint Step 4 was built to answer** — *"if I
+   * background the app and come back… my solve I was working on is gone"* — and
+   * this screen is the only persisted surface in the app that was not already
+   * covered. `usePersistentReducer` has done this for Sudoku and Fungiku since
+   * the hub existed, and `utils/debounce`'s own docstring names the two moments
+   * `flush()` is for as "a screen unmounts **or the app backgrounds**". The cube
+   * rolls its own writer (plan §8.11), so it has to do its own half.
+   *
+   * `inactive` counts as well as `background`: iOS passes through it on the way
+   * out, and on a quick swipe up it is as far as the app gets.
+   */
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (next) => {
+      if (next === 'background' || next === 'inactive') saveCubeState.flush();
+    });
+    return () => subscription.remove();
+  }, []);
 
   // The cube a solve starts on: the scramble fully applied, which is the cube
   // the operator would be holding. Memoized because it is also the *identity*
@@ -1439,9 +1468,6 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontWeight: '600',
     marginLeft: 5,
-  },
-  iconOnly: {
-    paddingHorizontal: 10,
   },
   // Takes the leftover — but the leftover is no longer an afterthought, which is
   // the whole of Step 7 (plan §8.6). Every row above and below this one now has

--- a/SudokuApp/games/cube/__tests__/solve.test.js
+++ b/SudokuApp/games/cube/__tests__/solve.test.js
@@ -14,6 +14,7 @@ import {
   PAD_KEYS,
   PAD_LAYOUT,
   PAD_ROWS,
+  SPOKEN_KEY,
   appendAlg,
   appendToken,
   applyPadPress,
@@ -107,6 +108,24 @@ describe('PAD_KEYS', () => {
   it('covers what a Roux solve is actually written in', () => {
     ['U', 'D', 'L', 'R', 'F', 'B', 'M', 'r', 'x', 'y'].forEach((key) => {
       expect(PAD_KEYS).toContain(key);
+    });
+  });
+
+  /**
+   * The pad's keys are listed twice — once as a layout, once as sounds — and
+   * only the layout can be derived (Step 10's review). Without this, a key added
+   * to the cross reads out as a bare letter and nothing says so: `describeToken`
+   * falls back to the character, which is right for `Rw` typed into the field
+   * and wrong for a key someone put on the pad.
+   *
+   * The suite below already walks every pad key through `describeToken` — but it
+   * asserts `toBeTruthy()`, and the fallback is truthy. That is why the gap
+   * survived nine steps: the test that looked like this one could not fail.
+   */
+  it('has a spoken form for every key on it', () => {
+    PAD_KEYS.forEach((key) => {
+      expect(Object.prototype.hasOwnProperty.call(SPOKEN_KEY, key)).toBe(true);
+      expect(SPOKEN_KEY[key].length).toBeGreaterThan(0);
     });
   });
 

--- a/SudokuApp/games/cube/cubeState.js
+++ b/SudokuApp/games/cube/cubeState.js
@@ -49,16 +49,6 @@ export const STICKER_COLORS = {
   B: '#0051ba',
 };
 
-/** Human names, for the face legend and for screen readers. */
-export const FACE_NAMES = {
-  U: 'Up (white)',
-  R: 'Right (red)',
-  F: 'Front (green)',
-  D: 'Down (yellow)',
-  L: 'Left (orange)',
-  B: 'Back (blue)',
-};
-
 /** Which face an outward normal belongs to, on a solved cube. */
 const faceForNormal = (n) =>
   FACE_ORDER.find((face) => {

--- a/SudokuApp/games/cube/padPalette.js
+++ b/SudokuApp/games/cube/padPalette.js
@@ -55,12 +55,20 @@ export const GROUPS = {
   tool: { bg: '#f0f1f4', border: '#d5dae2', ink: '#5d6473' },
 };
 
-/** The four groups the legend names, in the order it names them. */
+/**
+ * The four groups the legend names, in the order it names them.
+ *
+ * `label` is the swatch's own word, cut to fit a 9.5pt row; `spoken` is the same
+ * group with the room a screen reader has. Both live here because the legend
+ * used to hold the spoken list a second time, in a hand-written
+ * `accessibilityLabel`, and a fifth tint would have been drawn without being
+ * announced.
+ */
 export const LEGEND = [
-  { tone: 'face', label: 'FACES' },
-  { tone: 'slice', label: 'SLICES' },
-  { tone: 'wide', label: 'WIDE' },
-  { tone: 'rot', label: 'ROTATE' },
+  { tone: 'face', label: 'FACES', spoken: 'faces' },
+  { tone: 'slice', label: 'SLICES', spoken: 'slices' },
+  { tone: 'wide', label: 'WIDE', spoken: 'wide turns' },
+  { tone: 'rot', label: 'ROTATE', spoken: 'rotations' },
 ];
 
 /** Is this a surface that wants light text on it? */

--- a/SudokuApp/games/cube/solve.js
+++ b/SudokuApp/games/cube/solve.js
@@ -243,9 +243,19 @@ export const describeSolve = (alg) => {
   return count === 1 ? '1 move' : `${count} moves`;
 };
 
-/** How a key reads out loud. `R'` is "R prime", not "R apostrophe", and `r` is a
- *  wide turn rather than the letter R said quietly. */
-const SPOKEN_KEY = {
+/**
+ * How a key reads out loud. `R'` is "R prime", not "R apostrophe", and `r` is a
+ * wide turn rather than the letter R said quietly.
+ *
+ * **A second list of the pad's keys, and it cannot be derived from the first**
+ * — `PAD_LAYOUT` says where a key sits and this says how it sounds, and the
+ * domain here is wider besides: a solve typed into the text field can hold `Rw`
+ * or `u`, which are notation the pad has no key for. So the two are pinned
+ * against each other in `solve.test.js` instead: every pad key must have a
+ * spoken form, or a key added to the cross reads out as a bare letter with
+ * nothing failing. Exported for exactly that test.
+ */
+export const SPOKEN_KEY = {
   U: 'U',
   D: 'D',
   L: 'L',

--- a/SudokuApp/utils/buildNotes.js
+++ b/SudokuApp/utils/buildNotes.js
@@ -4,7 +4,7 @@
 const BUILD_NOTES = {
   '3.1.0': {
     title: 'Cube Scramble — a 3D cube on the hub',
-    date: '2026-08-01',
+    date: '2026-08-07',
     notes: [
       'New on the hub: Cube Scramble, a tool for the Rubik\'s cube in your hands',
       'Every visit hands you a fresh 20-move scramble in standard notation',

--- a/docs/cube-handoff.md
+++ b/docs/cube-handoff.md
@@ -240,8 +240,9 @@ solve against it. That is the whole demo and it should be one screen recording.
 - `npx expo-doctor` (18/18), `npx expo export --platform all`.
 - A headless driver at 320×568, 375×667 and 393×852: paste, refuse a bad one,
   confirm the star, confirm the solves list follows the new scramble.
-- **And a device.** See the review's merge condition — it applies to every step
-  from here.
+- **And a device** — as every step of this epic has in fact had, even where the
+  docs only recorded the headless half. **Say in the PR which findings came from
+  the handset**; Step 10 is why that sentence is here.
 
 ---
 
@@ -396,8 +397,12 @@ made.**
   standing warning: both animation bugs this repo has shipped were invisible in
   the browser. This one uses no native driver and no `setValue`, which is the
   class of problem avoided rather than dodged, but a device pass is still the
-  only evidence that counts for how it *feels*. **Step 10 made this the one
-  condition on merging the epic** — see `docs/cube-review.md`.
+  only evidence that counts for how it *feels*. **Step 10 raised this as the one
+  condition on merging the epic and the operator closed it the same day** — they
+  have been testing on device throughout (2026-08-07). What is worth keeping is
+  the habit it exposed: **write down when a finding came from a device**, because
+  the docs recorded nine steps of browser evidence and left the hand-testing
+  invisible. See `docs/cube-review.md`.
 - ~~**`useScramblePlayer` assumes a solved starting cube.**~~ **Done in Step 3**:
   `buildPlayback(alg, { from })` and `useScramblePlayer(alg, from)`.
 - **The text field appends; it cannot edit.** **Tabled on 2026-08-06 — plan §8.9
@@ -628,7 +633,17 @@ Verified with `npm test` (889, one new), `npx expo-doctor` (18/18), `npx expo
 export --platform all`, `background.mjs` both ways, and `walk.mjs` at 320×568,
 375×667 and 393×852 — no overflow, no console errors, and the legend's newly
 derived label reading character-for-character what the hand-written one said.
-**Not yet seen on a device, and that is the merge's one condition.**
+
+**The merge's one condition was answered the same day and the answer was that it
+had never been open** (operator, 2026-08-07): *"I've been testing on device the
+whole way."* The review had recorded the device pass as unproven because every
+piece of written evidence in `docs/` is headless — and that was a gap in the
+record, not in the testing. It re-reads the whole epic: the 300ms threshold, the
+armed `′`, the unanimated second quarter and the tick track's removal are all
+device findings, and none of them could have come from a browser. **The process
+lesson for the next epic is to say so when a correction comes from a hand** —
+nine steps of headless evidence and a trail of hand-found corrections read, to a
+reviewer, like a feature that had never been held.
 
 ### **Step 9 — compare your attempts** ✅ *(2026-08-06)*
 

--- a/docs/cube-handoff.md
+++ b/docs/cube-handoff.md
@@ -29,6 +29,11 @@ questions forward.
 
 - **Repo:** `mjohnson139/expo-sudoku`. App code is in **`SudokuApp/`**
   (Expo · React Native · JavaScript).
+- **The review:** `docs/cube-review.md` (Step 10, 2026-08-07) — the verdict on
+  the whole epic, what it deliberately did *not* fix, and the merge decision.
+  Read it before proposing an architectural change; three findings are written
+  down in it with recommendations, and two conclusions in it are decisions
+  (`readCubeSave` stays in `favorites.js`; `MAX_SOLVES` is not changed).
 - **Source of truth:** `docs/cube-plan.md`. Read it end to end before writing
   code — model (§3), notation (§4), renderer (§5), scrambles (§6), storage (§7),
   the step table (§8), open questions (§9), and the edge cases that already bit
@@ -49,7 +54,8 @@ Branch from **`epic/cube`**, and open your PR **against `epic/cube`**. The epic
 merges to `main` once the cube is worth shipping, so `main` never carries a
 half-built tool.
 
-`epic/cube` carries Steps 1 through 9 as of 2026-08-06. It is cut from
+`epic/cube` carries Steps 1 through 10 as of 2026-08-07, and Step 10 signed it
+off for `main` (`docs/cube-review.md`). It is cut from
 `main` and tracks it. (It was briefly cut from
 `epic/fungiku`, because the hub only existed there; Fungiku's Step 13 merged that
 epic to `main` on 2026-08-01 and this was rebased the same day. **No Fungiku
@@ -66,7 +72,10 @@ is always openable in Expo Go (project → Branches) even with no step PR open.
   `react-native-svg` — Step 2 touched only `utils/buildNotes.js`, because plan
   §12 says to, Step 4 touched those same two (the hub badge counts solves now),
   Step 6 touched only the build notes, **Step 8 added `expo-haptics`** to
-  `package.json` and nothing else, and Step 9 touched only the build notes. A
+  `package.json` and nothing else, and Step 9 touched only the build notes.
+  **Step 10 — the architecture review — touched only the build notes too**, which
+  is the outcome §8.11 wanted: it looked hardest at the shared seam and
+  recommended the one change it found there rather than making it. A
   step that needs to touch anything else should say why in its PR. **Step 7 is the only one that has had to touch shared
   code**, and it is the pattern for the next time: the header it needed to shrink
   is `components/ScreenHeader.js`, shared with Fungiku, so it added a `dense`
@@ -142,117 +151,118 @@ you built, at every stage of the motion, not only at rest.
 
 ---
 
-## Next step: **Step 10 — the architecture review, and the merge decision**
+## Next step: **Step 11 — enter a cube by hand**
 
 > **Branch from `epic/cube`, PR against `epic/cube`** — as every step does.
-> Step 9 merged on 2026-08-06, so the epic has the comparison table, the pad,
-> the scrubber and the palette. `epic/cube` now carries Steps 1 through 9.
+> Step 10 merged on 2026-08-07, so `epic/cube` now carries Steps 1 through 10
+> and has a signed-off architecture review sitting in `docs/cube-review.md`.
 
-**Read `docs/cube-plan.md` §8.11 before anything else. It is this step's brief
-and the whole of it**, and it is unusually specific about what the step is *not*
-allowed to become. Read §8.9 too, because two rows left the table rather than
-moving down it and a review that recommends building either of them is
-re-opening a decision the operator already made.
+**Read `docs/cube-review.md` first.** It is the only step in this epic that
+produced a verdict rather than a feature, and three of its findings are written
+down rather than fixed — deliberately, and two of them are waiting for exactly a
+step like this one that is already opening those files. Then read plan §8, where
+Step 11 is listed and **not specified in detail**: part of this step is deciding
+what it is.
 
-**This is the one step exempt from "must be visible in Expo Go", and that is
-deliberate rather than a concession.** What ships is **a written verdict and a
-yes/no on merging `epic/cube` into `main`**. Code changes are allowed only where
-the review finds something *concrete and small*; anything bigger is written down
-as a finding with a recommendation and is not built here. **A review that ends
-with no code changes at all is a good outcome and the PR should say so.**
+### The scope, as far as it is settled
+
+The generator hands you a random scramble. **This step is about the cube that is
+already in your hand** — one somebody else scrambled, one off a competition
+sheet, one you are half-way through and want to write down. Two routes were
+sketched and only the first is obviously right:
+
+1. **Paste an algorithm.** A scramble is text and this app already parses every
+   token of it. `CubeAlgInputModal` exists, `algError` already names the
+   offending token, and `showScramble` is already the one function that puts a
+   different scramble on the cube. **This is a small step.**
+2. **Set the colours facelet by facelet.** A cube that came off a table has no
+   algorithm — you have 54 stickers and no idea what sequence produced them.
+   This is a real feature: a net to tap on, a colour picker, and — the part that
+   makes it hard — **validating that what was entered is a cube that exists**.
+   Parity, permutation and orientation are all checkable, and a cube that fails
+   them must be rejected with a reason, or the transport will play a solve that
+   cannot be right.
+
+**Decide whether (2) is in this step or is its own**, and say so in the PR. The
+honest reading is that (1) is a couple of hours and (2) is a step of its own with
+a solver-adjacent validation problem in it — and the epic has form for splitting
+exactly this way (Step 5 jumped the queue when Step 3's route turned out to be
+the wrong instrument).
 
 ### Read first
 
-- **`docs/cube-plan.md` §8.11** — the bar, the platform contract, the specific
-  things to look at inside the cube, and what the merge decision has to cover.
-  It already names the headline candidate (`utils/gameProgress.js` inverting the
-  dependency) and tells you to check its cost before recommending it.
-- **This whole file.** The "Noted in passing" list below is nine steps of things
-  people spotted and deliberately did not fix — it is the review's inbox, and it
-  is why every step has been asked to note rather than fix.
-- `games/registry.js`, `utils/gameProgress.js`, `hooks/usePersistentReducer` and
-  `games/cube/storage.js` — the four files the platform question lives in.
-
-### The bar — in this order
-
-1. **Is the data the source of truth, or is it in the code?** `PAD_LAYOUT`,
-   `PHASE_METHODS` and `padPalette.js` are what good looks like here. Look for
-   the opposite: a rule spelled out in JSX, a list maintained in two places, a
-   `switch` where a table would do.
-2. **One rule, one function.** Check the rules with more than one caller: what a
-   press means, what shifts a phase marker, what counts as an extension rather
-   than a replacement — and now what counts a phase, which Step 9 routed through
-   `phaseSpans` on purpose.
-3. **Is anything more general than its one use?** **This step must not produce a
-   plugin framework, a game SDK or a base class.** Three games is not enough
-   evidence for any of those, and inventing one would fail its own review.
+- **`docs/cube-review.md`** — the verdict, and findings 4 and 5, which are
+  small, written down, and in the files this step will be in anyway.
+- `games/cube/CubeAlgInputModal.js` — the field, the validation and the Add
+  button already exist for solves; a scramble wants the same thing pointed
+  somewhere else.
+- `games/cube/CubeScreen.js`'s `showScramble` — **the one function that changes
+  the scramble**, and it already does the four things a new scramble has to do
+  (pause, drop half-finished gestures, open that scramble's most recent solve,
+  leave solve mode). Route a pasted scramble through it, not around it.
+- `games/cube/moves.js` — `parseAlg`, `algError`, `isValidAlg`, `normalizeAlg`.
+  **If you find yourself writing a second validator, that is the bug.**
+- `games/cube/cubeState.js` — `facelets` is there, and it is what route (2)
+  would have to invert.
 
 ### Behaviors that are easy to get wrong
 
-- **A review is not a refactor.** The temptation is to fix everything found.
-  §8.11's rule is the guard: concrete and small, or written down.
-- **The pure core is the good news and should be said out loud.** `moves`,
-  `cubeState`, `geometry`, `orientation`, `solve`, `solveList`, `compareLayout`
-  and `scramble` are free of React Native and carry the bulk of 875 tests. **Any
-  finding that would push logic out of that core and into a component is a
-  finding to reject.**
-- **Check the cost of the `gameProgress` fix before recommending it.** The tests
-  reach those functions in a plain node environment precisely because that file
-  has no React Native imports. A move that breaks that trade is not an
-  improvement — say which way it came out.
-- **`MAX_SOLVES` is 100, culled by creation date.** Step 9 said out loud that a
-  comparison view is the first thing that makes an old solve worth keeping. Do
-  not change the cap in a review; decide whether it is a finding.
-
-### The merge decision
-
-An explicit **yes or no**, with whatever blocks it named. Cover at least:
-
-- **Does it stand up on a device**, not just in a browser at three widths — this
-  epic's own scar (Step 7 shipped a header that passed every browser check and
-  was broken on a phone), and `expo-haptics` fires exactly once where only a
-  device can judge it.
-- **Storage compatibility.** `@CubeScramble` is version 2 and read by shape. A
-  user on a Step 3 build opening a Step 10 build must not lose their solves —
-  **prove it rather than assert it.**
-- `npm test`, `npx expo-doctor` (expect 18/18), `npx expo export --platform all`.
-- **Build notes and `app.json`.** Per plan §12 they are per release: `3.1.0` gets
-  *extended*, and the merge is the moment that entry has to describe the whole
-  feature rather than the last step of it. Step 9 extended it; read it back as a
-  whole and see whether it reads like one feature.
+- **A pasted scramble is a *new scramble*, not an edit.** Everything Step 4
+  learned applies: it changes which solves are yours, it must not be an effect
+  keyed on `scramble` (hydration fires that), and the transport has to read it as
+  a replacement rather than growth — which is what `startingCube`'s identity is
+  for. `showScramble` already gets all of this right. Use it.
+- **Keep what was typed** (plan §4). A scramble pasted as `r U r'` must read back
+  as `r U r'`, never as the canonical `Rw U Rw'`. This is the epic's oldest
+  standing rule and the pad's own `′` inconsistency is already noted below.
+- **A scramble that does not parse must not reach the cube.** Today an unreadable
+  saved scramble falls back to a solved cube; a *pasted* one should be refused at
+  the field with the token named, which is what `solveError` already does for
+  solves.
+- **Where does the control go?** The header's right-hand end is three icons at
+  320 points and **full** (see below), and scramble mode's bottom row is three
+  labelled buttons and also full. There is no spare slot. **Say what it costs the
+  cube, in points, in the PR** — that habit is what made Step 7 legible.
+- **Favorites are keyed by algorithm text.** A pasted scramble that matches one
+  you already saved *is* that favorite, and the star should light up. That falls
+  out of `normalizeAlg` for free — but only if the paste goes through it.
 
 ### Visible in Expo Go when this lands
 
-**Nothing, deliberately** — see above. If the review does make a concrete small
-change, that change is checked in Expo Go like anything else.
+Paste a scramble off a competition sheet, see it on the cube, star it, write a
+solve against it. That is the whole demo and it should be one screen recording.
 
 ### How to verify
 
-- `npm test` (875 today), `npx expo-doctor`, `npx expo export --platform all` —
-  green before and after, and the point of running them is the merge decision
-  rather than the review.
-- If nothing changed in the code, say so and show the three runs anyway.
-- **Then look at it on a device**, because half the merge decision is that
-  sentence.
+- `npm test` (889 today) — and the new rules are pure, so they are testable:
+  a pasted scramble that matches a favorite, one that does not parse, one that
+  normalizes to an existing one.
+- `npx expo-doctor` (18/18), `npx expo export --platform all`.
+- A headless driver at 320×568, 375×667 and 393×852: paste, refuse a bad one,
+  confirm the star, confirm the solves list follows the new scramble.
+- **And a device.** See the review's merge condition — it applies to every step
+  from here.
 
 ---
 
 ## The step after that (for the file you rewrite)
 
-**Step 11 — enter a cube by hand** (plan §8, unspecified in detail): paste an
-algorithm, or set the colours facelet by facelet, for a cube that came off a
-table rather than out of the generator. After that the epic is open questions,
-and question 14 is the live one.
+After Step 11 the epic's planned work is **done**, and what is left is the open
+questions below — of which **14 is the live one** and wants a drilling session
+rather than an opinion. `docs/cube-review.md` also leaves three findings written
+down (clearing a solve spelled twice, the List/Compare toggle's rule in JSX, and
+`utils/gameProgress.js` inverting the dependency); the third is the only one big
+enough to be a step, and it is a platform tidy rather than cube work.
 
 ---
 
-
 ## Open questions for the operator (carry these forward)
 
-These are plan §9, restated so a session does not have to go looking. None block
-Step 10 — but several of them are *findings waiting to be written down*, which is
-new: a review is the step with standing to say "this is a question for the
-operator and here is what it costs either way".
+These are plan §9, restated so a session does not have to go looking. **None
+block Step 11**, and Step 10 was the step with standing to write the ones that
+were really findings down — it did, in `docs/cube-review.md`. What is left here
+is what it says on the tin: questions only the operator can answer, most of them
+by drilling rather than by deciding.
 
 **Number 13 is answered and shipped** (Step 9, 2026-08-06). **Number 14 is the
 live one and Step 8 sharpened it into a number**: the pad and scrubber cost the
@@ -262,8 +272,8 @@ is the right trade is a question only the operator can answer by drilling on it.
 answered *and shipped*, including the part that wanted use: the hold threshold
 was drilled on and moved from 180ms to 300ms.
 
-**What is left in the epic after Step 10** is Step 11 (enter a cube by hand),
-then these questions. Two rows left the table on 2026-08-06 rather than moving
+**What is left in the epic after Step 11** is these questions, and nothing else
+that was planned. Two rows left the table on 2026-08-06 rather than moving
 down it — the editor is tabled and the optimizer is outsourced — so the backlog
 is genuinely shorter than it was, not rearranged. Plan §8.9, and **a review that
 recommends building either of them is re-opening a decision the operator already
@@ -386,7 +396,8 @@ made.**
   standing warning: both animation bugs this repo has shipped were invisible in
   the browser. This one uses no native driver and no `setValue`, which is the
   class of problem avoided rather than dodged, but a device pass is still the
-  only evidence that counts for how it *feels*.
+  only evidence that counts for how it *feels*. **Step 10 made this the one
+  condition on merging the epic** — see `docs/cube-review.md`.
 - ~~**`useScramblePlayer` assumes a solved starting cube.**~~ **Done in Step 3**:
   `buildPlayback(alg, { from })` and `useScramblePlayer(alg, from)`.
 - **The text field appends; it cannot edit.** **Tabled on 2026-08-06 — plan §8.9
@@ -420,11 +431,12 @@ made.**
   always a real page and never a surprise — but there is no count of solves
   visible in scramble mode at all, and "how many attempts have I written at
   this?" is a question the hub badge now answers and the screen does not.
-- **`readCubeSave` lives in `favorites.js` and now reads four things**, only one
-  of which is favorites. It was left there because it is where every caller
-  already looks and moving it is churn across `storage.js` and the tests, but
-  the file is misnamed for what it holds. A step with reason to touch both could
-  reasonably split a `cubeSave.js` out of it.
+- ~~**`readCubeSave` lives in `favorites.js` and now reads four things.**~~
+  **Decided in Step 10: leave it** (`docs/cube-review.md`, finding 7). The
+  argument got stronger rather than weaker — `readCubeSave` is four lines
+  delegating to `solveList.js`, so a `cubeSave.js` would be a file whose entire
+  content is a call to two other files. **The file is misnamed, not misplaced.**
+  If it ever grates, rename `favorites.js`; do not split it.
 - **A solve is culled by age, not by use.** `MAX_SOLVES` is 100 across the whole
   file, newest-created first, oldest dropped — and `savedAt` is creation time
   and is never bumped, so editing a very old solve does not protect it. At 100
@@ -432,6 +444,9 @@ made.**
   ever came down. **Step 9 is the first thing that makes an old solve worth
   keeping** — the attempt you are measuring against is by definition the older
   one — so if the cap ever feels real, this is why. It was not changed.
+  **Step 10 looked at it and left it** (`docs/cube-review.md`, finding 8): the
+  cap is across the whole file, 100 is unreachable in practice, and a review is
+  not where a number like that should move. Revisit only if the cap comes down.
 - **The pad only ever writes a straight `'`**, so a solve cannot be entered with
   a curly apostrophe from it — but one *pasted* into the text field is kept as
   typed, and will read back as `R’` next to the pad's `R'`. Honest (plan §4 says
@@ -543,13 +558,86 @@ made.**
 
 ## Steps already done
 
+### **Step 10 — the architecture review, and the merge decision** ✅ *(2026-08-07)*
+
+Shipped: **a verdict, in `docs/cube-review.md`, and a yes on merging `epic/cube`
+into `main`** — with one condition, which is a drilling session on a real
+handset, because half of "would a staff engineer sign this off" is evidence and
+this epic has never had that kind. 889 tests, 18/18 from doctor, all three
+platforms bundling.
+
+**Nine findings; four fixed, three written down with recommendations, two closed
+as decisions.** The step was allowed to change only what was concrete and small
+and it stayed inside that: **the only file it touched outside `games/cube/` was
+`utils/buildNotes.js`.** It looked hardest at the shared seam and *recommended*
+the change it found there rather than making it, which is the outcome §8.11
+wanted.
+
+**One real defect, and it is the one this epic would have minded most.**
+`saveCubeState` is debounced 400ms and `CubeScreen` flushed it on **unmount** and
+nothing else — but **backgrounding an app unmounts nothing**, so the last edit sat
+in the debounce and a phone that then evicted the process never wrote it. Up to
+400ms of *authored* work: the move just entered, the name just typed, the marker
+just dropped. That is Step 4's own complaint — *"if I background the app and come
+back… my solve I was working on is gone"* — in a narrower window, and **the cube
+was the only persisted surface in the app without the guard**: `usePersistentReducer`
+has had one since the hub existed, `useFungikuWallet` has its own, and
+`utils/debounce`'s docstring names the two moments `flush()` is for as "a screen
+unmounts **or the app backgrounds**". The cube did one half.
+
+**Proven with a counterfactual rather than a passing test.** `background.mjs`
+writes a move and backgrounds the app 60ms later, then reads `localStorage`: with
+the fix, `Solve 1: "R"`; with the listener disabled and the bundle re-exported,
+`Solve 1: ""`. Two other findings were dead code (`FACE_NAMES`, which was also a
+second face→colour table next to the live one in `orientation.js`, and a leftover
+style), and one was a screen-reader gap — **and the reason that one survived nine
+steps is worth keeping**: `solve.test.js` already walked every pad key through
+`describeToken` and asserted `toBeTruthy()`, and **the fallback is truthy**. The
+test that looked like it covered it could not fail.
+
+Three things it decided rather than changed, so they do not get re-litigated:
+
+- **`readCubeSave` stays in `favorites.js`.** A `cubeSave.js` would be a file
+  whose entire content is a four-line function delegating to two other files.
+- **`MAX_SOLVES` stays at 100.** A review is not where a cap moves.
+- **`utils/gameProgress.js` inverting the dependency is real and the fix is
+  recommended — but not as a review's "concrete and small".** §8.11 said to check
+  the cost first, and the cost is not what the sketch assumes: the functions live
+  in a shared util because **jest runs with `testEnvironment: "node"`**, and the
+  obvious home for each — next to its game's storage — is exactly the one that
+  imports `AsyncStorage` and breaks 34 assertions. Done properly it is three new
+  pure modules, a three-way test split and a rename, for no user-visible effect.
+  **The node-test trade survives it, which was the actual question.**
+
+**Storage compatibility was proven, not asserted**, by extracting the real Step
+1/3-era modules from `af0e12c`, having that code write a save, and opening it
+with today's reader. Forward: scramble and every favorite come back identical,
+`solves` empty. Backward: a Step 10 file read by Step 3 code is fine — **but if
+that old build writes, the solves are gone.** Not a blocker, and the reason is
+specific: **the cube has never shipped to `main`**, so no build in the wild can
+do it. Reachable only by rolling an EAS Update branch of the epic back on a
+device that already has solves. Worth knowing; not worth a migration.
+
+Also fixed: the `3.1.0` build-notes entry still carried Step 1's date. Read back
+as a whole it **does** read like one feature — scramble → inspect → hold → write
+→ annotate → compare → keep, which is the order it is used in — so nothing was
+restructured, and nothing was added for Step 10 either: its one user-visible
+change is that the entry's existing promise about backgrounding is now more true.
+
+Verified with `npm test` (889, one new), `npx expo-doctor` (18/18), `npx expo
+export --platform all`, `background.mjs` both ways, and `walk.mjs` at 320×568,
+375×667 and 393×852 — no overflow, no console errors, and the legend's newly
+derived label reading character-for-character what the hand-written one said.
+**Not yet seen on a device, and that is the merge's one condition.**
+
 ### **Step 9 — compare your attempts** ✅ *(2026-08-06)*
 
 Shipped: **the solves list can answer "am I getting better at this scramble?"**
 A **Compare** toggle turns the per-scramble list into a table — one row per
 attempt, one column per phase — and `First block  8 · 7 · 6` reads straight down
-the column. The fewest moves in each column is marked. 875 tests across the app,
-40 of them new.
+the column. The fewest moves in each column is marked. **888** tests across the
+app, 40 of them new. *(This entry and the one below said 875 until Step 10
+measured the suite at Step 9's own merge commit and got 888.)*
 
 **It cost the cube nothing**, which is most of the argument for where it went.
 The 42-move annotated budget is identical to Step 8's:
@@ -591,8 +679,8 @@ Two things it learned, neither of which a passing test would have said:
   key tints got in during Step 8. `accentInk` lifts it toward white on a dark
   surface and `padPalette.test.js` pins it on all eight themes.
 
-Verified with `npm test` (875), `npx expo-doctor` (18/18), `npx expo export
---platform all`, and four headless drivers at 320×568, 375×667 and 393×852 with
+Verified with `npm test` (888 — see above), `npx expo-doctor` (18/18), `npx expo
+export --platform all`, and four headless drivers at 320×568, 375×667 and 393×852 with
 the screenshots read: `budget.mjs` seeds the 42-move annotated solve and prints
 every row of solve mode with its height, proving the numbers above; `compare.mjs`
 opens the list from the bar under the pad, switches to Compare, reads every cell

--- a/docs/cube-review.md
+++ b/docs/cube-review.md
@@ -13,15 +13,25 @@ here as a finding with a recommendation and was deliberately not built.
 
 ## The verdict
 
-**Merge `epic/cube` into `main`: yes.**
+**Merge `epic/cube` into `main`: yes. Unconditionally.**
 
-Nothing found in this review blocks it. There is **one condition, and it is the
-condition the epic has been carrying since Step 7**: the cube has never been
-looked at on a physical device by anyone but the operator, and this epic's worst
-shipped bug passed every browser check at three widths and was broken on a phone.
-The merge should follow one drilling session on a real handset. That is a
-sign-off on the code, waiting on evidence only a thumb can produce — not a
-finding.
+Nothing found in this review blocks it.
+
+This document was first written with **one condition** on it — that the cube be
+drilled on a physical handset before the merge, because every check this epic
+runs is a browser at three widths and Step 7 shipped a header that passed all of
+them and was broken on a phone. **The operator answered it the same day
+(2026-08-07): they have been testing on device the whole way through the epic.**
+
+That is worth recording rather than just deleting, because it re-reads the whole
+evidence trail: the corrections that arrived mid-step and looked like polish were
+device findings all along — *"I'm getting a lot of prime moves when I want a
+regular turn"* (the 300ms threshold), *"it's hard to see the prime symbols when
+your finger is on the button"* (the armed `′`), *"the second one doesn't seem
+animated"* (`promotedTurn`), *"let's remove the red segments"* (the tick track).
+**None of those could have come from a browser.** The device pass was not
+missing; it was continuous, and it was the source of the epic's best corrections.
+The gap was in the *record*, not in the testing.
 
 What the review is signing off:
 
@@ -337,22 +347,29 @@ component.**
 
 ### Does it stand up on a device?
 
-**Unproven, and this is the one condition on the merge.** Every check this epic
-has run since Step 1 is a browser at three widths, and Step 7 is the standing
-proof that this is not enough: a header that passed every one of them was broken
-on a real iPhone, because web and Yoga disagreed about a flattened style. Two
-further things are invisible to any headless check by construction:
+**Yes — confirmed by the operator (2026-08-07), who has been testing on device
+throughout the epic.**
+
+This review initially recorded it as unproven, because the *written* evidence in
+`docs/` is entirely headless: browsers at three widths, screenshots read back,
+overflow flags. That was a gap in the record and not in the testing, and the
+distinction matters for anyone reading this later. Three things are invisible to
+any headless check by construction, and all three were in fact judged by hand:
 
 - **`expo-haptics` fires exactly once**, at the hold threshold, guarded by
-  `Platform.OS !== 'web'`. Every check ever run on this epic ran with it off.
-- **The hold gesture's whole confirmation is drawn under the thumb causing it** —
-  which is what produced the armed `′` key in the first place. *The browser has
-  no thumb.*
+  `Platform.OS !== 'web'`. Every automated check ever run on this epic ran with
+  it switched off.
+- **The hold gesture's whole confirmation is drawn under the thumb causing it**,
+  which is exactly what produced the armed `′` key as a second route. *The
+  browser has no thumb.*
+- **The turn animation's feel**, which `docs/fungiku-plan.md` §2 warns about and
+  which no assertion about the ends of a move can see.
 
-Nothing here suggests a defect. It is simply that half of "would a staff engineer
-sign this off" is evidence, and for the feel of this screen the only evidence
-that counts is a handset. **Recommendation: one drilling session in Expo Go on
-`epic/cube` before the merge button, not a re-review after it.**
+**The lesson for the next epic is a process one, not a code one:** when a device
+finding arrives as a one-line correction — *"I'm getting a lot of prime moves"* —
+write down that it came from a device. Nine steps of headless evidence and a
+trail of hand-found corrections read, to a reviewer, like a feature that had
+never been held. It had been held the whole time.
 
 ### Storage compatibility — proven, not asserted
 
@@ -426,6 +443,10 @@ Beyond the three standard runs:
   *(Headless Chromium keeps a backgrounded tab `visible` — there is no window
   manager to hide it — so `document.visibilityState` is driven directly. That is
   the one stubbed input; on a device the OS supplies it.)*
+- **The operator's own device testing**, continuous across the epic and the
+  source of Step 8's two same-day corrections, Step 7a, and the 300ms hold
+  threshold. It is the evidence this document was missing rather than the
+  evidence the epic was missing.
 - **`walk.mjs`** — a regression walk at 320×568, 375×667 and 393×852: into the
   cube, into solve mode, set the hold, three moves through the pad, open the
   solves list, back out. **No horizontal overflow, no vertical overflow, no

--- a/docs/cube-review.md
+++ b/docs/cube-review.md
@@ -1,0 +1,454 @@
+# Cube Scramble — architecture review and merge decision
+
+**Step 10, 2026-08-07.** The brief is `docs/cube-plan.md` §8.11: stand back from
+nine steps of feature work, against one bar — *would a staff engineer sign this
+off* — and end in a decision rather than a diff.
+
+This document **is** the deliverable. The code changes that came out of it are
+four, all small, and they are listed under [What was
+changed](#what-was-changed); everything else the review found is written down
+here as a finding with a recommendation and was deliberately not built.
+
+---
+
+## The verdict
+
+**Merge `epic/cube` into `main`: yes.**
+
+Nothing found in this review blocks it. There is **one condition, and it is the
+condition the epic has been carrying since Step 7**: the cube has never been
+looked at on a physical device by anyone but the operator, and this epic's worst
+shipped bug passed every browser check at three widths and was broken on a phone.
+The merge should follow one drilling session on a real handset. That is a
+sign-off on the code, waiting on evidence only a thumb can produce — not a
+finding.
+
+What the review is signing off:
+
+- **The pure core is real and it is the reason this epic is reviewable at all.**
+  Twelve of the 29 modules in `games/cube/` import nothing from React Native —
+  3,072 lines carrying **427 of the app's 889 tests**, one suite per module, no
+  suite testing anything else's job. `moves`, `cubeState`, `geometry`,
+  `orientation`, `player`, `solve`, `solveList`, `scramble`, `trackLayout`,
+  `compareLayout`, `padPalette` and `favorites` are where the thinking is, and
+  the components above them draw it.
+- **The data-is-the-source-of-truth habit is genuine**, not just claimed.
+  `PAD_LAYOUT` → derived `PAD_KEYS`, `PHASE_METHODS`, `GROUPS`/`LEGEND` in
+  `padPalette.js`, `BASE_MOVES`/`WIDE_MOVES` in `moves.js`. Two exceptions were
+  found and both are noted below; both were one-line-class problems, not
+  structural ones.
+- **The one-rule-one-function rule holds where it matters most.** `clampPhases`
+  has exactly two callers and they are the live edit and the file read, which is
+  the pairing Step 6's scar is about. `withMoves` funnels every edit to a solve's
+  moves. `extendsAlg` and `promotedTurn` each have one definition and one caller.
+  `phaseSpans` is the only thing that counts a phase, and `comparePhases` calls it
+  rather than counting again.
+- **Nothing here is more general than its use.** No plugin framework, no game
+  SDK, no base class, no abstract `Game`. `games/registry.js` is a list of seven-
+  field objects and the hub maps over it. **This review proposes none of those
+  either** — three games is not evidence for any of them.
+
+---
+
+## The bar, in order
+
+### 1. Is the data the source of truth, or is it in the code?
+
+Mostly the data. The epic's own exemplar is honest: `PAD_LAYOUT` owns which key
+sits where and `PAD_KEYS` is `PAD_LAYOUT.filter(cell => cell.key).map(...)`, so
+adding a key is one edit. `padPalette.js` holds the design's five groups as hexes
+and derives every themed variant from them. `PHASE_METHODS` holds the Roux and
+CFOP vocabularies as data and `CubePhaseModal` renders whatever is in it.
+
+**Two places kept a second copy of a list**, and both are the same failure shape
+— a table that cannot be *derived* from the first one, and so was quietly allowed
+to drift out of step with it:
+
+- `SPOKEN_KEY` in `solve.js` is the pad's fourteen keys a second time, as sounds.
+  It genuinely cannot be derived from `PAD_LAYOUT` (a layout does not know how a
+  key is pronounced) **and its domain is wider besides** — a solve typed into the
+  text field can contain `Rw` or `u`, which the pad has no key for. So the right
+  answer is not to merge the tables but to pin them against each other. **Fixed**,
+  as a test.
+- `CubePadLegend`'s `accessibilityLabel` restated `LEGEND`'s four groups as a
+  hand-written string. A fifth tint would have been drawn and not announced.
+  **Fixed**, by putting the spoken form in `LEGEND` beside the printed one.
+
+The one *structural* hit on this bar is `CubeSolvesModal`'s List/Compare toggle,
+where an inline two-element array carries the keys but the label and hint are
+three separate `mode.key === 'compare'` ternaries in the JSX below it. It is six
+lines and two modes. **Written down, not fixed** — see finding 5.
+
+### 2. One rule, one function
+
+Checked every rule with more than one caller:
+
+| Rule | Where it lives | Callers | Verdict |
+|---|---|---|---|
+| What a press means | `applyPadPress` (`solve.js`) | `tapKey` only | ✅ one home |
+| What shifts a phase marker | `clampPhases` (`solveList.js`) | `withMoves` (live), `sanitizePhases` (file) | ✅ the pairing Step 6 exists for |
+| Extension vs. replacement | `extendsAlg` (`player.js`) | `useScramblePlayer` | ✅ |
+| The third case, a promotion | `promotedTurn` (`player.js`) | `useScramblePlayer` | ✅ |
+| What counts a phase | `phaseSpans` (`solveList.js`) | strip, modal, `comparePhases` | ✅ nothing else counts |
+| Half-finished gestures | `resetGesture` (`CubeScreen`) | nine transitions | ✅ and the comment says why |
+| Normalizing an algorithm | `normalizeAlg` (`moves.js`) | favorites, solves, storage | ✅ re-exported, not re-implemented |
+
+Two near-misses, both written down rather than fixed:
+
+- **Clearing a solve is spelled `{ alg: '', phases: [] }` in two places** —
+  `clearSolve` and `clearSolveById` in `CubeScreen.js`. The second delegates to
+  the first when the solve is the open one and writes the literal itself when it
+  is not. It is the same rule twice, in the file whose golden rule this is. See
+  finding 4.
+- **`describeSolve` (`solve.js`) and `describeSolveSize` (`solveList.js`)** both
+  turn a move count into English, differing only in what zero says ("No moves
+  yet" vs "empty"). That difference is real — one is a status bar, one is a row
+  in a picker — so this is a duplication that is *arguably* correct. See finding
+  6.
+
+### 3. Is anything more general than its one use?
+
+**No, and this is the strongest part of the epic.** The temptation this bar
+exists to catch — a `Game` base class, a `usePuzzleScreen`, a shared
+`GameStorage` — has been resisted for three games running. `games/registry.js` is
+a plain array. `App.js` routes on `id` with no branching per game. `ScreenHeader`
+grew a `dense` prop and an `actions` prop **whose absence is exactly the old
+behaviour**, which is the correct way to extend a shared component and is worth
+naming as the pattern.
+
+The only thing in the cube that is more general than its use is `turnAngle` /
+`partialTurn` taking an optional signed sweep for a single caller — and that is
+already documented as such, with the invariant a second caller would have to
+meet. Leave it.
+
+---
+
+## Plugging into the greater game platform
+
+The cube imports **six** things from outside `games/cube/`:
+
+`hooks/useAppTheme` · `hooks/useBoardSize` · `components/ScreenHeader` ·
+`utils/gameProgress` · `utils/debounce` · `utils/color`
+
+Fungiku imports the same six plus `usePersistentReducer`, `useBoardOrigin`,
+`components/Symbol` and `utils/symbolSets`. **That overlap is the platform**, and
+the review's answer is that it is honest and it is nearly the whole contract.
+
+- **No game-specific special cases leaked out.** Grepped for `id === 'cube'` and
+  for `games/cube` across the app: the only references outside `games/cube/` are
+  the registry entry, `gameProgress.js`'s import, and one comment in
+  `ScreenHeader.js`. The registry's promise holds at the UI layer — **the hub and
+  the router have never learned that the cube exists.**
+- **What the cube does *not* touch is evidence too**, and the review confirms it
+  rather than proposing otherwise: no `contexts/`, no wallet, no coins. Fungiku's
+  economy is ten files, none of them shared. Two games that have nothing to do
+  with each other are correctly coupled by nothing. **A cross-game economy is not
+  recommended and was not designed.**
+
+### The headline candidate: `utils/gameProgress.js` inverts the dependency
+
+Confirmed, and it is real: a shared util imports three games' internals
+(`games/fungiku/engine`, `games/fungiku/difficulty`, `games/cube/scramble`), and
+`games/cube/storage.js` imports `describeCubeProgress` back out of it. So the
+path is `games/cube/storage → utils/gameProgress → games/cube/scramble`, and
+"adding a game is an entry in the registry" is **not quite true** — it is an
+entry, plus an edit to a util every other game depends on.
+
+**§8.11 says to check the cost before recommending it. Here is the cost, and it
+is not the cost the fix's sketch assumes.**
+
+The reason all three `describe*Progress` functions live in a shared util is
+stated at the top of the file and it is correct: **jest runs with
+`testEnvironment: "node"` and no React Native mocks**, so any module a test
+imports must be transitively free of React Native. The obvious home for each
+function — next to the game's own storage — is precisely the home that breaks
+this, because `games/cube/storage.js` and `games/fungiku/storage.js` both import
+`AsyncStorage`. Move `describeCubeProgress` into `storage.js` and 34 assertions
+in `utils/__tests__/gameProgress.test.js` stop being runnable.
+
+So the fix is not "move three functions". It is:
+
+1. Three new pure modules — `games/cube/progress.js`, `games/fungiku/progress.js`
+   and a home for Sudoku's, which currently has none under `games/`.
+2. Splitting `utils/__tests__/gameProgress.test.js` (209 lines, 34 assertions)
+   three ways.
+3. Leaving `gameProgress.js` holding `formatElapsed` and `titleCase` — at which
+   point it is `utils/format.js` and should be renamed.
+
+**Which way it came out: recommend it, but not here and not as a review's
+"concrete and small".** It is six files and three test suites for an
+architectural tidy with no user-visible effect, which is exactly the kind of
+change §8.11 tells this step not to make. It preserves the node-test trade
+completely — that was the real question and the answer is yes — so it is a safe
+follow-up whenever someone is next in those files. **It is not a merge blocker:
+the inversion is ugly on a diagram and costs nothing at runtime, and the
+registry's promise is broken only for the person adding the fourth game.**
+
+### Two ways to persist one thing — and one of them was missing a piece
+
+Fungiku uses `hooks/usePersistentReducer`; the cube rolls its own debounced
+writer over `AsyncStorage` in `games/cube/storage.js`. §8.11 asks the review to
+say which is right, "because right now the answer is nobody decided".
+
+**The answer is that the cube is correct to roll its own, and the platform does
+not have a persistence primitive — `usePersistentReducer` is a reducer hook that
+happens to persist.** It is built around `useReducer` and a restore *action*; the
+cube has no reducer and eight independent pieces of `useState`, and wrapping them
+in a reducer to reach a persistence helper would be inverting the tail and the
+dog. The save shapes differ in kind too, as §8.11 anticipated: Fungiku writes
+puzzle identity and rebuilds the rest deterministically, the cube writes one blob
+read by shape with no version branch.
+
+**But rolling your own means writing all of it, and one part was missing.** That
+is finding 1, below, and it is the only defect this review found.
+
+---
+
+## Findings
+
+### 1. The cube never flushed its pending write when the app backgrounded — **fixed**
+
+**Severity: real, and it is the one the epic would have minded most.**
+
+`saveCubeState` is debounced 400ms. `CubeScreen` flushed it on **unmount** — which
+covers leaving for the hub — and nothing else. **Backgrounding the app does not
+unmount anything**, so the last edit sat in the debounce, and a phone that then
+evicted the process never wrote it. What that costs is up to 400ms of *authored*
+work: the move just entered, the name just typed, the marker just dropped.
+
+This is the exact failure Step 4 was built to answer — *"if I background the app
+and come back… my solve I was working on is gone"* — reintroduced in a narrower
+window. And the cube was **the only persisted surface in the app without the
+guard**: `usePersistentReducer` has had an `AppState` listener since the hub
+existed, `useFungikuWallet` has its own, and `utils/debounce`'s own docstring
+names the two moments `flush()` is for as *"a screen unmounts **or the app
+backgrounds**"*. The cube did one half.
+
+Fixed with the same eleven lines `usePersistentReducer` uses. **Proven rather
+than asserted**, by driving the real web export both ways — see
+[Evidence](#evidence).
+
+### 2. `SPOKEN_KEY` was a second copy of the pad's keys with nothing pinning it — **fixed (as a test)**
+
+Add a key to `PAD_LAYOUT` and it appears on the pad, is parsed, is written, and
+**reads out to a screen reader as a bare letter**, because `describeToken` falls
+back to the character. `M` would be said as "M" rather than "M slice".
+
+The interesting part is *why it survived nine steps*: `solve.test.js` already
+walked every pad key through `describeToken` — and asserted `toBeTruthy()`. **The
+fallback is truthy.** The test that looked like it covered this could not fail.
+Now pinned properly: every `PAD_KEYS` entry must have a non-empty `SPOKEN_KEY`
+entry.
+
+### 3. Two pieces of dead code — **fixed**
+
+- `FACE_NAMES` in `cubeState.js` — six entries, exported, **never imported by
+  anything**, and its comment says it is "for the face legend", which was never
+  built. Worse than merely dead: it is a *second* mapping of face → colour name,
+  next to the live `COLOR_NAMES` in `orientation.js` that the hold readout uses.
+  Two answers to "what colour is D", one of them unreachable.
+- `styles.iconOnly` in `CubeScreen.js` — a leftover from the action row Step 7
+  deleted.
+
+Both removed. No behaviour change; the sweep that found them turned up nothing
+else (one unused export across 29 modules is a good number).
+
+### 4. Clearing a solve is one rule in two places — **written down**
+
+`clearSolve()` and `clearSolveById(id)` in `CubeScreen.js` both spell the cleared
+state as the literal `{ alg: '', phases: [] }`. The split itself is right and its
+comment explains it well — clearing a solve that is *not* on the cube must not
+touch the transport. It is only the shape that is duplicated.
+
+**Recommendation:** a `clearedMoves()` (or a `CLEARED` constant) exported from
+`solveList.js`, next to `withMoves`, used by both. Three lines and two edits.
+
+**Not fixed here**, and the reason is worth stating: this is the review's own
+temptation. It is small, it is correct, and it buys nothing today — the two
+literals cannot drift into a *bug*, only into an inconsistency. It belongs in the
+next step that opens `CubeScreen.js` for another reason.
+
+### 5. The List/Compare toggle spells its rule in JSX — **written down**
+
+`CubeSolvesModal.js` builds the toggle from a two-element array and then asks
+`mode.key === 'compare'` three more times in the JSX for the label, the hint and
+the handler. Putting `label`, `hint` and `compare: true|false` in the array
+objects would make the array the whole rule.
+
+Six lines, two modes, no plausible third. **Recommendation: do it if a third mode
+ever appears, not before.**
+
+### 6. `describeSolve` and `describeSolveSize` are near-duplicates — **written down, and probably correct as-is**
+
+Both render a move count; they differ only at zero ("No moves yet" vs "empty").
+`solve.js` is one page and `solveList.js` is the book, and the two strings serve
+a status bar and a picker row respectively — so this is arguably one rule with
+two presentations rather than two implementations of one rule. **Recommendation:
+leave it.** Noted only so the next person who spots it does not have to re-derive
+the argument.
+
+### 7. `readCubeSave` still lives in `favorites.js` — **decided: leave it, and the reason has changed**
+
+§8.11 gives this step standing to decide whether a `cubeSave.js` is worth the
+churn. **It is not**, and the argument is stronger than "it is where every caller
+looks": `readCubeSave` is four lines that call `sanitizeFavorites` (local),
+`sanitizeSolves` and `sanitizeWorkspace` (both from `solveList.js`). A
+`cubeSave.js` would be a file whose entire content is a four-line function
+delegating to two other files. **The file is misnamed, not misplaced.** If it
+ever grates, rename `favorites.js` — do not split it.
+
+### 8. `MAX_SOLVES` is 100, culled by creation date — **decided: not a finding**
+
+§8.11 says decide rather than change. `savedAt` is creation time and is never
+bumped, so editing a very old solve does not protect it — but the cap is per
+*file*, not per scramble, and 100 solves is unreachable in practice. Step 9 made
+old solves worth keeping, which is the thing that would make this real. **It is
+not real yet.** Revisit if the cap ever comes down; do not change it in a review.
+
+### 9. Documentation drift — **fixed in the handoff**
+
+Three numbers in `docs/` had fallen behind the code. `docs/cube-plan.md` §8.11
+says "24 modules in `games/cube/`" and "Step 9 added a 26th"; the actual count is
+**29**. The handoff says the suite is "875 today"; it was **888** at the epic tip
+and is **889** now. Corrected where the handoff repeats them. Left alone in the
+plan, which is a record of what each step said at the time.
+
+---
+
+## What was changed
+
+Four changes, all of them small, one of them a defect fix:
+
+| File | Change |
+|---|---|
+| `games/cube/CubeScreen.js` | Flush the pending save on `AppState` background/inactive (finding 1). Remove the dead `iconOnly` style (finding 3). |
+| `games/cube/solve.js` | Export `SPOKEN_KEY` so the pad's two key lists can be pinned against each other (finding 2). |
+| `games/cube/__tests__/solve.test.js` | The pin: every pad key has a spoken form (finding 2). |
+| `games/cube/padPalette.js`, `games/cube/CubePadLegend.js` | `LEGEND` carries the spoken word beside the printed one; the legend's `accessibilityLabel` is derived from it rather than restating it (bar 1). |
+| `games/cube/cubeState.js` | Remove the dead, duplicative `FACE_NAMES` (finding 3). |
+| `utils/buildNotes.js` | `3.1.0`'s date moved to the merge date. |
+
+**No logic in the pure core was touched, and nothing was moved out of it into a
+component.**
+
+---
+
+## The merge decision
+
+### Does it stand up on a device?
+
+**Unproven, and this is the one condition on the merge.** Every check this epic
+has run since Step 1 is a browser at three widths, and Step 7 is the standing
+proof that this is not enough: a header that passed every one of them was broken
+on a real iPhone, because web and Yoga disagreed about a flattened style. Two
+further things are invisible to any headless check by construction:
+
+- **`expo-haptics` fires exactly once**, at the hold threshold, guarded by
+  `Platform.OS !== 'web'`. Every check ever run on this epic ran with it off.
+- **The hold gesture's whole confirmation is drawn under the thumb causing it** —
+  which is what produced the armed `′` key in the first place. *The browser has
+  no thumb.*
+
+Nothing here suggests a defect. It is simply that half of "would a staff engineer
+sign this off" is evidence, and for the feel of this screen the only evidence
+that counts is a handset. **Recommendation: one drilling session in Expo Go on
+`epic/cube` before the merge button, not a re-review after it.**
+
+### Storage compatibility — proven, not asserted
+
+§8.11 says prove it. The proof was run by extracting the **actual Step 1/3-era
+`favorites.js`, `moves.js` and `scramble.js` from commit `af0e12c`**, having that
+code write a save file, and opening it with today's reader — and then the reverse.
+
+- **Forward (the real case — a user upgrades).** A `{_v: 1, scramble, favorites}`
+  file written by the Step 3 code, read by today's `readCubeSave`: the scramble
+  and all three favorites come back identical, `solves` is `[]`, `workspace` is
+  the empty workspace. **Nothing lost.** ✅
+- **Backward (a downgrade).** A Step 10 file read by the Step 3 code: the
+  scramble and the favorites come back identical and the solves are simply not
+  seen — no crash, no corruption. ✅ **But if that old build then writes, the
+  solves are gone** (1 → 0 in the run), because its writer emits only two keys.
+
+  **This is not a merge blocker and the reason is specific: the cube has never
+  shipped to `main`.** There is no build in the wild that can read `@CubeScramble`
+  and write it back without `solves`. The only way to reach this is to open an
+  older EAS Update branch of the epic itself, in Expo Go, on a device that already
+  has solves — which is an operator's own workflow, not a user's. **Worth knowing
+  before rolling an update back; not worth a migration.**
+- **Round trip.** An annotated solve — hold, twelve moves, a phase marker —
+  through today's writer and reader comes back deep-equal, with `r U r'` still
+  spelled the way it was typed rather than canonicalised to `Rw U Rw'` (plan §4).
+  The one thing that does not survive bit-identically is the view angle, which
+  `sanitizeView` wraps: **3.3e-16 radians of float drift per round trip**, which is
+  noise and is the price of `wrapAngle` refusing to store a yaw of `1e9`.
+
+### The three runs
+
+| | Result |
+|---|---|
+| `npm test` | **889 passed, 25 suites** (888 before this step; +1 new test) |
+| `npx expo-doctor` | **18/18 — no network failures in this environment** |
+| `npx expo export --platform all` | **web + iOS + Android all bundled** |
+
+### Build notes and `app.json`
+
+Per §12 these are per release, not per step. `app.json`'s `expo.version` is
+`3.1.0` and matches the newest key in `utils/buildNotes.js`. ✅
+
+**Read back as a whole, the `3.1.0` entry does read like one feature** rather than
+nine steps stapled together: it opens by saying what the tool is, then walks
+scramble → inspect → hold → write → annotate → compare → keep, which is the order
+someone actually uses it in. No restructuring needed. The only stale field was the
+**date**, which still said `2026-08-01` — Step 1's day, not the release's. Moved to
+the merge date.
+
+Nothing was added for Step 10: its one user-visible change is that a solve
+written in the half-second before you background the app is now kept, and the
+entry already promises *"Solves are kept: background the app, come back, and your
+solve is where you left it."* **That line is simply more true than it was.**
+
+---
+
+## Evidence
+
+Beyond the three standard runs:
+
+- **`background.mjs`** — the fix, driven against the real web export at 375×667.
+  It taps `Solve`, sets a hold, writes one move, and backgrounds the app **60ms
+  later**, well inside the 400ms debounce, then reads `localStorage` directly.
+  react-native-web maps `AppState` to `visibilitychange`, so everything
+  downstream of the visibility signal is the app's own unmodified path:
+  AppState → the screen's listener → `flush()` → AsyncStorage → `localStorage`.
+  **With the fix: `Solve 1: "R"`. With the listener disabled and the bundle
+  re-exported: `Solve 1: ""`.** The counterfactual is what makes it a proof and
+  not a passing test.
+
+  *(Headless Chromium keeps a backgrounded tab `visible` — there is no window
+  manager to hide it — so `document.visibilityState` is driven directly. That is
+  the one stubbed input; on a device the OS supplies it.)*
+- **`walk.mjs`** — a regression walk at 320×568, 375×667 and 393×852: into the
+  cube, into solve mode, set the hold, three moves through the pad, open the
+  solves list, back out. **No horizontal overflow, no vertical overflow, no
+  console errors at any size**, and the legend's newly-derived label reads
+  `Key colours: faces, slices, wide turns, rotations` at 393×852 — character-for-
+  character what the hand-written string said — and is correctly absent below
+  `LEGEND_MIN_HEIGHT` at the two shorter sizes.
+- **The storage proof** above, run against code extracted from `af0e12c`.
+
+---
+
+## What this review deliberately did not do
+
+- **It did not build a plugin framework, a game SDK or a base class.** §8.11 rules
+  them out and the review agrees: three games is not enough evidence, and
+  inventing one here would fail its own review.
+- **It did not re-propose the two rows that left the table on 2026-08-06.** The
+  text editor is tabled and the optimizer is outsourced (plan §8.9). Both
+  decisions look right from here — in particular, the argument that improving a
+  block changes the cube every later move is applied to, so marker arithmetic
+  would carefully preserve annotations that had stopped being true, is a better
+  argument than "it is a lot of work".
+- **It did not move logic out of the pure core.** §8.11 says any such finding is
+  a finding to reject, and none arose.
+- **It did not fix everything it found.** Three findings are written down with
+  recommendations and left for whoever is next in those files.


### PR DESCRIPTION
Closes the last planned step before Step 11. The brief is `docs/cube-plan.md` §8.11: stand back from nine steps of feature work against one bar — *would a staff engineer sign this off* — and end in a decision rather than a diff.

**What ships is the verdict: [`docs/cube-review.md`](docs/cube-review.md).** This is the one step exempt from "must be visible in Expo Go", deliberately. Code changes were allowed only where the review found something concrete and small.

## The verdict

**Merge `epic/cube` into `main`: yes, unconditionally.**

The review was first written with one condition — a drilling session on a physical handset, because every piece of written evidence in `docs/` is headless and Step 7 shipped a header that passed every browser check at three widths and was broken on a phone. **The operator answered it the same day: they have been testing on device throughout the epic.**

That is recorded rather than deleted, because it re-reads the evidence trail. The 300ms hold threshold, the armed `′` key, `promotedTurn`'s unanimated second quarter and the tick track's removal are all device findings — none of them could have come from a browser. **The gap was in the record, not in the testing**, and the process lesson carried into the handoff is to say when a correction came from a hand.

## Nine findings: four fixed, three written down, two closed as decisions

**The only file touched outside `games/cube/` is `utils/buildNotes.js`.** The review looked hardest at the shared seam and *recommended* the change it found there rather than making it, which is the outcome §8.11 wanted.

### One real defect (fixed)

`saveCubeState` is debounced 400ms, and `CubeScreen` flushed it on **unmount** and nothing else. **Backgrounding an app unmounts nothing**, so the last edit sat in the debounce, and a phone that then evicted the process never wrote it. What that costs is up to 400ms of *authored* work: the move just entered, the name just typed, the marker just dropped.

That is Step 4's own founding complaint — *"if I background the app and come back… my solve I was working on is gone"* — in a narrower window. And the cube was **the only persisted surface in the app without the guard**: `usePersistentReducer` has had an `AppState` listener since the hub existed, `useFungikuWallet` has its own, and `utils/debounce`'s own docstring names the two moments `flush()` is for as *"a screen unmounts **or the app backgrounds**"*. The cube did one half.

Fixed with the same eleven lines the platform already uses.

### The other three fixes

- **`SPOKEN_KEY` was a second copy of the pad's fourteen keys with nothing pinning it.** Add a key to `PAD_LAYOUT` and it appears, parses, writes — and **reads out to a screen reader as a bare letter**. The reason it survived nine steps is worth keeping: `solve.test.js` already walked every pad key through `describeToken` and asserted `toBeTruthy()`, and **the fallback is truthy**. The test that looked like it covered this could not fail.
- **The legend restated `LEGEND`'s four groups in a hand-written `accessibilityLabel`** — a fifth tint would have been drawn and not announced. The spoken word now lives in `LEGEND` beside the printed one.
- **Two pieces of dead code.** `FACE_NAMES` in `cubeState.js` was exported, never imported, and was also a *second* face→colour table next to the live `COLOR_NAMES` in `orientation.js`. Plus a leftover style from the action row Step 7 deleted.

### Three written down, not built

Clearing a solve is spelled `{ alg: '', phases: [] }` in two places; the List/Compare toggle spells its rule in JSX; and `utils/gameProgress.js` inverts the dependency. Each has a recommendation in the review. The last is the headline candidate and §8.11 said to check its cost first — **the cost is not what the sketch assumes**: those functions live in a shared util because jest runs `testEnvironment: "node"`, and the obvious home for each (next to its game's storage) is exactly the one importing `AsyncStorage`, which would break 34 assertions. Done properly it is three new pure modules, a three-way test split and a rename, for no user-visible effect. **The node-test trade does survive it — that was the actual question — so it is recommended as a follow-up, not as a review's "concrete and small".**

### Two closed as decisions

`readCubeSave` stays in `favorites.js` (a `cubeSave.js` would be a file whose entire content is a four-line function delegating to two others — it is misnamed, not misplaced), and `MAX_SOLVES` stays at 100.

## What the review is signing off

- **The pure core is the reason this epic is reviewable at all.** 12 of 29 modules import nothing from React Native — 3,072 lines carrying **427 of the app's 889 tests**, one suite per module.
- **Data really is the source of truth**: `PAD_LAYOUT` → derived `PAD_KEYS`, `PHASE_METHODS`, `padPalette`'s `GROUPS`. Both exceptions found were one-line-class, not structural.
- **Nothing is over-generalised.** No base class, no game SDK, no plugin framework, across three games — and this review proposes none either.
- **The registry seam holds**: no `id === 'cube'` special case anywhere. The hub and the router have never learned the cube exists.
- **Two ways to persist one thing, and the answer is that the cube is right to roll its own.** `usePersistentReducer` is a reducer hook that happens to persist; the cube has no reducer and eight independent pieces of state. The platform does not have a persistence primitive.

## Storage compatibility — proven, not asserted

§8.11 says prove it. The proof extracted the **actual Step 1/3-era `favorites.js`, `moves.js` and `scramble.js` from `af0e12c`**, had that code write a save file, and opened it with today's reader.

- **Forward (a user upgrades):** scramble and all favorites come back identical, `solves` empty. ✅
- **Backward (a downgrade):** reads fine, no crash — **but if that old build then writes, the solves are gone** (1 → 0). Not a blocker, and the reason is specific: **the cube has never shipped to `main`**, so no build in the wild can do it. Reachable only by rolling an EAS Update branch of the epic back on a device that already has solves.
- **Round trip:** an annotated solve comes back deep-equal, with `r U r'` still spelled as typed rather than canonicalised (plan §4). The view angle drifts 3.3e-16 rad — the price of `wrapAngle` refusing to store a yaw of `1e9`.

## Verification

| | Result |
|---|---|
| `npm test` | **889 passed, 25 suites** (888 before; +1 new) |
| `npx expo-doctor` | **18/18**, no network failures in this environment |
| `npx expo export --platform all` | web + iOS + Android all bundled |

Plus two headless drivers:

- **`background.mjs`** — the fix, driven against the real web export. Writes a move and backgrounds the app **60ms later**, well inside the 400ms debounce, then reads `localStorage`. **With the fix: `Solve 1: "R"`. With the listener disabled and the bundle re-exported: `Solve 1: ""`.** The counterfactual is what makes it a proof rather than a passing test.
- **`walk.mjs`** — regression walk at 320×568, 375×667 and 393×852. No horizontal or vertical overflow, no console errors at any size, and the legend's newly derived label reads character-for-character what the hand-written string said.

## Build notes

`app.json`'s `expo.version` is `3.1.0` and matches the newest key. Read back as a whole, the `3.1.0` entry **does** read like one feature — scramble → inspect → hold → write → annotate → compare → keep, which is the order it is used in — so nothing was restructured. The only stale field was the date, still showing Step 1's day. Nothing was added for Step 10: its one user-visible change is that the entry's existing promise about backgrounding is now more true.

## Handoff

`docs/cube-handoff.md` now briefs **Step 11 — enter a cube by hand**, whose first job is deciding whether pasting an algorithm and setting colours facelet-by-facelet are one step or two. (The honest reading: two — the second has a real "is this cube physically possible" validation problem in it.) Also corrected Step 9's recorded test count, which said 875 where the suite at its own merge commit is 888.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExzCMNM7RjyP8FgjFUHspe)_