### PR TITLE
Step 10a: the promotion turned the wrong way on L, D and B

### DIFF
--- a/SudokuApp/games/cube/__tests__/geometry.test.js
+++ b/SudokuApp/games/cube/__tests__/geometry.test.js
@@ -238,6 +238,82 @@ describe('buildScene', () => {
       solved.polygons.map((p) => p.fill)
     );
   });
+
+  /**
+   * **The promotion's frame, at the seam the renderer actually reads.**
+   *
+   * `turnAngle` and `partialTurn` have pinned the signed sweep since Step 8, and
+   * they kept passing while the promotion animated backwards on a phone — because
+   * the value was computed correctly and then **dropped one spread short of
+   * `buildScene`** (operator, 2026-08-07: *"double tapping for moves like L and
+   * D, the animation seems to reverse the direction"*).
+   *
+   * So this asserts the thing that was broken rather than the arithmetic under
+   * it: **the first frame of the promoted half turn is the frame the cube is
+   * already showing.** A `D` that has finished its quarter and a `D2` picked up
+   * at `t = 0.5` must draw the same 27 stickers in the same 27 places.
+   *
+   * Vertices are compared as a set per polygon: the same square listed from a
+   * different corner is the same square, which is exactly what carrying corners
+   * round by 90° does to the ordering.
+   */
+  describe('a promoted half turn picks up where the quarter left off', () => {
+    const stickers = (turn) =>
+      new Set(
+        scene({ turn })
+          .polygons.filter((polygon) => polygon.key.endsWith(':tile'))
+          .map(
+            (polygon) =>
+              `${polygon.fill}|${polygon.points
+                .map((point) => point.map((n) => n.toFixed(1)).join(','))
+                .sort()
+                .join(' ')}`
+          )
+      );
+
+    const overlap = (a, b) => [...a].filter((entry) => b.has(entry)).length;
+
+    it.each([
+      ['R', 2],
+      ['U', 2],
+      ['F', 2],
+      ['L', -2],
+      ['D', -2],
+      ['B', -2],
+    ])('%s2 continues the %s it grew from', (face, turns) => {
+      const finished = stickers({ ...parseMove(face), t: 1 });
+      const promoted = stickers({ ...parseMove(`${face}2`), t: 0.5, turns });
+
+      expect(promoted.size).toBe(27);
+      expect(overlap(finished, promoted)).toBe(27);
+    });
+
+    /**
+     * And the half that would go unnoticed. `R`, `U` and `F` carry `amount: 1`
+     * and sweep `+2`, so the default is already the right way round and the bug
+     * was invisible on them — which is why the report named L and D.
+     */
+    it.each(['R', 'U', 'F'])('%s2 is continuous even without the sweep', (face) => {
+      const finished = stickers({ ...parseMove(face), t: 1 });
+      const naive = stickers({ ...parseMove(`${face}2`), t: 0.5 });
+
+      expect(overlap(finished, naive)).toBe(27);
+    });
+
+    /**
+     * The three that broke. `L`, `D` and `B` look down the negative end of their
+     * axis, so they carry `amount: 3` and turn anticlockwise — and the default
+     * `shortWay(2)` of `+2` puts the layer 180° from where the cube is standing.
+     * Six of the 27 stickers land somewhere else entirely, which is the reversal
+     * a thumb sees.
+     */
+    it.each(['L', 'D', 'B'])('%s2 visibly jumps without the sweep', (face) => {
+      const finished = stickers({ ...parseMove(face), t: 1 });
+      const naive = stickers({ ...parseMove(`${face}2`), t: 0.5 });
+
+      expect(overlap(finished, naive)).toBe(21);
+    });
+  });
 });
 
 describe('shortWay', () => {

--- a/SudokuApp/games/cube/__tests__/player.test.js
+++ b/SudokuApp/games/cube/__tests__/player.test.js
@@ -21,6 +21,7 @@ import {
   ease,
   extendsAlg,
   promotedTurn,
+  renderTurn,
   gapDuration,
   nextSpeed,
   turnDuration,
@@ -395,6 +396,63 @@ describe('promotedTurn', () => {
   it('does not confuse a wide turn with its face', () => {
     expect(promotedTurn('r', 'R2', 1)).toBeNull();
     expect(promotedTurn('r', 'r2', 1)).toEqual({ at: 0, turns: 2 });
+  });
+
+  /**
+   * **The seam the sweep was actually lost at.**
+   *
+   * `promotedTurn` has returned the right signed sweep since Step 8 and every
+   * test of it passed — while the promotion animated backwards on a phone,
+   * because `useScramblePlayer` built the renderer's turn with a spread that
+   * left `turns` behind. A line inside a hook is a line no test here can reach,
+   * so it is a function now and this is it.
+   */
+  describe('renderTurn', () => {
+    const move = parseMove('D2');
+
+    it('carries the signed sweep out to the renderer', () => {
+      // Without this the renderer falls back to `shortWay(2)`, which is `+2`,
+      // and a `D` that turned anticlockwise jumps 180° before carrying on.
+      expect(renderTurn(move, { at: 0, t: 0.5, turns: -2 })).toEqual({
+        ...move,
+        t: 0.5,
+        turns: -2,
+      });
+    });
+
+    it('leaves an ordinary turn undefined, which is what "the short way" is', () => {
+      const turn = renderTurn(parseMove('R'), { at: 0, t: 0.25 });
+      expect(turn.t).toBe(0.25);
+      expect(turn.turns).toBeUndefined();
+    });
+
+    it('is null when nothing is turning, or when the move is gone', () => {
+      // A move index left over from a longer algorithm reaches the renderer
+      // before the effect that clears it — as `undefined`.
+      expect(renderTurn(move, null)).toBeNull();
+      expect(renderTurn(undefined, { at: 9, t: 0.5 })).toBeNull();
+    });
+
+    it('hands the move on whole, so the renderer still gets axis and layers', () => {
+      const turn = renderTurn(move, { at: 0, t: 1, turns: -2 });
+      expect(turn.axis).toBe(move.axis);
+      expect(turn.layers).toEqual(move.layers);
+      expect(turn.amount).toBe(move.amount);
+    });
+
+    /**
+     * The round trip that would have caught it: what `promotedTurn` decided has
+     * to be what the renderer is told, for every face on the pad — and the three
+     * that turn anticlockwise are the ones that broke.
+     */
+    it.each(['R', 'U', 'F', 'L', 'D', 'B'])(
+      'preserves the sweep %s2 was promoted with',
+      (face) => {
+        const carry = promotedTurn(face, `${face}2`, 1);
+        const turn = renderTurn(parseMove(`${face}2`), { at: carry.at, t: 0.5, turns: carry.turns });
+        expect(turn.turns).toBe(carry.turns);
+      }
+    );
   });
 
   it('carries on the way the first quarter went', () => {

--- a/SudokuApp/games/cube/player.js
+++ b/SudokuApp/games/cube/player.js
@@ -250,10 +250,38 @@ export const announcePosition = (index, count, noun = 'scramble') => {
   return `After move ${index} of ${count}`;
 };
 
+/**
+ * The turn the **renderer** gets: the move being played, plus how far through it
+ * is and which way round it is going.
+ *
+ * One line of object-spread, pulled out of `useScramblePlayer` and put here for
+ * the reason the rest of this file is here — **it was the one part of the
+ * transport a test could not reach, and it was wrong** (operator, 2026-08-07:
+ * *"double tapping for moves like L and D, the animation seems to reverse the
+ * direction"*).
+ *
+ * `promotedTurn` computed the signed sweep, `animate` carried it and `turnAngle`
+ * honoured it; the value was then dropped on the way out to `CubeView`, so
+ * `buildScene` fell back to `shortWay(amount)` — always `+2` for a half turn.
+ * `L`, `D` and `B` carry `amount: 3` and turn anticlockwise, so their promotions
+ * snapped 180° and travelled backwards, while `R`, `U` and `F` were fine. Every
+ * unit test passed throughout, because none of them could see this line.
+ *
+ * `turns` is `undefined` for every ordinary turn, and that is a value rather
+ * than a gap: it is what `turnAngle` reads as "go the short way".
+ *
+ * @param {Object|undefined} move the move being played
+ * @param {{at: number, t: number, turns?: number}|null} live the clock's turn
+ * @returns {Object|null} what `CubeView` draws, or null when nothing is turning
+ */
+export const renderTurn = (move, live) =>
+  live && move ? { ...move, t: live.t, turns: live.turns } : null;
+
 export default {
   buildPlayback,
   extendsAlg,
   promotedTurn,
+  renderTurn,
   turnDuration,
   gapDuration,
   nextSpeed,

--- a/SudokuApp/games/cube/useScramblePlayer.js
+++ b/SudokuApp/games/cube/useScramblePlayer.js
@@ -8,6 +8,7 @@ import {
   gapDuration,
   nextSpeed,
   promotedTurn,
+  renderTurn,
   turnDuration,
 } from './player';
 
@@ -442,7 +443,11 @@ const useScramblePlayer = (alg, from) => {
   // renderer first — as `undefined`.
   const live = turn && turn.at < count ? turn : null;
   const cube = live ? states[live.at] : states[clampIndex(index, count)];
-  const turning = live ? { ...moves[live.at], t: live.t } : null;
+  // **`renderTurn`, and not a spread written here.** This line dropped the
+  // promotion's signed sweep for nine steps and no test could see it, because a
+  // line inside a hook is not something the node runner can reach. It is a pure
+  // function in `player.js` now, pinned there, and this is the call.
+  const turning = renderTurn(moves[live ? live.at : 0], live);
 
   return {
     moves,

--- a/docs/cube-handoff.md
+++ b/docs/cube-handoff.md
@@ -557,11 +557,70 @@ made.**
   noted rather than fixed.
 - **Half turns animate clockwise.** `shortWay(2)` is 2, not −2; both land in the
   same place and nothing prefers one. If a solve tutorial ever wants `R2` to go
-  the way a particular fingertrick goes, that is the line to change.
+  the way a particular fingertrick goes, that is the line to change. **A
+  *promotion* is the exception and must not use it** — see Step 10a: the cube is
+  already a quarter of the way round, so the sweep is signed and the renderer has
+  to be told.
+- **Anything a hook hands to a component is a seam a test cannot reach**, and
+  Step 10a is what that costs. `renderTurn` exists because one object spread
+  inside `useScramblePlayer` silently dropped a field for nine steps while every
+  unit test passed. If a component starts receiving something assembled inline in
+  a hook, that assembly belongs in a pure function.
 
 ---
 
 ## Steps already done
+
+### **Step 10a — the promotion turned the wrong way** ✅ *(2026-08-07)*
+
+A device finding, from the operator using the pad the day the review merged:
+*"double tapping for moves like L and D, the animation seems to reverse the
+direction."*
+
+It was exactly that, and the diagnosis is worth keeping because **every piece of
+the mechanism was already correct**. `promotedTurn` computed the signed sweep,
+`animate` carried it, `turnAngle` and `partialTurn` honoured it, `buildScene`
+accepted it — and `useScramblePlayer` **dropped it one spread short of the
+renderer**:
+
+```js
+const turning = live ? { ...moves[live.at], t: live.t } : null;   // no `turns`
+```
+
+Without it `buildScene` falls back to `shortWay(amount)`, which for a half turn
+is always `+2`. **`L`, `D` and `B` look down the negative end of their axis**, so
+they carry `amount: 3` and turn anticlockwise: their promotions jumped from +90°
+to −90° on the frame the second tap landed, then travelled the wrong way round to
+−180°. `R`, `U` and `F` sweep `+2` anyway and were perfect — which is exactly why
+the report named L and D.
+
+**Why nine steps of tests never saw it.** Step 8 pinned the signed sweep hard, at
+`turnAngle` and `partialTurn`, including a test literally called *"would snap
+without the signed sweep, which is the bug it fixes"* — and all of it passed
+throughout, because **the arithmetic was never wrong.** The bug was in a line
+inside a hook, which the node runner cannot reach. So the fix is two things:
+
+- **`renderTurn` in `player.js`** — the assembly of the renderer's turn, lifted
+  out of the hook into a pure function and pinned there. The rule this
+  establishes is in the golden rules now: *anything a hook hands to a component
+  is a seam a test cannot reach.*
+- **A `buildScene` test that asserts the picture rather than the angle**: a `D`
+  that has finished its quarter and a `D2` picked up at `t = 0.5` must draw the
+  same 27 stickers in the same 27 places. With the sweep, all six faces are
+  27/27. Without it, `R`/`U`/`F` are still 27/27 and **`L`/`D`/`B` are 21/27** —
+  the six stickers that changed sides, which is the reversal a thumb sees.
+
+**One measurement trap, recorded because it cost most of the time.** A headless
+driver comparing polygon *positions* across the promotion calls the bug smooth,
+and it is not a bug in the driver: **a layer turned 180° lands on the same nine
+screen positions it started on** — the cubies swap places among themselves. What
+changes is *which colour sits where*, and sticker shading follows the face
+normal, so colour is not a stable key mid-turn either. That is why the guard is
+two pure tests at the two seams rather than a pixel check.
+
+911 tests (22 new). `npx expo-doctor` 18/18, `npx expo export --platform all`,
+and a driver confirming every face still promotes and animates with no console
+errors.
 
 ### **Step 10 — the architecture review, and the merge decision** ✅ *(2026-08-07)*
 

--- a/docs/cube-review.md
+++ b/docs/cube-review.md
@@ -47,17 +47,6 @@ What the review is signing off:
   `padPalette.js`, `BASE_MOVES`/`WIDE_MOVES` in `moves.js`. Two exceptions were
   found and both are noted below; both were one-line-class problems, not
   structural ones.
-> **Postscript, 2026-08-07 (Step 10a).** The operator found a real bug the day
-> this merged — the pad's promotion animated backwards on `L`, `D` and `B` — and
-> it is worth reading against finding 2 rather than as an unrelated escape.
-> **Both are the same shape**: a value that is correct everywhere a test can see
-> it, and wrong at the one seam a test cannot. Finding 2 was a table the tests
-> walked with an assertion too weak to fail; this was a field dropped inside a
-> hook, which the node runner cannot reach at all. The review checked whether
-> rules had one home. It did not ask **which lines no test can see** — and on this
-> codebase that is a short, enumerable list: the object literals hooks hand to
-> components. `renderTurn` is the first of them to be pulled into the pure core.
-
 - **The one-rule-one-function rule holds where it matters most.** `clampPhases`
   has exactly two callers and they are the live edit and the file read, which is
   the pairing Step 6's scar is about. `withMoves` funnels every edit to a solve's
@@ -68,6 +57,23 @@ What the review is signing off:
   SDK, no base class, no abstract `Game`. `games/registry.js` is a list of seven-
   field objects and the hub maps over it. **This review proposes none of those
   either** — three games is not evidence for any of them.
+
+> **Postscript, 2026-08-07 — and the one thing this review did not ask.**
+>
+> The operator found a real bug the same day this merged: the pad's promotion
+> animated backwards on `L`, `D` and `B` (Step 10a). It belongs here rather than
+> in a separate note, because it is **the same shape as this review's own finding
+> 2** — a value that is correct everywhere a test can see it and wrong at the one
+> seam a test cannot. Finding 2 was a table the suite already walked, with an
+> assertion too weak to fail. Step 10a was a field dropped inside a hook, which
+> the node runner cannot reach at all.
+>
+> So the bar in §8.11 has a fourth question hiding behind it, and this review did
+> not ask it: **which lines can no test see?** On this codebase that list is
+> short and enumerable — the object literals hooks hand to components — and it is
+> exactly where nine steps of green tests were hiding a reversed animation.
+> `renderTurn` is the first of them pulled into the pure core; the rest are worth
+> an afternoon whenever someone is next in `useScramblePlayer` or `CubeScreen`.
 
 ---
 

--- a/docs/cube-review.md
+++ b/docs/cube-review.md
@@ -47,6 +47,17 @@ What the review is signing off:
   `padPalette.js`, `BASE_MOVES`/`WIDE_MOVES` in `moves.js`. Two exceptions were
   found and both are noted below; both were one-line-class problems, not
   structural ones.
+> **Postscript, 2026-08-07 (Step 10a).** The operator found a real bug the day
+> this merged — the pad's promotion animated backwards on `L`, `D` and `B` — and
+> it is worth reading against finding 2 rather than as an unrelated escape.
+> **Both are the same shape**: a value that is correct everywhere a test can see
+> it, and wrong at the one seam a test cannot. Finding 2 was a table the tests
+> walked with an assertion too weak to fail; this was a field dropped inside a
+> hook, which the node runner cannot reach at all. The review checked whether
+> rules had one home. It did not ask **which lines no test can see** — and on this
+> codebase that is a short, enumerable list: the object literals hooks hand to
+> components. `renderTurn` is the first of them to be pulled into the pure core.
+
 - **The one-rule-one-function rule holds where it matters most.** `clampPhases`
   has exactly two callers and they are the live edit and the file read, which is
   the pairing Step 6's scar is about. `withMoves` funnels every edit to a solve's


### PR DESCRIPTION
A device finding, from the operator: *"double tapping for moves like L and D, the animation seems to reverse the direction."*

It was exactly that.

## The bug

**Every piece of the mechanism was already correct.** `promotedTurn` computed the signed sweep, `animate` carried it, `turnAngle` and `partialTurn` honoured it, `buildScene` accepted it — and `useScramblePlayer` **dropped it one spread short of the renderer**:

```js
const turning = live ? { ...moves[live.at], t: live.t } : null;   // no `turns`
```

Without it `buildScene` falls back to `shortWay(amount)`, which for a half turn is always `+2`. **`L`, `D` and `B` look down the negative end of their axis**, so they carry `amount: 3` and turn anticlockwise — their promotions jumped from **+90° to −90°** on the frame the second tap landed, then travelled the wrong way round to −180°. `R`, `U` and `F` sweep `+2` anyway and were perfect, which is exactly why the report named L and D.

The angle table, per face:

| face | `amount` | end of first quarter | drawn at the promotion | |
|---|---|---|---|---|
| R, U, F | 1 | −90° | −90° | continuous |
| **L, D, B** | **3** | **+90°** | **−90°** | **180° snap, then backwards** |

## Why nine steps of tests never saw it

Step 8 pinned the signed sweep *hard* — at `turnAngle` and `partialTurn`, including a test literally named *"would snap without the signed sweep, which is the bug it fixes"*. All of it passed throughout, because **the arithmetic was never wrong.** The bug was one line inside a hook, which the node runner cannot reach.

So the fix is two things rather than one:

- **`renderTurn` in `player.js`** — the assembly of the renderer's turn, lifted out of the hook into a pure function and pinned there. It now round-trips `promotedTurn`'s decision for all six faces.
- **A `buildScene` test that asserts the picture rather than the angle** — a `D` that has finished its quarter and a `D2` picked up at `t = 0.5` must draw the same 27 stickers in the same 27 places. With the sweep, all six faces are **27/27**. Without it, `R`/`U`/`F` are still 27/27 and **`L`/`D`/`B` are 21/27** — the six stickers that changed sides, which is the reversal a thumb sees.

The rule this establishes is in the handoff's golden rules now: **anything a hook hands to a component is a seam a test cannot reach.** On this codebase that is a short, enumerable list — the object literals hooks pass to components — and `renderTurn` is the first pulled into the pure core.

## One measurement trap, recorded because it cost the most time

A headless driver comparing polygon **positions** across the promotion calls this bug smooth, and that is not a flaw in the driver: **a layer turned 180° lands on the same nine screen positions it started on** — the cubies simply swap places among themselves. What changes is *which colour sits where* — and sticker shading follows the face normal, so colour is not a stable key mid-turn either.

That is why the guard here is two pure tests at the two seams rather than a pixel check, and it is written into `docs/cube-handoff.md` so the next person does not spend the afternoon rediscovering it.

## Relation to the Step 10 review

`docs/cube-review.md` gains a short postscript, because this is **not** an unrelated escape — it is the same shape as the review's own finding 2 (`SPOKEN_KEY` walked by a test whose assertion was too weak to fail). Both are a value that is correct everywhere a test can see it and wrong at the one seam a test cannot. The review asked whether rules had one home; it did not ask **which lines no test can see**.

## Verification

| | Result |
|---|---|
| `npm test` | **911 passed, 25 suites** (889 before; **+22 new**) |
| `npx expo-doctor` | **18/18** |
| `npx expo export --platform all` | web + iOS + Android all bundled |

Plus a driver over the web export confirming every face still promotes (`R2`…`B2` all written) and still animates, with no console errors, and the Step 10 regression walk re-run clean at 320×568, 375×667 and 393×852.

**Worth a look on a device before merging** — the direction of a turn is exactly the thing the browser evidence could not settle, which is how this got here in the first place.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExzCMNM7RjyP8FgjFUHspe)_